### PR TITLE
fix: MCP transport crash-loop, loopback 429, and workspace label

### DIFF
--- a/bin/osa
+++ b/bin/osa
@@ -38,6 +38,13 @@ HOME="${HOME:-/root}"
 export LC_ALL="${LC_ALL:-C.UTF-8}"
 export LANG="${LANG:-C.UTF-8}"
 
+# Capture the user's launch directory BEFORE any `cd` below, and hand it to the
+# backend as OSA_ORIGINAL_CWD. The daemon starts with `cd "$ROOT"` (the OSA
+# source tree) then `mix osa.serve`, so without this the backend's File.cwd!()
+# resolves to the OSA source dir — making the workspace identity (and the TUI
+# status bar) read "OptimalSystemAgent" instead of the project you launched in.
+export OSA_ORIGINAL_CWD="${OSA_ORIGINAL_CWD:-$PWD}"
+
 # sudo helper: skip when already root
 if [ "$(id -u)" -eq 0 ]; then
   SUDO=""

--- a/lib/optimal_system_agent/channels/http/rate_limiter.ex
+++ b/lib/optimal_system_agent/channels/http/rate_limiter.ex
@@ -40,10 +40,27 @@ defmodule OptimalSystemAgent.Channels.HTTP.RateLimiter do
 
   @impl Plug
   def call(conn, _opts) do
-    ensure_table()
-    ip = conn.remote_ip |> normalize_ip() |> format_ip()
-    limit = limit_for_path(conn.request_path)
+    normalized = normalize_ip(conn.remote_ip)
 
+    # Loopback is the trusted local TUI/SDK — the only client when the backend
+    # binds to 127.0.0.1 (the default). It legitimately bursts many requests on
+    # attach (session create, command execute, event polling), so a 60/min cap
+    # throttles the app into unusability against itself. Rate limiting exists to
+    # bound REMOTE abuse (relevant only when OSA_HTTP_IP exposes the port), so
+    # skip it entirely for loopback — mirroring the "open-access on loopback"
+    # posture the auth layer already takes.
+    if loopback?(normalized) do
+      conn
+    else
+      ensure_table()
+      ip = format_ip(normalized)
+      limit = limit_for_path(conn.request_path)
+
+      consume(conn, ip, limit)
+    end
+  end
+
+  defp consume(conn, ip, limit) do
     case check_and_consume(ip, limit) do
       {:ok, remaining} ->
         conn
@@ -108,6 +125,11 @@ defmodule OptimalSystemAgent.Channels.HTTP.RateLimiter do
   defp limit_for_path("/api/v1/auth/" <> _), do: @auth_limit
   defp limit_for_path("/api/v1/platform/auth/" <> _), do: @auth_limit
   defp limit_for_path(_), do: @default_limit
+
+  # 127.0.0.0/8 and IPv6 ::1 (IPv4-mapped loopback already normalized above).
+  defp loopback?({127, _, _, _}), do: true
+  defp loopback?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp loopback?(_), do: false
 
   defp format_ip({a, b, c, d}), do: "#{a}.#{b}.#{c}.#{d}"
   defp format_ip({a, b, c, d, e, f, g, h}), do: "#{a}:#{b}:#{c}:#{d}:#{e}:#{f}:#{g}:#{h}"

--- a/lib/optimal_system_agent/mcp/client/server_session.ex
+++ b/lib/optimal_system_agent/mcp/client/server_session.ex
@@ -485,8 +485,8 @@ defmodule OptimalSystemAgent.MCP.Client.ServerSession do
     :exit, _ -> :ok
   end
 
-  defp transport_mod(%Server{transport: :stdio}) do
-    Application.get_env(:optimal_system_agent, :mcp_stdio_transport, Stdio)
+  defp transport_mod(%Server{transport: :http_sse}) do
+    Application.get_env(:optimal_system_agent, :mcp_http_transport, Http)
   end
 
   defp transport_mod(_) do

--- a/lib/optimal_system_agent/memory/store.ex
+++ b/lib/optimal_system_agent/memory/store.ex
@@ -735,6 +735,15 @@ defmodule OptimalSystemAgent.Memory.Store do
     rescue
       e ->
         Logger.warning("[Memory.Store] failed to load from SQLite: #{Exception.message(e)}")
+    catch
+      # A DBConnection pool worker can be transiently down (:noproc on
+      # checkout) while Infrastructure is still settling under load. That
+      # surfaces as an EXIT signal, not a raised exception, so `rescue`
+      # alone doesn't catch it — letting it crash init/1 here takes down
+      # the whole AgentServices supervisor (and thus the entire app), since
+      # Memory.Store is its first child.
+      :exit, reason ->
+        Logger.warning("[Memory.Store] failed to load from SQLite: #{inspect(reason)}")
     end
   end
 


### PR DESCRIPTION
Follow-up to #87 (closed after the Events.Bus fix was cherry-picked). This carries the fixes that were NOT yet on `main`, all found while running `osa` end-to-end on macOS.

## What's fixed

**1. MCP transport crash-loop (deterministic, was the real "keeps happening" boot failure)**
`ServerSession.transport_mod/1` had two clauses that both returned the stdio transport — including for `%Server{transport: :http_sse}`. Any MCP server configured with a `url` (no `command`) got routed to stdio, which raises `KeyError` on the missing `:command` on every connect. With `autoConnect: true` this retries fast enough to exhaust every supervisor's restart budget up the chain, tearing down and restarting the whole Infrastructure supervisor forever. Routed `:http_sse` configs to the existing (implemented, aliased, just never wired) `Transport.Http`.

**2. Memory.Store crashed boot on transient DB pool unavailability**
`load_from_sqlite/0` used `rescue` only, which doesn't catch DBConnection's `:noproc` *exit* when a pool worker is briefly down. Added a matching `catch :exit`. Memory.Store is AgentServices' first child, so this took down the whole subsystem.

**3. Loopback rate-limiting — "Session create failed: HTTP 429"**
`RateLimiter` capped all traffic at 60 req/min per IP, including loopback. The backend binds to 127.0.0.1 by default, so the only client is the local TUI, which bursts requests on attach and 429'd itself into unusability. Loopback is now exempt (mirrors the auth layer's "open-access on loopback" posture); remote IPs stay bounded.

**4. Workspace mislabeled "OptimalSystemAgent"**
`bin/osa` never exported `OSA_ORIGINAL_CWD`, so the daemon (started via `cd "$ROOT" && mix osa.serve`) resolved `File.cwd!()` to the OSA source tree — the status bar showed "OptimalSystemAgent" instead of the launch dir. Capture `$PWD` before any `cd` and export it, matching what `Workspace.Cwd` already expects.

## Test plan
- [x] `mix osa.serve` x3: boots to healthy `/health` and stays healthy (previously crash-looped forever on every attempt).
- [x] 0/20 rapid `POST /api/v1/sessions` return 429 (previously every one after the burst).
- [x] `/api/v1/workspace/identity` returns `{"name":"MIOSA", ...}` when launched from `~/code/MIOSA`.
- [x] `mix compile` clean (no new warnings from these files).

Note: the #1 dispatch fix is the one that actually stops the reported boot failure — the Bus retry fix from #87 alone did not (empirically 3/5 boots still failed until this landed).