### PR TITLE
fix(ci): bump Zig 0.13.0 → 0.15.2 (Burrito 1.5.0 baseline)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Zig (Burrito pre_check requires zig on PATH)
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.15.2
 
       - name: Build Burrito binary (macos_arm64)
         run: mix release burrito
@@ -99,7 +99,7 @@ jobs:
       - name: Install Zig (Burrito pre_check requires zig on PATH)
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.15.2
 
       - name: Build Burrito binary (linux_amd64)
         run: mix release burrito
@@ -141,7 +141,7 @@ jobs:
       - name: Install Zig (Burrito pre_check requires zig on PATH)
         uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.15.2
 
       - name: Build Burrito binary (linux_arm64)
         run: mix release burrito


### PR DESCRIPTION
v0.4.3 hit: 'Your Zig version does not match the one Burrito requires! We need 0.15.2, you have: 0.13.0'

Burrito 1.5.0 pins to Zig 0.15.2. My earlier 0.13.0 pick was based on stale info. Bump.

This is the 4th layer of the bug chain. After this lands and we tag v0.4.4, the build should converge.