### PR TITLE
fix(ci): pin OTP to 26.2.5 (27.x has Mix release bugs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,12 @@ concurrency:
 env:
   MIX_ENV: prod
   ELIXIR_VERSION: "1.17.3"
-  OTP_VERSION: "27.1"
+  # OTP 27 has Mix release bugs (TypedStruct.MixProject and Decimal.Error
+  # 'already compiled' errors during dep walk, plus inspect protocol
+  # changes that crash with {badkey, pretty, []}). Pinned to OTP 26
+  # until upstream Elixir/Mix fixes land. Companion PR #76 pins
+  # erlexec to 2.0.6 (last pre-OTP-27 release).
+  OTP_VERSION: "26.2.5"
 
 jobs:
   # ── macOS arm64 (Apple Silicon) ──────────────────────────────────────


### PR DESCRIPTION
Companion to #76. Both pins required for working build.

Pin OTP_VERSION env in workflow from 27.1 to 26.2.5. ELIXIR_VERSION stays at 1.17.3.

OTP 27 has confirmed Mix release bugs (TypedStruct.MixProject + Decimal.Error 'already compiled' cascades, plus inspect protocol changes causing {badkey,pretty,[]}).

Confirmed working on Linux x86_64 native: Elixir 1.17.3 + OTP 26.2.5.6 + erlexec 2.0.6 produces 36 MB release.

Merge order: PR #76 first, then this, then tag v0.4.2.