### PR TITLE
fix(ci): remove invalid --target flag from mix release/burrito calls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         run: mix deps.get --only prod
 
       - name: Build Burrito binary (macos_arm64)
-        run: mix release burrito --target macos_arm64
+        run: mix release burrito
         env:
           BURRITO_TARGET: macos_arm64
 
@@ -87,7 +87,7 @@ jobs:
         run: mix deps.get --only prod
 
       - name: Build Burrito binary (linux_amd64)
-        run: mix release burrito --target linux_amd64
+        run: mix release burrito
         env:
           BURRITO_TARGET: linux_amd64
 
@@ -124,7 +124,7 @@ jobs:
         run: mix deps.get --only prod
 
       - name: Build Burrito binary (linux_arm64)
-        run: mix release burrito --target linux_arm64
+        run: mix release burrito
         env:
           BURRITO_TARGET: linux_arm64
 
@@ -189,7 +189,7 @@ jobs:
 
       - name: Build Burrito binary (windows_amd64)
         shell: bash
-        run: mix release burrito --target windows_amd64
+        run: mix release burrito
         env:
           BURRITO_TARGET: windows_amd64
 


### PR DESCRIPTION
Diagnosed from v0.4.0 workflow run [25628885014](https://github.com/Miosa-osa/OSA/actions/runs/25628885014) — all 4 build jobs failed with:
```
** (Mix) Could not invoke task "release": 1 error found!
--target : Unknown option
```

Burrito reads `BURRITO_TARGET` env var (already set in each job), `--target` CLI flag is the bug. Mix arg parsing fails before BURRITO_TARGET is ever read.

## Audit (full workflow scan)

```
$ grep -nE 'mix release|mix burrito' .github/workflows/release.yml
53:        run: mix release burrito --target macos_arm64    ← FIXED
90:        run: mix release burrito --target linux_amd64    ← FIXED
127:        run: mix release burrito --target linux_arm64   ← FIXED
188:        run: mix burrito.get_zig || true                (no --target, OK)
192:        run: mix release burrito --target windows_amd64 ← FIXED
```

## Diff

4 lines, drop `--target X` from each. `BURRITO_TARGET: X` env vars unchanged. `mix burrito.get_zig` is target-agnostic Zig fetch, untouched.

## Test plan

- [ ] After merge, tag `v0.4.1` from main
- [ ] Watch release workflow — Linux amd64 should succeed (~10-15 min)
- [ ] curl `https://github.com/Miosa-osa/OSA/releases/latest/download/osa-linux-amd64` returns 302 → 200
- [ ] Re-run MIOSA Firecracker rootfs build