### PR TITLE
feat(agents): per-agent model/tier customization via settings (stage 1: engine)

### DIFF
--- a/lib/optimal_system_agent/agent/tier.ex
+++ b/lib/optimal_system_agent/agent/tier.ex
@@ -199,16 +199,31 @@ defmodule OptimalSystemAgent.Agent.Tier do
 
   @doc """
   Get the model for a specific agent by name.
-  Looks up the agent's tier in the Roster, then maps to the current provider.
+
+  Resolution precedence (high -> low), matching the `delegate` spawn path:
+
+      settings override (agent_overrides)  >  agent .md `model:`  >
+        agent tier -> provider tier-model  >  provider auto model
+
+  Previously this ignored the agent entirely and always returned the provider
+  auto model, so a named agent's declared tier/model never took effect on this
+  path.
   """
   @spec model_for_agent(String.t()) :: String.t()
-  def model_for_agent(agent_name) do
+  def model_for_agent(agent_name) when is_binary(agent_name) do
     provider = Application.get_env(:optimal_system_agent, :default_provider, :ollama)
+    agent_def = OptimalSystemAgent.Agents.Registry.get(agent_name)
 
-    # Roster module removed — use auto model
-    _ = agent_name
-    auto_model(provider)
+    tier =
+      OptimalSystemAgent.Agents.Config.tier_override(agent_name) ||
+        (agent_def && agent_def[:tier]) || :specialist
+
+    OptimalSystemAgent.Agents.Config.model_override(agent_name) ||
+      (agent_def && agent_def[:model]) ||
+      model_for(tier, provider)
   end
+
+  def model_for_agent(_), do: auto_model(Application.get_env(:optimal_system_agent, :default_provider, :ollama))
 
   @doc "Get the token budget for a tier."
   @spec budget_for(tier()) :: map()

--- a/lib/optimal_system_agent/agents/config.ex
+++ b/lib/optimal_system_agent/agents/config.ex
@@ -1,0 +1,63 @@
+defmodule OptimalSystemAgent.Agents.Config do
+  @moduledoc """
+  User-facing per-agent customization: model + tier overrides read from the
+  settings cascade so users can retarget which model runs which agent (and at
+  what tier) WITHOUT hand-editing each agent's `.md` frontmatter.
+
+  Overrides live under the `agent_overrides` settings key (settings.json):
+
+      "agent_overrides": {
+        "code-reviewer": { "model": "glm-5.2:cloud", "tier": "elite" },
+        "debugger":      { "model": "minimax-m3:cloud" }
+      }
+
+  Resolution precedence (high -> low), applied by the spawn paths:
+
+      explicit per-call arg  >  settings override (here)  >  agent .md frontmatter  >  tier default
+
+  So a settings override retargets an agent globally, an agent's own `.md`
+  `model:`/`tier:` is the shipped default, and a one-off `delegate` call arg
+  still wins for that single dispatch.
+  """
+
+  alias OptimalSystemAgent.Settings
+
+  @settings_key "agent_overrides"
+
+  @doc "Per-agent model override from settings, or nil when unset."
+  @spec model_override(String.t() | nil) :: String.t() | nil
+  def model_override(agent_name), do: field(agent_name, "model")
+
+  @doc "Per-agent tier override (atom) from settings, or nil when unset/invalid."
+  @spec tier_override(String.t() | nil) :: :elite | :specialist | :utility | nil
+  def tier_override(agent_name) do
+    case field(agent_name, "tier") do
+      t when t in ["elite", "specialist", "utility"] -> String.to_existing_atom(t)
+      _ -> nil
+    end
+  end
+
+  @doc "The full overrides map (agent_name => %{...}), or an empty map."
+  @spec all() :: %{optional(String.t()) => map()}
+  def all do
+    case Settings.get(@settings_key) do
+      %{} = m -> m
+      _ -> %{}
+    end
+  end
+
+  defp field(nil, _key), do: nil
+
+  defp field(agent_name, key) when is_binary(agent_name) do
+    case Map.get(all(), agent_name) do
+      %{} = a ->
+        case Map.get(a, key) do
+          v when is_binary(v) and v != "" -> v
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/optimal_system_agent/settings/schema.ex
+++ b/lib/optimal_system_agent/settings/schema.ex
@@ -22,6 +22,9 @@ defmodule OptimalSystemAgent.Settings.Schema do
       {:map, ~s(Use {"hooks": {"pre_tool_use": [{"type": "shell", "command": "..."}]}})},
     "permissions" =>
       {:map, ~s(Use {"permissions": {"allow": [...], "deny": [...], "ask": [...]}})},
+    "agent_overrides" =>
+      {:map,
+       ~s(Use {"agent_overrides": {"code-reviewer": {"model": "glm-5.2:cloud", "tier": "elite"}}})},
     "model" => {:string, ~s(Use a model id string, e.g. {"model": "glm-4.7:cloud"})},
     "personality" => {:string, "Use a personality name string"},
     "skin" => {:string, ~s(Use a skin name string, e.g. "dark")},

--- a/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
@@ -14,6 +14,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
   alias OptimalSystemAgent.Tools.Builtins.Delegate.Constants
   alias OptimalSystemAgent.Tools.UseContext
   alias OptimalSystemAgent.Agents.Registry, as: AgentRegistry
+  alias OptimalSystemAgent.Agents.Config, as: AgentConfig
   alias OptimalSystemAgent.Orchestrator
   alias OptimalSystemAgent.Agent.RunStore
   alias OptimalSystemAgent.Agent.Tier
@@ -143,6 +144,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
     raw_tier =
       cond do
         tier_str -> parse_tier(tier_str)
+        tier_override = AgentConfig.tier_override(role) -> tier_override
         agent_def -> agent_def[:tier] || Constants.min_subagent_tier()
         true -> Constants.min_subagent_tier()
       end
@@ -169,7 +171,9 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
       # name (fan-out) wins over a top-level "name" arg.
       name: name || Map.get(args, "name"),
       tier: tier,
-      model: Map.get(args, "model") || (agent_def && agent_def[:model]),
+      model:
+        Map.get(args, "model") || AgentConfig.model_override(role) ||
+          (agent_def && agent_def[:model]),
       provider: Map.get(args, "provider") || (agent_def && agent_def[:provider]),
       permission_tier:
         parse_permission_tier(

--- a/test/optimal_system_agent/agents/config_test.exs
+++ b/test/optimal_system_agent/agents/config_test.exs
@@ -1,0 +1,55 @@
+defmodule OptimalSystemAgent.Agents.ConfigTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Agents.Config
+  alias OptimalSystemAgent.Settings
+
+  setup do
+    # Session layer is highest-priority and cheap to set/clear per test.
+    on_exit(fn -> Settings.set_session("agent_overrides", %{}) end)
+    :ok
+  end
+
+  describe "model_override/1" do
+    test "returns nil when no overrides configured" do
+      Settings.set_session("agent_overrides", %{})
+      assert Config.model_override("code-reviewer") == nil
+    end
+
+    test "returns nil for nil / unknown agent" do
+      Settings.set_session("agent_overrides", %{"debugger" => %{"model" => "glm-5.2:cloud"}})
+      assert Config.model_override(nil) == nil
+      assert Config.model_override("no-such-agent") == nil
+    end
+
+    test "returns the configured model for a matching agent" do
+      Settings.set_session("agent_overrides", %{
+        "code-reviewer" => %{"model" => "glm-5.2:cloud"}
+      })
+
+      assert Config.model_override("code-reviewer") == "glm-5.2:cloud"
+    end
+
+    test "ignores blank model values" do
+      Settings.set_session("agent_overrides", %{"code-reviewer" => %{"model" => ""}})
+      assert Config.model_override("code-reviewer") == nil
+    end
+  end
+
+  describe "tier_override/1" do
+    test "parses a valid tier string to an atom" do
+      Settings.set_session("agent_overrides", %{"code-reviewer" => %{"tier" => "elite"}})
+      assert Config.tier_override("code-reviewer") == :elite
+    end
+
+    test "rejects an invalid tier string" do
+      Settings.set_session("agent_overrides", %{"code-reviewer" => %{"tier" => "bogus"}})
+      assert Config.tier_override("code-reviewer") == nil
+    end
+
+    test "returns nil when unset" do
+      Settings.set_session("agent_overrides", %{"code-reviewer" => %{"model" => "x"}})
+      assert Config.tier_override("code-reviewer") == nil
+    end
+  end
+end


### PR DESCRIPTION
Stage 1 of making agent/model customization real. You asked to "select which model runs which agent, how many agents, all that" — this lays the engine + a settings surface, so it works **today** without a TUI, and the TUI (stage 3) will just drive these same knobs.

## The bug this also fixes
`Tier.model_for_agent/1` was stubbed — literally `# Roster module removed - use auto model`, ignoring the agent name *and* its tier and returning the provider's auto model for every agent. So on that path, "which model runs which agent" did nothing.

(The primary `delegate` spawn path *did* already honor an agent's `.md` `model:`/`tier:` — but only by hand-editing files, with no settings-level or discoverable override.)

## What stage 1 adds
- **`Agents.Config`** — per-agent overrides from the settings cascade under `agent_overrides`:
  ```json
  "agent_overrides": {
    "code-reviewer": { "model": "glm-5.2:cloud", "tier": "elite" },
    "debugger":      { "model": "minimax-m3:cloud" }
  }
  ```
- Precedence (high→low): **explicit per-call arg > settings override > agent `.md` frontmatter > tier default.**
- Wired into `delegate/handler.ex` (the main subagent spawn path) for both model and tier.
- Fixed the `model_for_agent/1` stub to use the same chain.
- Registered `agent_overrides` in the settings schema (friendly boot-time validation).

## Test plan
- [x] New `config_test.exs`: override present / absent / blank / invalid-tier / nil-agent (all pass).
- [x] Existing `tier_test.exs` green — 17 tests, 0 failures.
- [x] `mix compile` clean (no new warnings from touched files).

## Next stages (separate PRs)
2. Per-tier **agent-count** overrides (the "how many agents" half) via the same settings surface.
3. **TUI editor** — interactive screens to view/edit the agent→model→tier map and counts live, writing back to `agent_overrides`.