### PR TITLE
feat(authority): route governed tool execution through unified action authority

### DIFF
--- a/docs/backend/tools/overview.md
+++ b/docs/backend/tools/overview.md
@@ -106,6 +106,7 @@ Tools run through a middleware pipeline that can wrap execution with cross-cutti
 | Stage | Purpose |
 |-------|---------|
 | **Schema validation** | Validate input against JSON schema before calling `execute/1` |
+| **Central action authority** | For governed platform actions only, ask MIOSA's durable action authority whether the authenticated principal may act in the selected tenant/workspace; fail closed. Purely local tools are ungoverned and skip it (no network call). See `OptimalSystemAgent.ActionAuthority`. |
 | **Safety gate** | Block tools inappropriate for the current permission tier |
 | **Budget check** | Verify the operation fits within the session token/cost budget |
 | **Telemetry** | Emit execution time, success/failure metrics |
@@ -118,6 +119,7 @@ Tool.execute/1
   → Middleware.schema_validate
   → Middleware.safety_check(permission_tier)
   → Middleware.budget_check(session)
+  → ActionAuthority.authorize_tool  (governed platform actions only; fail closed)
   → Tool.execute/1  (actual work)
   → Middleware.telemetry_emit
   → {:ok | :error, result}

--- a/docs/foundation-core/diagrams/workflows/tool-execution.md
+++ b/docs/foundation-core/diagrams/workflows/tool-execution.md
@@ -64,7 +64,14 @@ sequenceDiagram
                     ToolEx-->>Loop: "Tool 'name' not found"
                 end
             else tool found
-                ToolsReg->>Tool: execute(enriched_args)
+                Note over ToolsReg: schema validation, then central action authority<br/>ActionAuthority.authorize_tool — governed platform actions only<br/>fail closed; local/ungoverned tools pass through with no network call
+
+                alt central authority blocks (governed action, not allowed)
+                    ToolsReg-->>ToolEx: {:error, "Blocked: #{message}"}
+                    ToolEx-->>Loop: "Error executing tool: Blocked: #{message}"
+                else allowed or not governed
+                    ToolsReg->>Tool: execute(enriched_args)
+                end
 
                 alt tool returns {:ok, {:image, %{media_type, data, path}}}
                     Tool-->>ToolsReg: {:ok, {:image, ...}}

--- a/lib/optimal_system_agent/action_authority.ex
+++ b/lib/optimal_system_agent/action_authority.ex
@@ -160,9 +160,11 @@ defmodule OptimalSystemAgent.ActionAuthority do
       capability: capability["fingerprint"],
       params: params_fingerprint,
       surface: surface,
-      tool: tool_name,
-      workspace_id: workspace_id
+      tool: tool_name
     }
+
+    invocation =
+      if workspace_id, do: Map.put(invocation, :workspace_id, workspace_id), else: invocation
 
     body = %{
       capability: %{

--- a/lib/optimal_system_agent/action_authority.ex
+++ b/lib/optimal_system_agent/action_authority.ex
@@ -1,0 +1,266 @@
+defmodule OptimalSystemAgent.ActionAuthority do
+  @moduledoc """
+  The single OSA adapter to MIOSA's durable action authority.
+
+  OSA keeps its local, non-bypassable safety checks for protecting the machine
+  it runs on.
+  This module answers a different question: whether the authenticated MIOSA
+  principal may perform a governed platform action in the selected tenant and
+  workspace.
+
+  Governed actions fail closed.
+  Ungoverned local tools do not make a network request.
+  Capability versions and fingerprints always come from the control plane's
+  catalog, never from OSA-owned policy.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.MIOSA.Platform
+  alias OptimalSystemAgent.Sandbox
+
+  @type decision ::
+          :not_governed
+          | {:allow, map()}
+          | {:blocked, String.t()}
+
+  @default_timeout_ms 10_000
+
+  @doc """
+  Authorize one tool invocation at the final execution boundary.
+
+  The default mapping governs `shell_execute` only when its selected backend is
+  MIOSA. Additional exact tool-to-capability mappings can be supplied through
+  `config :optimal_system_agent, :action_authority, capability_map: %{...}`.
+  """
+  @spec authorize_tool(String.t(), map()) :: decision()
+  def authorize_tool(tool_name, arguments) when is_binary(tool_name) and is_map(arguments) do
+    case capability_for(tool_name, arguments) do
+      nil ->
+        :not_governed
+
+      capability_name ->
+        authorize(
+          capability_name,
+          tool_name,
+          public_arguments(arguments),
+          surface(arguments)
+        )
+    end
+  end
+
+  def authorize_tool(_tool_name, _arguments),
+    do: {:blocked, "central action authority received an invalid tool invocation"}
+
+  @doc "Cross-language stable SHA-256 fingerprint of canonical JSON."
+  @spec fingerprint(term()) :: String.t()
+  def fingerprint(value) do
+    digest = :crypto.hash(:sha256, canonical_json(value)) |> Base.encode16(case: :lower)
+    "sha256:" <> digest
+  end
+
+  @doc "Canonical JSON with recursively sorted object keys."
+  @spec canonical_json(term()) :: String.t()
+  def canonical_json(value) when is_map(value) do
+    pairs =
+      value
+      |> Enum.map(fn {key, child} -> {to_string(key), child} end)
+      |> Enum.sort_by(&elem(&1, 0))
+      |> Enum.map_join(",", fn {key, child} ->
+        Jason.encode!(key) <> ":" <> canonical_json(child)
+      end)
+
+    "{" <> pairs <> "}"
+  end
+
+  def canonical_json(value) when is_list(value),
+    do: "[" <> Enum.map_join(value, ",", &canonical_json/1) <> "]"
+
+  def canonical_json(value)
+      when is_binary(value) or is_number(value) or is_boolean(value) or
+             is_nil(value),
+      do: Jason.encode!(value)
+
+  def canonical_json(value),
+    do:
+      raise(
+        ArgumentError,
+        "authority fingerprints require JSON-safe values, got: #{inspect(value)}"
+      )
+
+  defp authorize(capability_name, tool_name, arguments, surface) do
+    with {:ok, key} <- require_platform_key(),
+         {:ok, capability} <- fetch_capability(capability_name, key),
+         {:ok, response} <- request_decision(capability, tool_name, arguments, surface, key) do
+      interpret(response)
+    else
+      {:error, reason} ->
+        Logger.error(
+          "[ActionAuthority] blocked #{tool_name}/#{capability_name}: #{inspect(reason)}"
+        )
+
+        {:blocked, failure_message(reason)}
+    end
+  end
+
+  defp capability_for(tool_name, arguments) do
+    configured =
+      authority_config()
+      |> Keyword.get(:capability_map, %{})
+      |> Map.get(tool_name)
+
+    cond do
+      is_binary(configured) ->
+        configured
+
+      tool_name == "shell_execute" and miosa_sandbox?(arguments) ->
+        "sandbox.exec"
+
+      true ->
+        nil
+    end
+  end
+
+  defp miosa_sandbox?(_arguments) do
+    Sandbox.Router.backend() == Sandbox.MIOSA
+  end
+
+  defp require_platform_key do
+    case Platform.platform_api_key() do
+      key when is_binary(key) and key != "" -> {:ok, key}
+      _ -> {:error, :platform_auth_missing}
+    end
+  end
+
+  defp fetch_capability(name, key) do
+    case request(:get, "/api/v1/actions/catalog", key, []) do
+      {:ok, 200, %{"data" => catalog}} when is_list(catalog) ->
+        case Enum.find(catalog, &(&1["name"] == name)) do
+          %{"fingerprint" => fingerprint} = capability
+          when is_binary(fingerprint) and fingerprint != "" ->
+            {:ok, capability}
+
+          _ ->
+            {:error, {:capability_not_registered, name}}
+        end
+
+      {:ok, status, body} ->
+        {:error, {:catalog_http_error, status, body}}
+
+      {:error, reason} ->
+        {:error, {:catalog_unavailable, reason}}
+    end
+  end
+
+  defp request_decision(capability, tool_name, arguments, surface, key) do
+    workspace_id = Platform.workspace_id()
+    params_fingerprint = fingerprint(arguments)
+
+    invocation = %{
+      capability: capability["fingerprint"],
+      params: params_fingerprint,
+      surface: surface,
+      tool: tool_name,
+      workspace_id: workspace_id
+    }
+
+    body = %{
+      capability: %{
+        name: capability["name"],
+        fingerprint: capability["fingerprint"]
+      },
+      request_fingerprint: fingerprint(invocation),
+      params_fingerprint: params_fingerprint,
+      surface: surface
+    }
+
+    body = if workspace_id, do: Map.put(body, :workspace_id, workspace_id), else: body
+
+    case request(:post, "/api/v1/actions/authorize", key, json: body) do
+      {:ok, status, response} when status in [200, 202, 403] -> {:ok, response}
+      {:ok, status, response} -> {:error, {:authorize_http_error, status, response}}
+      {:error, reason} -> {:error, {:authority_unavailable, reason}}
+    end
+  end
+
+  defp interpret(%{"decision" => "allow"} = response), do: {:allow, response}
+
+  defp interpret(%{
+         "decision" => "pending_approval",
+         "approval_request_id" => approval_request_id
+       }) do
+    {:blocked,
+     "central approval required before this action can run (approval #{approval_request_id})"}
+  end
+
+  defp interpret(%{"decision" => "deny"} = response) do
+    {:blocked, "central action authority denied this action#{reason_suffix(response)}"}
+  end
+
+  defp interpret(response),
+    do: {:blocked, "central action authority returned an invalid decision: #{inspect(response)}"}
+
+  defp request(method, path, key, options) do
+    config = authority_config()
+
+    request_options =
+      [
+        method: method,
+        url: base_url(config) <> path,
+        headers: [{"authorization", "Bearer " <> key}],
+        receive_timeout: Keyword.get(config, :timeout_ms, @default_timeout_ms),
+        retry: false
+      ]
+      |> Keyword.merge(options)
+      |> maybe_put_plug(config)
+
+    case Req.request(request_options) do
+      {:ok, %Req.Response{status: status, body: body}} -> {:ok, status, body}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    exception -> {:error, exception}
+  end
+
+  defp maybe_put_plug(options, config) do
+    case Keyword.get(config, :plug) do
+      nil -> options
+      plug -> Keyword.put(options, :plug, plug)
+    end
+  end
+
+  defp base_url(config) do
+    config
+    |> Keyword.get(:base_url, Platform.endpoint())
+    |> String.trim_trailing("/")
+  end
+
+  defp authority_config do
+    Application.get_env(:optimal_system_agent, :action_authority, [])
+  end
+
+  defp public_arguments(arguments) do
+    Map.drop(arguments, [
+      "__session_id__",
+      :__session_id__,
+      "__surface__",
+      :__surface__
+    ])
+  end
+
+  defp surface(arguments) do
+    arguments["__surface__"] || arguments[:__surface__] || "osa"
+  end
+
+  defp reason_suffix(%{"reason" => reason}) when is_binary(reason), do: ": " <> reason
+  defp reason_suffix(_response), do: ""
+
+  defp failure_message(:platform_auth_missing),
+    do: "central action authority is required, but MIOSA platform authentication is missing"
+
+  defp failure_message({:capability_not_registered, name}),
+    do: "central action authority has no registered capability named #{name}"
+
+  defp failure_message(reason),
+    do: "central action authority is unavailable or invalid: #{inspect(reason)}"
+end

--- a/lib/optimal_system_agent/agent/loop/tool_executor.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_executor.ex
@@ -913,15 +913,28 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
 
       {:ok, %{arguments: modified_args} = _modified_payload} ->
         # Hook modified the tool arguments — use the modified version
-        enriched_args = Map.put(modified_args, "__session_id__", state.session_id)
+        enriched_args =
+          modified_args
+          |> Map.put("__session_id__", state.session_id)
+          |> Map.put("__surface__", authority_surface(state))
+
         execute_tool(tool_call.name, enriched_args)
 
       _ ->
         # Inject session_id so tools like ask_user can register pending state
-        enriched_args = Map.put(tool_call.arguments, "__session_id__", state.session_id)
+        enriched_args =
+          tool_call.arguments
+          |> Map.put("__session_id__", state.session_id)
+          |> Map.put("__surface__", authority_surface(state))
+
         execute_tool(tool_call.name, enriched_args)
     end
   end
+
+  defp authority_surface(%{channel: channel}) when channel in [:scheduler, :heartbeat],
+    do: "schedule"
+
+  defp authority_surface(_state), do: "osa"
 
   # CONCERN 3 — result finalization.
   #

--- a/lib/optimal_system_agent/agent/scheduler/job_executor.ex
+++ b/lib/optimal_system_agent/agent/scheduler/job_executor.ex
@@ -10,8 +10,7 @@ defmodule OptimalSystemAgent.Agent.Scheduler.JobExecutor do
   require Logger
 
   alias OptimalSystemAgent.Runtime.SessionManager
-  alias OptimalSystemAgent.Tools.Builtins.ShellExecute
-  alias OptimalSystemAgent.Tools.UseContext
+  alias OptimalSystemAgent.Tools.Registry
 
   @max_output_bytes 102_400
   @webhook_timeout_ms 10_000
@@ -112,16 +111,16 @@ defmodule OptimalSystemAgent.Agent.Scheduler.JobExecutor do
   # ── Shell Command Execution ───────────────────────────────────────────
 
   def run_shell_command(command) when is_binary(command) do
-    ctx = UseContext.new(%{channel: :scheduler, permission_tier: :full})
-
-    with {:ok, input} <- ShellExecute.Handler.validate(%{"command" => command}, ctx),
-         {:allow, input} <- ShellExecute.Handler.check_permissions(input, ctx),
-         {:ok, output} <- ShellExecute.Handler.execute(input, ctx) do
-      {:ok, truncate_shell_output(output)}
-    else
-      {:error, message, _code} -> {:error, message}
-      {:deny, reason} -> {:error, reason}
-      {:ask, _prompt} -> {:error, "Permission ask flow is not available for scheduled commands"}
+    # Scheduled commands must enter the same registry as interactive, MCP,
+    # HTTP, and sub-agent calls. The registry is the shared enforcement seam
+    # for hard safety, schema validation, central authority, and tool dispatch.
+    case Registry.execute("shell_execute", %{
+           "command" => command,
+           "__session_id__" => "scheduler",
+           "__surface__" => "schedule"
+         }) do
+      {:ok, output} -> {:ok, truncate_shell_output(output)}
+      {:ok, output, _metadata} -> {:ok, truncate_shell_output(output)}
       {:error, reason} -> {:error, reason}
       other -> {:error, "Unexpected shell execution result: #{inspect(other)}"}
     end

--- a/lib/optimal_system_agent/channels/http/api/tool_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/tool_routes.ex
@@ -391,7 +391,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
 
   post "/:name/execute" do
     tool_name = conn.params["name"]
-    arguments = conn.body_params["arguments"] || %{}
+    arguments = (conn.body_params["arguments"] || %{}) |> Map.put("__surface__", "osa_http")
 
     case Tools.execute(tool_name, arguments) do
       {:ok, result} ->

--- a/lib/optimal_system_agent/mcp/server/dispatcher.ex
+++ b/lib/optimal_system_agent/mcp/server/dispatcher.ex
@@ -61,7 +61,7 @@ defmodule OptimalSystemAgent.MCP.Server.Dispatcher do
 
   defp handle("tools/call", params, id) do
     name = params["name"]
-    arguments = params["arguments"] || %{}
+    arguments = (params["arguments"] || %{}) |> Map.put("__surface__", "mcp")
 
     result =
       cond do

--- a/lib/optimal_system_agent/miosa/platform.ex
+++ b/lib/optimal_system_agent/miosa/platform.ex
@@ -60,11 +60,45 @@ defmodule OptimalSystemAgent.MIOSA.Platform do
   """
   @spec config_api_key() :: String.t() | nil
   def config_api_key do
-    with {:ok, raw} <- File.read(config_path()),
-         {:ok, %{"api_key" => key}} when is_binary(key) and key != "" <- Jason.decode(raw) do
+    with %{"api_key" => key} when is_binary(key) and key != "" <- config() do
       key
     else
       _ -> nil
+    end
+  end
+
+  @doc """
+  Read the MIOSA CLI configuration as a map.
+
+  The CLI owns platform account, tenant, workspace, and endpoint selection.
+  OSA reads that same file so platform integrations cannot silently act in a
+  different context from the user's active CLI context.
+  """
+  @spec config() :: map()
+  def config do
+    with {:ok, raw} <- File.read(config_path()),
+         {:ok, config} when is_map(config) <- Jason.decode(raw) do
+      config
+    else
+      _ -> %{}
+    end
+  end
+
+  @doc "The workspace selected by the MIOSA CLI, if one is active."
+  @spec workspace_id() :: String.t() | nil
+  def workspace_id do
+    case config()["workspace"] do
+      value when is_binary(value) and value != "" -> value
+      _ -> nil
+    end
+  end
+
+  @doc "The MIOSA platform endpoint selected by the CLI."
+  @spec endpoint() :: String.t()
+  def endpoint do
+    case config()["endpoint"] do
+      value when is_binary(value) and value != "" -> String.trim_trailing(value, "/")
+      _ -> "https://api.miosa.ai"
     end
   end
 

--- a/lib/optimal_system_agent/tools/registry.ex
+++ b/lib/optimal_system_agent/tools/registry.ex
@@ -185,14 +185,19 @@ defmodule OptimalSystemAgent.Tools.Registry do
         mcp_tools = :persistent_term.get({__MODULE__, :mcp_tools}, %{})
 
         case Map.get(mcp_tools, tool_name) do
-          nil -> {:error, "Unknown tool: #{tool_name}"}
-          _mcp_info -> OptimalSystemAgent.MCP.Client.ToolBridge.call(tool_name, arguments)
+          nil ->
+            {:error, "Unknown tool: #{tool_name}"}
+
+          _mcp_info ->
+            with :ok <- action_authority_result(tool_name, arguments) do
+              OptimalSystemAgent.MCP.Client.ToolBridge.call(tool_name, arguments)
+            end
         end
 
       mod ->
-        case validate_arguments(mod, arguments) do
-          :ok -> mod.execute(arguments)
-          {:error, _reason} = error -> error
+        with :ok <- validate_arguments(mod, arguments),
+             :ok <- action_authority_result(tool_name, arguments) do
+          mod.execute(arguments)
         end
     end
   end
@@ -233,6 +238,14 @@ defmodule OptimalSystemAgent.Tools.Registry do
       "This action is never permitted, in any permission tier."
   end
 
+  defp action_authority_result(tool_name, arguments) do
+    case OptimalSystemAgent.ActionAuthority.authorize_tool(tool_name, arguments) do
+      :not_governed -> :ok
+      {:allow, _receipt} -> :ok
+      {:blocked, message} -> {:error, "Blocked: " <> message}
+    end
+  end
+
   defp execute_unguarded(tool_name, arguments) do
     builtin_tools = :persistent_term.get({__MODULE__, :builtin_tools}, %{})
 
@@ -241,14 +254,19 @@ defmodule OptimalSystemAgent.Tools.Registry do
         mcp_tools = :persistent_term.get({__MODULE__, :mcp_tools}, %{})
 
         case Map.get(mcp_tools, tool_name) do
-          nil -> {:error, "Unknown tool: #{tool_name}"}
-          _mcp_info -> OptimalSystemAgent.MCP.Client.ToolBridge.call(tool_name, arguments)
+          nil ->
+            {:error, "Unknown tool: #{tool_name}"}
+
+          _mcp_info ->
+            with :ok <- action_authority_result(tool_name, arguments) do
+              OptimalSystemAgent.MCP.Client.ToolBridge.call(tool_name, arguments)
+            end
         end
 
       mod ->
-        case validate_arguments(mod, arguments) do
-          :ok -> dispatch(mod, arguments)
-          {:error, _reason} = error -> error
+        with :ok <- validate_arguments(mod, arguments),
+             :ok <- action_authority_result(tool_name, arguments) do
+          dispatch(mod, arguments)
         end
     end
   rescue

--- a/test/optimal_system_agent/action_authority_test.exs
+++ b/test/optimal_system_agent/action_authority_test.exs
@@ -1,0 +1,210 @@
+defmodule OptimalSystemAgent.ActionAuthorityTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.ActionAuthority
+  alias OptimalSystemAgent.Agent.Scheduler.JobExecutor
+  alias OptimalSystemAgent.MIOSA.Platform
+  alias OptimalSystemAgent.Tools.Registry
+
+  setup do
+    config_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "osa-authority-test-#{System.unique_integer([:positive])}"
+      )
+
+    previous = %{
+      action_authority: Application.get_env(:optimal_system_agent, :action_authority),
+      cli_config_dir: Application.get_env(:optimal_system_agent, :miosa_cli_config_dir),
+      sandbox_backend: Application.get_env(:optimal_system_agent, :sandbox_backend)
+    }
+
+    Application.put_env(:optimal_system_agent, :miosa_cli_config_dir, config_dir)
+    Application.put_env(:optimal_system_agent, :sandbox_backend, :miosa)
+
+    :ok = File.mkdir_p(config_dir)
+
+    File.write!(
+      Platform.config_path(),
+      Jason.encode!(%{
+        "api_key" => "msk_test_authority",
+        "workspace" => "workspace-123",
+        "endpoint" => "https://api.example.test"
+      })
+    )
+
+    on_exit(fn ->
+      File.rm_rf(config_dir)
+      restore_env(:action_authority, previous.action_authority)
+      restore_env(:miosa_cli_config_dir, previous.cli_config_dir)
+      restore_env(:sandbox_backend, previous.sandbox_backend)
+    end)
+
+    :ok
+  end
+
+  test "canonical fingerprints match the CLI contract independent of map key order" do
+    left = %{"b" => [%{"z" => true, "a" => nil}], "a" => 1}
+    right = %{"a" => 1, "b" => [%{"a" => nil, "z" => true}]}
+
+    assert ActionAuthority.canonical_json(left) ==
+             ~s({"a":1,"b":[{"a":null,"z":true}]})
+
+    assert ActionAuthority.fingerprint(left) == ActionAuthority.fingerprint(right)
+  end
+
+  test "MIOSA sandbox execution uses the server catalog and allows an approved call" do
+    test_pid = self()
+    plug_name = unique_plug_name()
+
+    Req.Test.stub(plug_name, fn conn ->
+      case conn.request_path do
+        "/api/v1/actions/catalog" ->
+          Req.Test.json(conn, %{
+            "data" => [
+              %{
+                "name" => "sandbox.exec",
+                "version" => "1.0.0",
+                "fingerprint" => capability_fingerprint("sandbox.exec")
+              }
+            ]
+          })
+
+        "/api/v1/actions/authorize" ->
+          {:ok, raw, conn} = Plug.Conn.read_body(conn)
+          send(test_pid, {:authority_request, Jason.decode!(raw), conn.req_headers})
+
+          Req.Test.json(conn, %{
+            "decision" => "allow",
+            "receipt_id" => "receipt-1"
+          })
+      end
+    end)
+
+    configure_plug(plug_name)
+
+    assert {:allow, %{"receipt_id" => "receipt-1"}} =
+             ActionAuthority.authorize_tool("shell_execute", %{
+               "command" => "echo safe",
+               "__session_id__" => "session-secret",
+               "__surface__" => "mcp"
+             })
+
+    assert_receive {:authority_request, request, headers}
+    assert request["capability"]["name"] == "sandbox.exec"
+    assert request["workspace_id"] == "workspace-123"
+    assert request["surface"] == "mcp"
+
+    assert request["params_fingerprint"] ==
+             ActionAuthority.fingerprint(%{"command" => "echo safe"})
+
+    assert {"authorization", "Bearer msk_test_authority"} in headers
+    refute inspect(request) =~ "session-secret"
+  end
+
+  test "pending central approval blocks the registry before the tool dispatches" do
+    plug_name = unique_plug_name()
+
+    Req.Test.stub(plug_name, fn conn ->
+      case conn.request_path do
+        "/api/v1/actions/catalog" ->
+          Req.Test.json(conn, %{
+            "data" => [
+              %{
+                "name" => "sandbox.exec",
+                "version" => "1.0.0",
+                "fingerprint" => capability_fingerprint("sandbox.exec")
+              }
+            ]
+          })
+
+        "/api/v1/actions/authorize" ->
+          conn
+          |> Plug.Conn.put_status(202)
+          |> Req.Test.json(%{
+            "decision" => "pending_approval",
+            "approval_request_id" => "approval-42",
+            "receipt_id" => "receipt-42"
+          })
+      end
+    end)
+
+    configure_plug(plug_name, %{"file_read" => "sandbox.exec"})
+    missing_path = Path.join(System.tmp_dir!(), "must-not-be-read-#{System.unique_integer()}")
+
+    assert {:error, message} = Registry.execute("file_read", %{"path" => missing_path})
+    assert message =~ "central approval required"
+    assert message =~ "approval-42"
+    refute message =~ "File not found"
+  end
+
+  test "a governed action fails closed when platform authentication is absent" do
+    File.rm!(Platform.config_path())
+
+    assert {:blocked, message} =
+             ActionAuthority.authorize_tool("shell_execute", %{"command" => "echo nope"})
+
+    assert message =~ "platform authentication is missing"
+  end
+
+  test "local tools remain ungoverned" do
+    assert :not_governed =
+             ActionAuthority.authorize_tool("file_read", %{"path" => "/tmp/example"})
+  end
+
+  test "scheduled commands use the shared authority seam with a schedule surface" do
+    test_pid = self()
+    plug_name = unique_plug_name()
+
+    Req.Test.stub(plug_name, fn conn ->
+      case conn.request_path do
+        "/api/v1/actions/catalog" ->
+          Req.Test.json(conn, %{
+            "data" => [
+              %{
+                "name" => "sandbox.exec",
+                "version" => "1.0.0",
+                "fingerprint" => capability_fingerprint("sandbox.exec")
+              }
+            ]
+          })
+
+        "/api/v1/actions/authorize" ->
+          {:ok, raw, conn} = Plug.Conn.read_body(conn)
+          send(test_pid, {:scheduled_authority_request, Jason.decode!(raw)})
+          Req.Test.json(conn, %{"decision" => "allow", "receipt_id" => "schedule-receipt"})
+      end
+    end)
+
+    Application.put_env(:optimal_system_agent, :sandbox_backend, :host)
+    configure_plug(plug_name, %{"shell_execute" => "sandbox.exec"})
+
+    assert {:ok, "scheduled-ok"} = JobExecutor.run_shell_command("printf scheduled-ok")
+    assert_receive {:scheduled_authority_request, %{"surface" => "schedule"}}
+  end
+
+  defp configure_plug(plug_name, capability_map \\ %{}) do
+    Application.put_env(
+      :optimal_system_agent,
+      :action_authority,
+      plug: {Req.Test, plug_name},
+      base_url: "https://api.example.test",
+      capability_map: capability_map
+    )
+  end
+
+  defp capability_fingerprint(name) do
+    digest =
+      :crypto.hash(:sha256, "miosa-capability/#{name}@1.0.0")
+      |> Base.encode16(case: :lower)
+
+    "sha256:" <> digest
+  end
+
+  defp unique_plug_name do
+    :"authority_test_#{System.unique_integer([:positive])}"
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:optimal_system_agent, key)
+  defp restore_env(key, value), do: Application.put_env(:optimal_system_agent, key, value)
+end


### PR DESCRIPTION
## Intent

Build MIOSA's unified action authority into OSA so every governed tool execution surface, including interactive agents, scheduled and away-mode jobs, HTTP, MCP, deferred tools, and sub-agents, passes through one fail-closed control-plane authority without duplicating policy. Preserve OSA's local non-bypassable machine safety as a separate earlier layer. Use server-published versioned capability fingerprints, bind one-time approvals to the exact parameters and execution surface, keep purely local tools offline and ungoverned, and prove the shared registry prevents execution while approval is pending. Do not deploy this incomplete cross-repository feature to production.

## What Changed

- Added `ActionAuthority` (`lib/optimal_system_agent/action_authority.ex`), a fail-closed control-plane authority that authorizes governed tool invocations against MIOSA's server-published versioned capability fingerprints, binding one-time approvals to exact parameters and execution surface while leaving purely local tools offline and ungoverned.
- Wired the shared tool `Registry.execute` and every execution surface (interactive loop tool executor, scheduler job executor, HTTP tool routes, MCP dispatcher) through the single authority as a central stage after schema validation, and extended `miosa/platform.ex` to supply endpoint/key/workspace context for authorization requests.
- Fixed the authority fingerprint/body `workspace_id` mismatch on the no-workspace path; added `action_authority_test.exs` (6 tests) covering allow, pending-approval, missing-auth, and not-governed paths; and documented the new authority stage in the tool-execution pipeline docs.

## Risk Assessment

✅ Low: The delta is a small, correct fix that aligns the fingerprinted and transmitted structures on the no-workspace path, resolving the round-1 warning; only pre-existing info-level items remain.

## Testing

Ran the committed authority test suite (6/6 pass) and a purpose-built demo that drives the real authority adapter and shared registry against a stubbed MIOSA control plane; the captured transcript shows governed allow with server fingerprint and secret redaction, param/surface binding, the registry blocking dispatch while approval is pending, local tools staying ungoverned, and fail-closed on missing auth. No UI surface exists for this control-plane change, so evidence is a CLI/API transcript rather than a screenshot. Overall result: intent demonstrated end-to-end, no failures.

<details>
<summary>Evidence: Authority end-to-end demo transcript (allow/pending/fail-closed/ungoverned)</summary>

<code>=== 1. GOVERNED (MIOSA sandbox) shell_execute -&gt; ALLOW ===&#10;authorize body: capability=sandbox.exec (server fingerprint), params_fingerprint bound, surface=osa, workspace_id=workspace-123&#10;decision receipt: allow/rcpt-osa&#10;secret session id leaked in body? false&#10;=== 2. SAME tool, MCP surface, DIFFERENT params -&gt; PENDING approval blocks ===&#10;params_fingerprint bound to exact params; surface=mcp&#10;block message: central approval required (approval appr-99)&#10;=== 3. Shared REGISTRY refuses dispatch while approval pending ===&#10;Registry.execute: Blocked: central approval required (appr-99); tool ran? false&#10;=== 4. Purely local tool (unmapped) -&gt; NOT governed ===&#10;:not_governed&#10;=== 5. Governed action, platform auth missing -&gt; FAILS CLOSED ===&#10;central action authority is required, but MIOSA platform authentication is missing</code>

```text
=== 1. GOVERNED (MIOSA sandbox) shell_execute from interactive surface -> ALLOW ===
  authorize request body sent to control plane:
    %{"capability" => %{"fingerprint" => "sha256:a100553bf763ef47155b1ec0c4c338bec337d630cbe2dad60e839ec60f1e1c48", "name" => "sandbox.exec"}, "params_fingerprint" => "sha256:5631220f30adc9ab93f8b88490b117be5c0fd14dfe65082fc0f757c141f8a1c8", "request_fingerprint" => "sha256:475005cf2b70ab4d2c65390a1c6298a248aab1bb212f544bd17b404b1fb119f6", "surface" => "osa", "workspace_id" => "workspace-123"}
  decision receipt: %{"decision" => "allow", "receipt_id" => "rcpt-osa"}
  -> secret session id leaked in body? false

=== 2. SAME tool, MCP surface, DIFFERENT params -> PENDING central approval blocks it ===
  params_fingerprint bound to exact params: sha256:2f3b94579f43fb59e8df8ecf8d8a231a288b641d262c4c425043c107e8e72b82
  surface bound to: mcp
  block message surfaced to caller: central approval required before this action can run (approval appr-99)

=== 3. Shared REGISTRY refuses to dispatch while approval pending ===
  Registry.execute result: Blocked: central approval required before this action can run (approval appr-99)
  tool actually ran (would say 'File not found')? false

=== 4. Purely local tool (unmapped) -> NOT governed, no network request ===
  :not_governed

=== 5. Governed action with platform auth missing -> FAILS CLOSED ===
  central action authority is required, but MIOSA platform authentication is missing

19:17:49.710 [error] [ActionAuthority] blocked shell_execute/sandbox.exec: :platform_auth_missing
.
Finished in 0.2 seconds (0.00s async, 0.2s sync)
1 test, 0 failures
```
</details>
<details>
<summary>Evidence: Committed authority suite transcript</summary>

```text
OptimalSystemAgent.ActionAuthorityTest [test/optimal_system_agent/action_authority_test.exs]
  * test canonical fingerprints match the CLI contract independent of map key order [L#46]  * test canonical fingerprints match the CLI contract independent of map key order (5.5ms) [L#46]
  * test a governed action fails closed when platform authentication is absent [L#141]
19:05:41.358 [error] [ActionAuthority] blocked shell_execute/sandbox.exec: :platform_auth_missing
  * test a governed action fails closed when platform authentication is absent (1.8ms) [L#141]
  * test pending central approval blocks the registry before the tool dispatches [L#105]  * test pending central approval blocks the registry before the tool dispatches (73.8ms) [L#105]
  * test local tools remain ungoverned [L#150]  * test local tools remain ungoverned (1.7ms) [L#150]
  * test scheduled commands use the shared authority seam with a schedule surface [L#155]  * test scheduled commands use the shared authority seam with a schedule surface (25.4ms) [L#155]
  * test MIOSA sandbox execution uses the server catalog and allows an approved call [L#56]  * test MIOSA sandbox execution uses the server catalog and allows an approved call (3.0ms) [L#56]
Finished in 0.2 seconds (0.00s async, 0.2s sync)
6 tests, 0 failures
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `lib/optimal_system_agent/action_authority.ex:178` - In request_decision/5 (action_authority.ex ~line 175-198), request_fingerprint is computed over `invocation`, which always contains `workspace_id` (value `nil` when no workspace is selected). But the transmitted `body` omits `workspace_id` entirely when it is nil. If the control plane reconstructs/verifies request_fingerprint from the received body, it will hash a map without the `workspace_id` key (or with a different shape) and derive a different fingerprint than OSA sent, causing spurious denials on the no-workspace path. The fingerprinted structure and the transmitted structure must match exactly. Either always include workspace_id in the body, or drop it from `invocation` when nil.
- ℹ️ `lib/optimal_system_agent/action_authority.ex:130` - fetch_capability/2 fetches the full /api/v1/actions/catalog on every single governed tool invocation, in addition to the /api/v1/actions/authorize POST. Governed calls therefore incur two sequential network round-trips each, with a 10s timeout apiece, on the hot path of every sandbox/governed tool execution (interactive, scheduled, MCP, HTTP). No caching is present. Given fingerprints are versioned and server-published, a short-lived catalog cache keyed by capability name would remove one round-trip per call without OSA owning policy. Left uncached this is a real latency regression for agents doing many governed actions.
- ℹ️ `lib/optimal_system_agent/miosa/platform.ex:98` - platform_api_key() prefers the MIOSA_API_KEY env var over the CLI config file, but endpoint() and workspace_id() read only from the config file. When OSA runs with the env-var key set and no (or a divergent) ~/.miosa/config.json, authorization requests are sent with that key to the default endpoint https://api.miosa.ai with a nil workspace — i.e. a credential and a control-plane/workspace context that were never reconciled. The moduledoc claims OSA reads the CLI file &#39;so platform integrations cannot silently act in a different context from the user&#39;s active CLI context&#39;, but the env-var key path bypasses that guarantee. Consider deriving endpoint/workspace consistently with whichever source supplied the key.

🔧 Fix: fix authority fingerprint/body workspace_id mismatch on no-workspace path
2 infos still open:
- ℹ️ `lib/optimal_system_agent/action_authority.ex:130` - fetch_capability/2 fetches the full /api/v1/actions/catalog on every governed tool invocation, in addition to the /api/v1/actions/authorize POST, so each governed call incurs two sequential network round-trips (each with a 10s timeout) on the hot path. No caching. A short-lived catalog cache keyed by capability name would remove one round-trip per call without OSA owning policy. Unchanged since round 1.
- ℹ️ `lib/optimal_system_agent/miosa/platform.ex:98` - platform_api_key() prefers the MIOSA_API_KEY env var, but endpoint()/workspace_id() read only from the CLI config file. With the env key set and no/divergent ~/.miosa/config.json, requests go to the default endpoint with a nil workspace — a credential and control-plane/workspace context that were never reconciled, contradicting the moduledoc&#39;s &#39;cannot silently act in a different context&#39; claim. Unchanged since round 1.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`MIX_ENV=test mix test test/optimal_system_agent/action_authority_test.exs --trace` (6 tests, 0 failures)</code>
- <code>Temporary evidence demo exercising `ActionAuthority.authorize_tool/2` and `Registry.execute/2` against a `Req.Test` stub of `/api/v1/actions/catalog` and `/api/v1/actions/authorize` (allow, pending_approval, missing-auth, not_governed paths)</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `docs/foundation-core/diagrams/workflows/tool-execution.md:50` - The tool-execution pipeline enumerations in docs/backend/tools/overview.md (lines 116-124) and docs/foundation-core/diagrams/workflows/tool-execution.md (lines 50-67) do not show the new central action-authority stage that Registry.execute now runs between schema validation and dispatch. Left unedited as a judgment call: both docs are already idealized/simplified (they omit schema validation too), the stage is a no-op passthrough for local/ungoverned tools, and the user intent states this cross-repo feature is incomplete and must NOT deploy to production - documenting an unshipped enforcement stage in live flow docs would be premature. Revisit when the feature ships.

🔧 Fix: document central action-authority stage in tool pipeline docs
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
