### PR TITLE
fix(opencomputers): enable installer runtime

### DIFF
--- a/bin/osa
+++ b/bin/osa
@@ -171,6 +171,12 @@ case "${1:-}" in
     exit 0
     ;;
 
+  opencomputers)
+    shift
+    (cd "$ROOT" && mix run --no-start -e "OptimalSystemAgent.CLI.opencomputers(System.argv())" -- "$@")
+    exit $?
+    ;;
+
   help|--help|-h)
     echo ""
     echo -e "${BOLD}  OSA Agent${RESET} — Your OS, Supercharged"
@@ -182,6 +188,7 @@ case "${1:-}" in
     echo -e "    ${CYAN}osa serve${RESET}        Start backend only (headless HTTP API)"
     echo -e "    ${CYAN}osa doctor${RESET}       Run health checks"
     echo -e "    ${CYAN}osa version${RESET}      Print version"
+    echo -e "    ${CYAN}osa opencomputers${RESET} Manage MIOSA host connection"
     echo ""
     echo -e "  ${BOLD}Options:${RESET}"
     echo -e "    ${CYAN}--dev${RESET}            Dev profile (port 19001)"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -357,6 +357,12 @@ config :optimal_system_agent,
   update_url: System.get_env("OSA_UPDATE_URL"),
   update_interval: parse_int.(System.get_env("OSA_UPDATE_INTERVAL"), 86_400_000),
 
+  # OpenComputers host daemon mode. The installer sets the env var in the
+  # launchd/systemd service; the marker is kept for interactive CLI enablement.
+  open_computers_enabled:
+    System.get_env("OSA_OPEN_COMPUTERS_ENABLED") == "true" or
+      File.exists?(Path.expand("~/.osa/.open_computers_enabled")),
+
   # Provider failover chain — auto-detected from configured API keys.
   # Override with comma-separated list: OSA_FALLBACK_CHAIN=anthropic,openai,ollama
   fallback_chain:

--- a/lib/optimal_system_agent/cli/opencomputers.ex
+++ b/lib/optimal_system_agent/cli/opencomputers.ex
@@ -2,7 +2,7 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
   @moduledoc """
   CLI handler for `osa opencomputers <verb>`.
 
-  Verbs: status | login | enable | disable | logout
+  Verbs: status | login | connect | enable | disable | logout
   """
 
   @osa_dir Path.join(System.user_home!(), ".osa")
@@ -17,7 +17,8 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
     case verb do
       "status" -> cmd_status()
       "login" -> cmd_login(rest)
-      "enable" -> cmd_enable()
+      "connect" -> cmd_login(rest)
+      "enable" -> cmd_enable(rest)
       "disable" -> cmd_disable()
       "logout" -> cmd_logout(rest)
       _ -> usage()
@@ -178,20 +179,30 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
 
   # ── enable ───────────────────────────────────────────────────────
 
-  defp cmd_enable do
+  defp cmd_enable(args) do
+    {opts, _} =
+      OptionParser.parse!(args,
+        strict: [profile: :boolean, no_profile: :boolean]
+      )
+
     File.mkdir_p!(@osa_dir)
     File.write!(@marker_path, "")
 
-    shell = detect_shell()
-    wrote_profile = set_env_in_profile(shell)
+    wrote_profile =
+      if Keyword.get(opts, :no_profile, false) do
+        false
+      else
+        shell = detect_shell()
+        set_env_in_profile(shell)
+      end
 
     IO.puts("OpenComputers enabled.")
-    if wrote_profile, do: IO.puts("Added #{@env_var}=true to #{shell_profile(shell)}")
+    if wrote_profile, do: IO.puts("Added #{@env_var}=true to your shell profile")
     IO.puts("Marker written: #{@marker_path}")
     IO.puts("")
 
     if is_nil(Process.whereis(OptimalSystemAgent.OpenComputers.Supervisor)) do
-      IO.puts("Supervisor not running. Restart OSA or run `osa opencomputers start` to activate.")
+      IO.puts("Supervisor not running. Restart OSA to activate.")
     else
       IO.puts("Supervisor already running — extension is live.")
     end
@@ -406,9 +417,10 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
     Verbs:
       status                         Print config + connection state
       login [--key <key>]            Write host key to ~/.osa/open_computers.toml
+      connect [--key <key>]          Alias for login
             [--control-url <url>]    (default: #{@default_control_url})
             [--force]                Skip overwrite confirmation
-      enable                         Set OSA_OPEN_COMPUTERS_ENABLED=true in shell profile
+      enable [--no-profile]          Enable host mode; optionally skip shell profile edits
       disable                        Remove env var + stop running supervisor
       logout [--force]               Clear host_key and stop session
     """)

--- a/scripts/install-binary.ps1
+++ b/scripts/install-binary.ps1
@@ -207,7 +207,7 @@ if ($pathChanged) {
 
 Write-Host "  Next step:"
 Write-Host ""
-Write-Host "    osa opencomputers connect --key <your-key>" -ForegroundColor White
+Write-Host "    osa opencomputers login --key <your-key>" -ForegroundColor White
 Write-Host ""
 Write-Host "  Get your key at: https://miosa.ai/opencomputers" -ForegroundColor DarkGray
 Write-Host ""

--- a/scripts/install-binary.sh
+++ b/scripts/install-binary.sh
@@ -274,6 +274,6 @@ fi
 printf "\n${GREEN}${BOLD}  OSA ${VERSION} installed successfully!${RESET}\n\n"
 printf "  Next step:\n"
 printf "\n"
-printf "    ${BOLD}osa opencomputers connect --key <your-key>${RESET}\n"
+printf "    ${BOLD}osa opencomputers login --key <your-key>${RESET}\n"
 printf "\n"
 printf "  ${DIM}Get your key at: https://miosa.ai/opencomputers${RESET}\n\n"


### PR DESCRIPTION
## Summary
- route `osa opencomputers` through the CLI entrypoint
- allow installer-managed host mode via `OSA_OPEN_COMPUTERS_ENABLED` or marker file
- add `connect` alias, `--no-profile` enablement, and updated installer next steps

## Verification
- `mix compile`
- `./bin/osa opencomputers status`
- `git diff --check -- bin/osa config/runtime.exs lib/optimal_system_agent/cli/opencomputers.ex scripts/install-binary.sh scripts/install-binary.ps1`
- `bash -n bin/osa scripts/install-binary.sh`