### PR TITLE
fix(tui): chat view rendering — reachable scroll + one header per turn

### DIFF
--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -176,12 +176,20 @@ impl App {
             if !final_text.is_empty() {
                 self.chat.add_agent_continuation(&final_text);
             }
-            self.agent_header_sent = false;
+            // Do NOT reset agent_header_sent here. It is reset only when the user
+            // submits a new prompt (submit_prompt). Resetting it per response
+            // meant a turn that produced more than one agent_response event
+            // (e.g. text → subagent/tool → more text) emitted a second "◈ OSA"
+            // header, visually splitting one answer into chunks. Keeping it set
+            // makes the rest of the turn render as header-less continuations.
         } else {
-            // No tool calls occurred this turn — show the full response
-            // under the "◈ OSA" header as a single block.
+            // First agent output of this turn — show it under the "◈ OSA"
+            // header, then mark the header as sent so any further output this
+            // turn (continued text after a tool/subagent) flows underneath the
+            // same header instead of starting a new block.
             self.chat
                 .add_agent_message(&display_response, signal.as_ref());
+            self.agent_header_sent = true;
         }
 
         // Clear streaming state

--- a/priv/rust/tui/src/components/chat/mod.rs
+++ b/priv/rust/tui/src/components/chat/mod.rs
@@ -5,6 +5,8 @@ pub mod message;
 pub mod thinking_box;
 pub mod welcome;
 
+use std::cell::Cell;
+
 use ratatui::prelude::*;
 use ratatui::widgets::{Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState};
 
@@ -23,6 +25,12 @@ pub struct Chat {
     /// Viewport dimensions
     width: u16,
     height: u16,
+    /// Actual chat-area height from the most recent draw. The cached `height`
+    /// (set on resize) does not subtract the activity-spinner rows that the
+    /// real draw area reserves — using it for scroll bounds left the top of
+    /// long output unreachable until the terminal was enlarged. Captured every
+    /// frame so scroll math matches what is actually on screen.
+    last_viewport_height: Cell<u16>,
     /// Streaming content (live while processing)
     streaming_content: Option<String>,
     /// Whether we have items (vs showing welcome)
@@ -40,6 +48,7 @@ impl Chat {
             scroll_offset: 0,
             width: 80,
             height: 20,
+            last_viewport_height: Cell::new(20),
             streaming_content: None,
             has_messages: false,
             welcome_provider: None,
@@ -272,7 +281,9 @@ impl Chat {
     }
 
     pub fn scroll_up(&mut self, lines: u16) {
-        let max_scroll = self.compute_content_height().saturating_sub(self.height);
+        let max_scroll = self
+            .compute_content_height()
+            .saturating_sub(self.last_viewport_height.get());
         self.scroll_offset = (self.scroll_offset + lines).min(max_scroll);
     }
 
@@ -281,7 +292,9 @@ impl Chat {
     }
 
     pub fn scroll_to_top(&mut self) {
-        self.scroll_offset = self.compute_content_height().saturating_sub(self.height);
+        self.scroll_offset = self
+            .compute_content_height()
+            .saturating_sub(self.last_viewport_height.get());
     }
 
     pub fn scroll_to_bottom(&mut self) {
@@ -378,6 +391,11 @@ impl Component for Chat {
         if area.height == 0 || area.width == 0 {
             return;
         }
+
+        // Record the real viewport height so scroll bounds (scroll_up /
+        // scroll_to_top) clamp against what is actually rendered, not the
+        // cached resize-time height that ignores the activity-spinner rows.
+        self.last_viewport_height.set(area.height);
 
         if !self.has_messages {
             welcome::draw_welcome_with_tools(


### PR DESCRIPTION
Two chat-view bugs hit while using the TUI.

## 1. Long output unreachable by scrolling (`components/chat/mod.rs`)
`scroll_up` / `scroll_to_top` clamp against `self.height`, the cached value set on resize via `Layout::compute_with_input_height` — which computes chat height as `term − header − status − input − tasks − agents` and **omits the activity-spinner rows**. The actual draw area (`LayoutAreas::compute_with_chat_height`) **does** subtract `activity_lines`, so the rendered viewport is shorter than `self.height`.

Result: `max_scroll = content − self.height` is too small, so the **top of long responses can't be scrolled into view** — you have to enlarge the terminal to see it (the spinner is active during streaming, exactly when output is long).

**Fix:** capture the real draw-area height each frame in a `Cell<u16>` and clamp scrolling against that, so scroll range always matches what's on screen.

## 2. One answer split into multiple `◈ OSA` blocks (`app/handle_actions.rs`)
`handle_agent_response` reset `agent_header_sent = false` on **every** response. A turn that emits more than one `agent_response` (text → tool/subagent → more text) therefore printed a **second `◈ OSA` header**, visually chunking a single answer into separate blocks.

**Fix:** the flag is already reset when the user submits (`submit_prompt`); stop resetting it per-response and set it after the first block. The whole turn now renders under **one** header, with subsequent text as header-less continuations. Separate user turns still get their own header.

Both verified to compile (`cargo build --release`) and exercised locally. Single-purpose, no API/dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)