### PR TITLE
fix(ci): install Zig on PATH so Burrito pre_check passes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Install deps
         run: mix deps.get --only prod
 
+      - name: Install Zig (Burrito pre_check requires zig on PATH)
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
+
       - name: Build Burrito binary (macos_arm64)
         run: mix release burrito
         env:
@@ -91,6 +96,11 @@ jobs:
       - name: Install deps
         run: mix deps.get --only prod
 
+      - name: Install Zig (Burrito pre_check requires zig on PATH)
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
+
       - name: Build Burrito binary (linux_amd64)
         run: mix release burrito
         env:
@@ -127,6 +137,11 @@ jobs:
 
       - name: Install deps
         run: mix deps.get --only prod
+
+      - name: Install Zig (Burrito pre_check requires zig on PATH)
+        uses: mlugg/setup-zig@v1
+        with:
+          version: 0.13.0
 
       - name: Build Burrito binary (linux_arm64)
         run: mix release burrito


### PR DESCRIPTION
v0.4.2 hit the SAME zig+xz bug as v0.4.1 — the OTP 26 + erlexec 2.0.6 pins (PRs #76 + #77) fixed the deeper dep issues but didn't address Burrito's toolchain prerequisite.

Adds mlugg/setup-zig@v1 with Zig 0.13.0 (Burrito 1.5.0 baseline) before each `mix release burrito` step in macOS arm64, Linux amd64, Linux arm64 jobs.

Windows already handles Zig via `mix burrito.get_zig` — unchanged.

Tag v0.4.3 after merge.