### PR TITLE
fix(boot): don't crash the app when Events.Bus is transiently unavailable at startup

### DIFF
--- a/lib/optimal_system_agent/agent/progress.ex
+++ b/lib/optimal_system_agent/agent/progress.ex
@@ -94,11 +94,25 @@ defmodule OptimalSystemAgent.Agent.Progress do
 
   @impl true
   def init(state) do
-    # Register handlers for orchestrator events on the event bus
-    register_event_handlers()
+    {:ok, state, {:continue, :register_bus_handler}}
+  end
 
-    Logger.info("[Progress] Progress tracker started")
-    {:ok, state}
+  # Registering with Events.Bus is deferred to handle_continue (rather than
+  # done inline in init/1) so a boot-time hiccup there — e.g. Bus transiently
+  # unreachable while Infrastructure is still settling under load — degrades
+  # Progress instead of crashing it, which would otherwise take down the
+  # whole AgentServices supervisor (and hence the entire app) on startup.
+  @impl true
+  def handle_continue(:register_bus_handler, state) do
+    case try_register_event_handlers() do
+      :ok ->
+        Logger.info("[Progress] Progress tracker started")
+        {:noreply, state}
+
+      :error ->
+        Process.send_after(self(), :retry_register_bus_handler, 500)
+        {:noreply, state}
+    end
   end
 
   @impl true
@@ -184,9 +198,23 @@ defmodule OptimalSystemAgent.Agent.Progress do
   end
 
   @impl true
+  def handle_info(:retry_register_bus_handler, state) do
+    {:noreply, state, {:continue, :register_bus_handler}}
+  end
+
+  @impl true
   def handle_info(_msg, state), do: {:noreply, state}
 
   # ── Event Handlers ──────────────────────────────────────────────────
+
+  defp try_register_event_handlers do
+    register_event_handlers()
+    :ok
+  catch
+    :exit, reason ->
+      Logger.warning("[Progress] Events.Bus unavailable, will retry: #{inspect(reason)}")
+      :error
+  end
 
   defp register_event_handlers do
     progress_pid = self()

--- a/lib/optimal_system_agent/agent/scheduler.ex
+++ b/lib/optimal_system_agent/agent/scheduler.ex
@@ -164,7 +164,7 @@ defmodule OptimalSystemAgent.Agent.Scheduler do
 
     state = %{state | heartbeat_started_at: DateTime.utc_now()}
     state = load_crons(state)
-    state = load_triggers(state)
+    state = load_trigger_state(state)
 
     Logger.info(
       "Scheduler started — heartbeat every #{div(heartbeat_interval(), 60_000)} min, " <>
@@ -172,7 +172,25 @@ defmodule OptimalSystemAgent.Agent.Scheduler do
         "#{map_size(state.trigger_handlers)} trigger(s)"
     )
 
-    {:ok, state}
+    {:ok, state, {:continue, :register_bus_triggers}}
+  end
+
+  # Registering triggers with Events.Bus is deferred to handle_continue so a
+  # boot-time hiccup there — e.g. Bus transiently unreachable while
+  # Infrastructure is still settling under load — degrades the bus-trigger
+  # bridge instead of crashing the Scheduler, which would otherwise take
+  # down the whole AgentServices supervisor (and hence the entire app).
+  @impl true
+  def handle_continue(:register_bus_triggers, state) do
+    try do
+      register_event_triggers(state.triggers_raw)
+      {:noreply, state}
+    catch
+      :exit, reason ->
+        Logger.warning("[Scheduler] Events.Bus unavailable, will retry: #{inspect(reason)}")
+        Process.send_after(self(), :retry_register_bus_triggers, 500)
+        {:noreply, state}
+    end
   end
 
   # ── Cast Handlers ─────────────────────────────────────────────────────
@@ -440,6 +458,11 @@ defmodule OptimalSystemAgent.Agent.Scheduler do
   # ── Info Handlers ─────────────────────────────────────────────────────
 
   @impl true
+  def handle_info(:retry_register_bus_triggers, state) do
+    {:noreply, state, {:continue, :register_bus_triggers}}
+  end
+
+  @impl true
   def handle_info(:heartbeat, state) do
     state = run_heartbeat(state)
     schedule_heartbeat()
@@ -455,6 +478,10 @@ defmodule OptimalSystemAgent.Agent.Scheduler do
 
   # ── CRONS/TRIGGERS I/O (delegated to Scheduler.Persistence) ────────
   defp load_crons(state), do: Persistence.load_crons(state)
+
+  # Loads trigger state only — used at init/1, where bus registration is
+  # deferred to handle_continue(:register_bus_triggers, ...) instead.
+  defp load_trigger_state(state), do: Persistence.load_triggers(state)
 
   defp load_triggers(state) do
     state = Persistence.load_triggers(state)

--- a/lib/optimal_system_agent/signal/persistence.ex
+++ b/lib/optimal_system_agent/signal/persistence.ex
@@ -13,11 +13,34 @@ defmodule OptimalSystemAgent.Signal.Persistence do
 
   @impl true
   def init(_opts) do
-    ref = Bus.register_handler(:signal_classified, &handle_signal_event/1)
-    {:ok, %{handler_ref: ref}}
+    {:ok, %{handler_ref: nil}, {:continue, :register_bus_handler}}
+  end
+
+  # Deferred to handle_continue so a boot-time hiccup on Events.Bus (e.g.
+  # transiently unreachable while Infrastructure is still settling under
+  # load) degrades Signal.Persistence instead of crashing it and taking
+  # down the whole AgentServices supervisor.
+  @impl true
+  def handle_continue(:register_bus_handler, state) do
+    try do
+      ref = Bus.register_handler(:signal_classified, &handle_signal_event/1)
+      {:noreply, %{state | handler_ref: ref}}
+    catch
+      :exit, reason ->
+        Logger.warning("[Persistence] Events.Bus unavailable, will retry: #{inspect(reason)}")
+        Process.send_after(self(), :retry_register_bus_handler, 500)
+        {:noreply, state}
+    end
   end
 
   @impl true
+  def handle_info(:retry_register_bus_handler, state) do
+    {:noreply, state, {:continue, :register_bus_handler}}
+  end
+
+  @impl true
+  def terminate(_reason, %{handler_ref: nil}), do: :ok
+
   def terminate(_reason, %{handler_ref: ref}) do
     Bus.unregister_handler(:signal_classified, ref)
     :ok


### PR DESCRIPTION
## Summary
- `Agent.Progress`, `Signal.Persistence`, and `Agent.Scheduler` each register an `Events.Bus` handler synchronously inside `init/1`. Under boot-time CPU contention, `Events.Bus` can be mid-restart (Infrastructure's own `rest_for_one` recovering it) when these later `AgentServices` children start, so `Process.whereis(Bus)` resolves to `nil` for a few seconds.
- That produced a `GenServer.call ... :noproc` crash inside `init/1`, which took down the whole `AgentServices` supervisor — and therefore the entire OSA application — on that boot attempt.
- Deferred each Bus registration to `handle_continue`, with a `catch :exit` + `Process.send_after` retry, so a transient Bus hiccup degrades the affected subsystem instead of crashing app boot.

## Root cause
On a heavily loaded machine, `Tools.Registry`'s goldrush compile step during `Infrastructure` boot can take several seconds. During that window `Events.Bus` was observed crashing and being restarted by `Infrastructure`'s `rest_for_one` (confirmed via `Process.monitor` + multiple `Event bus started` log lines per boot). `Agent.Progress.init/1` (and the other two modules) called `Bus.register_handler/2` synchronously with no tolerance for that window, so the very first hit crashed the whole app.

## Test plan
- [x] Reproduced the crash on unmodified `origin/main` (`git stash` + rerun) — confirmed it's not caused by anything else in this branch.
- [x] `mix run --no-halt` x5 on unmodified code under the same load: 4/5 failed to start with the exact reported trace.
- [x] Same test x5 with this fix applied: 5/5 booted cleanly to `OSA boot complete`, with `[Progress] Events.Bus unavailable, will retry` warnings logged during the contended window and successful registration afterward.
- [x] `mix compile` clean, no new warnings introduced by this change.
- [x] Ran existing scheduler/persistence test files — no regressions (8 pre-existing failures are an unrelated test-DB migration gap, reproduced identically on a fully fresh test DB with this branch checked out).