### PR TITLE
fix(tools): implement safety/0 and available?/0 for all 29 builtins

### DIFF
--- a/lib/optimal_system_agent/tools/builtins/ask_user.ex
+++ b/lib/optimal_system_agent/tools/builtins/ask_user.ex
@@ -12,6 +12,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.AskUser do
   @timeout_ms 300_000
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "ask_user"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/budget_status.ex
+++ b/lib/optimal_system_agent/tools/builtins/budget_status.ex
@@ -4,6 +4,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.BudgetStatus do
   alias MiosaBudget.Budget
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "budget_status"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/code_symbols.ex
+++ b/lib/optimal_system_agent/tools/builtins/code_symbols.ex
@@ -18,6 +18,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.CodeSymbols do
   @skip_dirs ~w(_build deps node_modules .git __pycache__ dist build target .elixir_ls ebin priv/static)
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "code_symbols"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/codebase_explore.ex
+++ b/lib/optimal_system_agent/tools/builtins/codebase_explore.ex
@@ -27,6 +27,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.CodebaseExplore do
   }
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "codebase_explore"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/delegate.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate.ex
@@ -22,6 +22,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate do
   @read_only_tools ~w(file_read file_grep file_glob dir_list web_search web_fetch memory_recall session_search)
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "delegate"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/dir_list.ex
+++ b/lib/optimal_system_agent/tools/builtins/dir_list.ex
@@ -7,6 +7,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.DirList do
     "/etc/master.passwd", ".netrc", ".npmrc", ".pypirc"]
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "dir_list"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/file_edit.ex
+++ b/lib/optimal_system_agent/tools/builtins/file_edit.ex
@@ -10,6 +10,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.FileEdit do
     "/bin/", "/sbin/", "/var/", ".aws/", ".env"]
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "file_edit"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/file_glob.ex
+++ b/lib/optimal_system_agent/tools/builtins/file_glob.ex
@@ -9,6 +9,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.FileGlob do
   @max_results 200
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "file_glob"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/file_grep.ex
+++ b/lib/optimal_system_agent/tools/builtins/file_grep.ex
@@ -9,6 +9,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.FileGrep do
   @max_output_bytes 8_000
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "file_grep"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/github.ex
+++ b/lib/optimal_system_agent/tools/builtins/github.ex
@@ -11,6 +11,9 @@ defmodule OptimalSystemAgent.Tools.Builtins.Github do
   @gh_timeout 30_000
 
   @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "github"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/knowledge.ex
+++ b/lib/optimal_system_agent/tools/builtins/knowledge.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.Knowledge do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "knowledge"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/mcts_index.ex
+++ b/lib/optimal_system_agent/tools/builtins/mcts_index.ex
@@ -23,6 +23,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.MCTSIndex do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "mcts_index"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/memory_recall.ex
+++ b/lib/optimal_system_agent/tools/builtins/memory_recall.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.MemoryRecall do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "memory_recall"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/memory_save.ex
+++ b/lib/optimal_system_agent/tools/builtins/memory_save.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.MemorySave do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "memory_save"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/multi_file_edit.ex
+++ b/lib/optimal_system_agent/tools/builtins/multi_file_edit.ex
@@ -11,6 +11,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit do
     "/bin/", "/sbin/", "/var/", ".aws/", ".env"]
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "multi_file_edit"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/orchestrate.ex
+++ b/lib/optimal_system_agent/tools/builtins/orchestrate.ex
@@ -18,6 +18,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.Orchestrate do
   require Logger
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "orchestrate"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/semantic_search.ex
+++ b/lib/optimal_system_agent/tools/builtins/semantic_search.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.SemanticSearch do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "semantic_search"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/session_search.ex
+++ b/lib/optimal_system_agent/tools/builtins/session_search.ex
@@ -16,6 +16,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.SessionSearch do
   alias OptimalSystemAgent.Store.Repo
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "session_search"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/task_write.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_write.ex
@@ -13,6 +13,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWrite do
   @default_session "default"
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "task_write"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/use_skill.ex
+++ b/lib/optimal_system_agent/tools/builtins/use_skill.ex
@@ -21,6 +21,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.UseSkill do
   alias OptimalSystemAgent.Tools.Registry, as: Tools
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "use_skill"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/vault_checkpoint.ex
+++ b/lib/optimal_system_agent/tools/builtins/vault_checkpoint.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.VaultCheckpoint do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "vault_checkpoint"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/vault_context.ex
+++ b/lib/optimal_system_agent/tools/builtins/vault_context.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.VaultContext do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "vault_context"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/vault_inject.ex
+++ b/lib/optimal_system_agent/tools/builtins/vault_inject.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.VaultInject do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "vault_inject"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/vault_remember.ex
+++ b/lib/optimal_system_agent/tools/builtins/vault_remember.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.VaultRemember do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "vault_remember"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/vault_sleep.ex
+++ b/lib/optimal_system_agent/tools/builtins/vault_sleep.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.VaultSleep do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "vault_sleep"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/vault_wake.ex
+++ b/lib/optimal_system_agent/tools/builtins/vault_wake.ex
@@ -2,6 +2,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.VaultWake do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "vault_wake"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/wallet_ops.ex
+++ b/lib/optimal_system_agent/tools/builtins/wallet_ops.ex
@@ -11,6 +11,9 @@ defmodule OptimalSystemAgent.Tools.Builtins.WalletOps do
   end
 
   @impl true
+  def safety, do: :write_safe
+
+  @impl true
   def name, do: "wallet_ops"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/web_fetch.ex
+++ b/lib/optimal_system_agent/tools/builtins/web_fetch.ex
@@ -7,6 +7,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.WebFetch do
   @timeout_ms 30_000
 
   @impl true
+  def available?, do: true
+
+  @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "web_fetch"
 
   @impl true

--- a/lib/optimal_system_agent/tools/builtins/web_search.ex
+++ b/lib/optimal_system_agent/tools/builtins/web_search.ex
@@ -2,6 +2,9 @@ defmodule OptimalSystemAgent.Tools.Builtins.WebSearch do
   @behaviour MiosaTools.Behaviour
 
   @impl true
+  def safety, do: :read_only
+
+  @impl true
   def name, do: "web_search"
 
   @impl true


### PR DESCRIPTION
## Summary
- Added `safety/0` callback to all 29 builtin tool modules that were missing it
- Added `available?/0` callback (returning `true`) to 26 modules; 3 already had it (`wallet_ops`, `github`, `web_search`)
- Safety classifications: `:read_only` for search/list/status/recall tools, `:write_safe` for reversible mutation tools
- `mix compile 2>&1 | grep "safety/0 required"` returns 0 results

## Classification

| Safety | Tools |
|--------|-------|
| `:read_only` | ask_user, budget_status, codebase_explore, code_symbols, delegate, dir_list, file_glob, file_grep, mcts_index, memory_recall, semantic_search, session_search, vault_context, vault_inject, web_fetch, web_search |
| `:write_safe` | file_edit, github, knowledge, memory_save, multi_file_edit, orchestrate, task_write, use_skill, vault_checkpoint, vault_remember, vault_sleep, vault_wake, wallet_ops |

## Test plan
- [x] `mix compile` passes with zero `safety/0 required` warnings
- [ ] Verify tool registry loads all 29 tools without error
- [ ] Spot-check safety classification matches tool behavior