### PR TITLE
fix: provider swap tests, replay cap, introspection fields

### DIFF
--- a/lib/optimal_system_agent/agent/loop.ex
+++ b/lib/optimal_system_agent/agent/loop.ex
@@ -532,7 +532,7 @@ defmodule OptimalSystemAgent.Agent.Loop do
 
   def handle_call(:get_state, _from, state) do
     uptime = if state.started_at, do: DateTime.diff(DateTime.utc_now(), state.started_at), else: 0
-    snap = %{session_id: state.session_id, iteration: state.iteration, tokens_used: estimate_tokens_for_introspection(state), tools_called: state.last_meta[:tools_used] || [], status: state.status, started_at: state.started_at, uptime_seconds: uptime}
+    snap = %{session_id: state.session_id, iteration: state.iteration, tokens_used: estimate_tokens_for_introspection(state), tools_called: state.last_meta[:tools_used] || [], status: state.status, started_at: state.started_at, uptime_seconds: uptime, provider: state.provider, model: state.model}
     {:reply, {:ok, snap}, state}
   end
 

--- a/lib/optimal_system_agent/agent/replay.ex
+++ b/lib/optimal_system_agent/agent/replay.ex
@@ -11,6 +11,8 @@ defmodule OptimalSystemAgent.Agent.Replay do
   alias OptimalSystemAgent.Agent.{Loop, Memory}
   alias OptimalSystemAgent.SDK.Session
 
+  @max_replay_messages 100
+
   @doc """
   Replay the conversation stored under `source_session_id` into a new session.
 
@@ -60,7 +62,17 @@ defmodule OptimalSystemAgent.Agent.Replay do
   # ── Private ──────────────────────────────────────────────────────────
 
   defp dispatch_messages(session_id, messages) do
-    Enum.each(messages, fn m ->
+    total = length(messages)
+
+    if total > @max_replay_messages do
+      Logger.warning(
+        "Replay #{session_id}: truncating #{total} messages to #{@max_replay_messages}"
+      )
+    end
+
+    messages
+    |> Enum.take(@max_replay_messages)
+    |> Enum.each(fn m ->
       content = Map.get(m, "content") || Map.get(m, :content) || ""
 
       if content != "" do


### PR DESCRIPTION
## Summary
- **Replay rate limiting**: Added `@max_replay_messages 100` cap to `Replay.dispatch_messages/2`. Messages beyond the cap are truncated with a Logger warning.
- **Introspection enrichment**: Added `provider` and `model` fields to the `Loop.get_state/1` snapshot map, making them visible in `Introspection.snapshot/0`.
- **Provider swap tests**: Verified existing `provider_swap_test.exs` already covers all 4 required cases (missing provider 400, empty provider 400, non-existent session 404, happy-path shape).

## Test plan
- [x] `mix compile` passes cleanly
- [x] `mix test test/channels/http/api/provider_swap_test.exs` -- 5 tests, 0 failures
- [ ] Verify introspection snapshot includes provider/model for a running session
- [ ] Verify replay of >100 messages triggers truncation warning in logs