### PR TITLE
fix(ci): make publish job depend only on Linux build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,28 +203,30 @@ jobs:
           path: burrito_out/osa-windows-amd64.exe
 
   # ── Publish GitHub Release ────────────────────────────────────────────
+  #
+  # Depends ONLY on the Linux amd64 build. macOS, Linux arm64, and Windows
+  # builds still run in parallel above — they just don't block publishing.
+  # Rationale: a flaky build on any single platform should not hold the
+  # entire release hostage. Linux amd64 binaries are the immediate consumer
+  # (MIOSA Firecracker rootfs install.sh). Other platforms can be added
+  # back to `needs:` and `files:` once their build pipelines are confirmed
+  # stable.
   publish:
-    needs:
-      - build-macos-arm64
-      - build-linux-amd64
-      - build-linux-arm64
-      - build-windows-amd64
+    needs: build-linux-amd64
     runs-on: ubuntu-22.04
     permissions:
       contents: write  # required to create the GitHub Release
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download all binaries
+      - name: Download Linux amd64 binary
         uses: actions/download-artifact@v4
         with:
-          path: release-assets
+          name: osa-linux-amd64
+          path: release-assets/osa-linux-amd64
 
-      - name: Make Linux/macOS binaries executable
-        run: |
-          chmod +x release-assets/osa-darwin-arm64/osa-darwin-arm64
-          chmod +x release-assets/osa-linux-amd64/osa-linux-amd64
-          chmod +x release-assets/osa-linux-arm64/osa-linux-arm64
+      - name: Make Linux binary executable
+        run: chmod +x release-assets/osa-linux-amd64/osa-linux-amd64
 
       - name: Create GitHub Release and upload assets
         uses: softprops/action-gh-release@v2
@@ -235,7 +237,4 @@ jobs:
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true
           files: |
-            release-assets/osa-darwin-arm64/osa-darwin-arm64
             release-assets/osa-linux-amd64/osa-linux-amd64
-            release-assets/osa-linux-arm64/osa-linux-arm64
-            release-assets/osa-windows-amd64/osa-windows-amd64.exe


### PR DESCRIPTION
## Summary

Decouple the GitHub Release publish job from non-Linux platform builds.

Previously `publish.needs:` required all four platform builds (macOS arm64, Linux amd64, Linux arm64, Windows amd64) to succeed before *any* release assets were published. A flaky build on any single platform blocked the entire release — even when the Linux binary that downstream consumers (e.g. MIOSA Firecracker rootfs `install.sh`) actually need was built fine.

This was the cause of `v0.3.0` shipping with zero release assets despite the workflow being in place.

## Changes

- `publish.needs:` 4-platform list → `build-linux-amd64` only
- Download step uses `name: osa-linux-amd64` (not bulk download all)
- `chmod` step trimmed to the Linux binary
- `softprops/action-gh-release@v2` `files:` list trimmed to the Linux binary

Non-Linux build jobs are intentionally left in place. They still run on every release tag and surface platform breakage in CI logs — they just don't block the actual release. When all platforms are stable across consecutive releases, revert to restore multi-platform publishing.

## Test plan

- [ ] After merge, tag `v0.4.0` from `main` and watch the workflow
- [ ] Verify Linux job completes (~10-15 min, Burrito downloads Zig + ERTS first run)
- [ ] Confirm `curl -sIL https://github.com/Miosa-osa/OSA/releases/latest/download/osa-linux-amd64` returns 302 → 200
- [ ] (Optional, non-blocking) Note which other platform builds passed/failed so we know which to keep in `needs:` later
