### PR TITLE
fix(deps): pin erlexec to 2.0.6 for OTP 26 compat

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -91,7 +91,11 @@ defmodule OptimalSystemAgent.MixProject do
 
       # PTY spawning — used by OpenComputers.Executor.Direct.Pty to open
       # real interactive shells with full terminal geometry (cols, rows, resize).
-      {:erlexec, "~> 2.0"}
+      # PINNED to 2.0.6 — later versions use OTP 27 -doc() attribute which
+      # breaks compile on OTP 26. We pin OTP 26 because OTP 27 has Mix release
+      # bugs (TypedStruct.MixProject + Decimal.Error already compiled). When
+      # OTP 27 Mix issues are resolved upstream, this pin can be relaxed.
+      {:erlexec, "== 2.0.6"}
 
       # miosa_* packages are not standalone deps — their implementations live
       # in this repo. Shim modules in lib/miosa/ satisfy all call sites.


### PR DESCRIPTION
## Root cause

OTP 27 introduced two breaking changes that cascade through OSA's dep tree during `mix release`:

1. **Mix.ProjectStack internals changed** → causes `TypedStruct.MixProject already compiled` errors during deps walk
2. **Inspect protocol changed** → causes `{badkey, pretty, []}` runtime crashes
3. **Added `-doc()` attribute syntax** → erlexec 2.0.7+ adopted it, breaks compile on OTP 26

Pinning OSA to OTP 26 sidesteps issues 1 and 2. But `erlexec ~> 2.0` resolves to 2.0.7+ which uses OTP 27 syntax (issue 3) and won't compile on OTP 26.

## Fix

Pin erlexec to exactly 2.0.6 (released 2024-04-18, before OTP 27 GA on 2024-06-24).

## Confirmation

Confirmed working on Linux x86_64 native (compute host, not emulated):
- Elixir 1.17.3
- OTP 26.2.5.6
- erlexec 2.0.6 (this PR's pin)
- mix.exs HEAD with full current main feature set (burrito, ex_json_schema, postgrex, bcrypt_elixir, amqp, gen_smtp, mint, mint_web_socket — everything)

Result: working 36 MB `mix release osagent` output. SHA256 `5b218ee0f0d45c6dbcd45ddd783d5ab080406e5be658e37d0d7f9a8a3de30b04`.

## Followup PR coming

A second PR will pin OTP version in `.github/workflows/release.yml` setup-beam to `26.2.5` (currently `27.1`). That's required to make CI actually build on the matching toolchain.

## Reversion path

When OTP 27's Mix issues are resolved upstream, this pin can be relaxed back to `~> 2.0`. Comment in mix.exs documents the reasoning.