### PR TITLE
fix(models): correct Ollama Cloud context windows; drop retired Gemini model

### DIFF
--- a/lib/optimal_system_agent/agent/tier.ex
+++ b/lib/optimal_system_agent/agent/tier.ex
@@ -117,14 +117,15 @@ defmodule OptimalSystemAgent.Agent.Tier do
     },
 
     # --- Ollama Cloud (all models must support tool calling) ---
-    # Updated 2026-07 — verified live against ollama.com/search?c=cloud
+    # Updated 2026-07-20 — verified live against ollama.com/api/show per model.
     ollama_cloud: %{
-      # Z.ai flagship — long-horizon agentic + coding
+      # Z.ai flagship — long-horizon agentic + coding (1M ctx)
       elite: "glm-5.2:cloud",
-      # 1M ctx, native multimodal agentic
+      # native multimodal agentic (512K ctx)
       specialist: "minimax-m3:cloud",
-      # frontier intelligence built for speed
-      utility: "gemini-3-flash-preview:cloud"
+      # OpenAI open-weight, fast (131K ctx). Replaced gemini-3-flash-preview,
+      # which Ollama Cloud retired 2026-07-15 (/api/show → "was retired").
+      utility: "gpt-oss:20b-cloud"
     },
 
     # --- Local providers (dynamic, auto-detect best installed) ---

--- a/lib/optimal_system_agent/onboarding.ex
+++ b/lib/optimal_system_agent/onboarding.ex
@@ -187,7 +187,7 @@ defmodule OptimalSystemAgent.Onboarding do
           %{
             id: "glm-5.2:cloud",
             name: "GLM-5.2",
-            ctx: 204_800,
+            ctx: 1_000_000,
             tools: true,
             recommended: true,
             note: "Z.ai flagship — long-horizon agentic + coding"
@@ -195,7 +195,7 @@ defmodule OptimalSystemAgent.Onboarding do
           %{
             id: "glm-5.1:cloud",
             name: "GLM-5.1",
-            ctx: 204_800,
+            ctx: 202_752,
             tools: true,
             note: "agentic, state-of-the-art coding"
           },
@@ -216,23 +216,23 @@ defmodule OptimalSystemAgent.Onboarding do
           %{
             id: "minimax-m3:cloud",
             name: "MiniMax M3",
-            ctx: 1_048_576,
+            ctx: 524_288,
             tools: true,
-            note: "1M ctx, native multimodal + agentic"
+            note: "512K ctx, native multimodal + agentic"
           },
           %{
             id: "deepseek-v4-pro:cloud",
             name: "DeepSeek V4 Pro",
-            ctx: 163_840,
+            ctx: 524_288,
             tools: true,
-            note: "frontier MoE, multiple reasoning modes"
+            note: "512K ctx, frontier MoE, multiple reasoning modes"
           },
           %{
             id: "deepseek-v4-flash:cloud",
             name: "DeepSeek V4 Flash",
-            ctx: 163_840,
+            ctx: 1_048_576,
             tools: true,
-            note: "284B MoE / 13B active — fast"
+            note: "1M ctx, 284B MoE / 13B active — fast"
           },
           %{
             id: "gpt-oss:120b-cloud",
@@ -249,25 +249,25 @@ defmodule OptimalSystemAgent.Onboarding do
             note: "multimodal, vision + tools"
           },
           %{
-            id: "gemini-3-flash-preview:cloud",
-            name: "Gemini 3 Flash",
-            ctx: 1_048_576,
+            id: "gpt-oss:20b-cloud",
+            name: "GPT-OSS 20B",
+            ctx: 131_072,
             tools: true,
-            note: "frontier intelligence built for speed"
+            note: "OpenAI open-weight, fast — light utility tier"
           },
           %{
             id: "nemotron-3-super:cloud",
             name: "Nemotron 3 Super",
-            ctx: 1_048_576,
+            ctx: 262_144,
             tools: true,
-            note: "1M ctx, 120B MoE — efficient agentic"
+            note: "262K ctx, 120B MoE — efficient agentic"
           },
           %{
             id: "gemma4:cloud",
             name: "Gemma 4",
-            ctx: 131_072,
+            ctx: 262_144,
             tools: true,
-            note: "frontier reasoning + multimodal"
+            note: "262K ctx, frontier reasoning + multimodal"
           }
         ]
       },

--- a/lib/optimal_system_agent/providers/registry.ex
+++ b/lib/optimal_system_agent/providers/registry.ex
@@ -779,11 +779,27 @@ defmodule OptimalSystemAgent.Providers.Registry do
     # published maximums. GLM-5.2 ships a real 1M-token window (Ollama shows
     # "976K" only because it displays the count ÷1024); GLM-4.6 is 200K.
     "glm-5.2" => 1_000_000,
-    "glm-5.1" => 200_000,
+    "glm-5.1" => 202_752,
     "glm-5" => 200_000,
     "glm-4.6" => 200_000,
     "glm-4.5-air" => 128_000,
-    "glm-4.5" => 128_000
+    "glm-4.5" => 128_000,
+    # Other Ollama Cloud models. Windows verified 2026-07-20 live against
+    # ollama.com/api/show (model_info "<arch>.context_length") per model, so the
+    # runtime context budget matches the model's real limit instead of the
+    # picker's prior guesses (several were 4x off — e.g. nemotron-3-super was
+    # listed at 1M but is 262K, which would overflow the real window).
+    "nemotron-3-ultra" => 262_144,
+    "nemotron-3-super" => 262_144,
+    "minimax-m3" => 524_288,
+    "deepseek-v4-pro" => 524_288,
+    "deepseek-v4-flash" => 1_048_576,
+    "kimi-k2.7-code" => 262_144,
+    "kimi-k2.6" => 262_144,
+    "qwen3.5" => 262_144,
+    "gpt-oss:120b" => 131_072,
+    "gpt-oss:20b" => 131_072,
+    "gemma4" => 262_144
   }
 
   @spec context_window(String.t()) :: pos_integer()


### PR DESCRIPTION
The model picker and tier defaults shipped guessed context windows — several were 4–6x off, and the utility tier pointed at a model Ollama Cloud has retired. Verified every value live against `ollama.com/api/show` (`model_info."<arch>.context_length"`) on 2026-07-20.

## Corrections

| model | was | real | note |
|---|---|---|---|
| glm-5.2 | 204K | **1M** | understated 5x |
| glm-5.1 | 204K | 202,752 | |
| minimax-m3 | 1M | **512K** | ⚠ overstated 2x |
| deepseek-v4-pro | 163K | 512K | understated 3x |
| deepseek-v4-flash | 163K | 1M | understated 6x |
| nemotron-3-super | 1M | **262K** | ⚠ overstated 4x |
| nemotron-3-ultra | (implicit 1M) | 262K | this is the default model |
| gemma4 | 131K | 262K | understated 2x |
| kimi-k2.7-code / k2.6 / qwen3.5 / gpt-oss:120b | — | — | confirmed already correct |

The **overstated** ones are the real hazard: the runtime context budget would pack more than the model accepts and overflow its actual window.

## Retired model
`gemini-3-flash-preview:cloud` was the **utility-tier default** and a picker entry, but Ollama Cloud retired it 2026-07-15 (`/api/show` → "was retired") — so the entire utility tier resolved to a dead model. Replaced with `gpt-oss:20b-cloud` (131K, verified live, genuinely fast).

## Scope
Corrected in all three sources so display and runtime agree:
- `onboarding.ex` — the model picker
- `tier.ex` — elite/specialist/utility tier defaults
- `registry.ex` — `context_window/1` runtime budget (added verified fallback entries)

## Test plan
- [x] `Registry.context_window/1` returns the real value for all 12 cloud models (verified via `mix run`).
- [x] `mix compile` clean (no new warnings from these files).
- [x] All replacement/candidate models confirmed to resolve against `/api/show` with the account key.