### PR TITLE
fix(tui): suppress redundant coordinator toasts on SSE reconnect

### DIFF
--- a/lib/optimal_system_agent/channels/http/api/tool_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/tool_routes.ex
@@ -184,7 +184,14 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
   # `/coordinator [on|off|toggle|status]`: the TUI coordinator posture toggle.
   # Applied IN PLACE on the live loop (no session restart / id churn), recorded
   # in the sticky `Agent.CoordinatorMode` store, and echoed as a `coordinator_mode`
-  # system_event so the status-bar chip tracks it. `status` reads without changing.
+  # system_event so the status-bar chip tracks it.
+  #
+  # `status` is a READ-ONLY query: it must NOT call `set_coordinator/2` (which
+  # unconditionally emits a `coordinator_mode` system_event via `Bus.emit`).
+  # The TUI sends `coordinator status` on every SSE (re)connect, so emitting an
+  # event for a no-op status read produces a redundant toast on each reconnect.
+  # The TUI-side handler now also guards against unchanged-state toasts, but the
+  # root cause is here: a read should not have side effects.
   defp handle_coordinator_command(conn, arg) do
     session_id =
       conn.body_params["session_id"] || "http_#{:erlang.unique_integer([:positive])}"
@@ -192,23 +199,33 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
     verb = arg |> to_string() |> String.trim() |> String.downcase()
     current = coordinator_active?(session_id)
 
-    desired =
-      case verb do
-        v when v in ~w(on true 1 yes enable) -> true
-        v when v in ~w(off false 0 no disable) -> false
-        v when v in ["status", ""] -> current
-        _ -> not current
-      end
+    if verb in ["status", ""] do
+      # Read-only: return current state without emitting a system_event.
+      output =
+        if current,
+          do: "Coordinator mode ON (delegation and messaging only).",
+          else: "Coordinator mode OFF (full tool access)."
 
-    {:ok, active} = OptimalSystemAgent.Agent.Loop.set_coordinator(session_id, desired)
+      body = Jason.encode!(%{output: output, command: "coordinator", active: current})
+      conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+    else
+      desired =
+        case verb do
+          v when v in ~w(on true 1 yes enable) -> true
+          v when v in ~w(off false 0 no disable) -> false
+          _ -> not current
+        end
 
-    output =
-      if active,
-        do: "Coordinator mode ON (delegation and messaging only).",
-        else: "Coordinator mode OFF (full tool access)."
+      {:ok, active} = OptimalSystemAgent.Agent.Loop.set_coordinator(session_id, desired)
 
-    body = Jason.encode!(%{output: output, command: "coordinator", active: active})
-    conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+      output =
+        if active,
+          do: "Coordinator mode ON (delegation and messaging only).",
+          else: "Coordinator mode OFF (full tool access)."
+
+      body = Jason.encode!(%{output: output, command: "coordinator", active: active})
+      conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+    end
   end
 
   defp coordinator_active?(session_id) do
@@ -260,13 +277,20 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
           do: {:mode, :ask},
           else: {:mode, :overdrive}
 
-      Enum.any?(tokens, &(&1 in ~w(overdrive bypass yolo dangerous))) -> {:mode, :overdrive}
+      Enum.any?(tokens, &(&1 in ~w(overdrive bypass yolo dangerous))) ->
+        {:mode, :overdrive}
+
       Enum.any?(tokens, &(&1 in ~w(accept-edits accept_edits auto-edit auto_edit edits))) ->
         {:mode, :accept_edits}
 
-      Enum.any?(tokens, &(&1 in ~w(plan plan-mode plan_mode))) -> {:mode, :plan}
-      Enum.any?(tokens, &(&1 in ~w(ask default prompt))) -> {:mode, :ask}
-      true -> :tier
+      Enum.any?(tokens, &(&1 in ~w(plan plan-mode plan_mode))) ->
+        {:mode, :plan}
+
+      Enum.any?(tokens, &(&1 in ~w(ask default prompt))) ->
+        {:mode, :ask}
+
+      true ->
+        :tier
     end
   end
 
@@ -348,43 +372,43 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
     cmd_name = command |> String.split() |> List.first() |> String.downcase()
 
     if cmd_name in @blocked_http_commands do
-        body =
-          Jason.encode!(%{
-            output: "Command '#{cmd_name}' is not available via HTTP.",
-            command: command
-          })
+      body =
+        Jason.encode!(%{
+          output: "Command '#{cmd_name}' is not available via HTTP.",
+          command: command
+        })
 
-        conn |> put_resp_content_type("application/json") |> send_resp(200, body)
-      else
-        session_id =
-          conn.body_params["session_id"] || "http_#{:erlang.unique_integer([:positive])}"
+      conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+    else
+      session_id =
+        conn.body_params["session_id"] || "http_#{:erlang.unique_integer([:positive])}"
 
-        output =
+      output =
+        try do
+          {:ok, string_io} = StringIO.open("")
+          original_gl = Process.group_leader()
+          Process.group_leader(self(), string_io)
+
           try do
-            {:ok, string_io} = StringIO.open("")
-            original_gl = Process.group_leader()
-            Process.group_leader(self(), string_io)
-
-            try do
-              OptimalSystemAgent.Channels.CLI.Commands.dispatch(command, session_id)
-            after
-              Process.group_leader(self(), original_gl)
-            end
-
-            {_, captured} = StringIO.close(string_io)
-            captured
-          rescue
-            e -> "Error: #{Exception.message(e)}"
+            OptimalSystemAgent.Channels.CLI.Commands.dispatch(command, session_id)
+          after
+            Process.group_leader(self(), original_gl)
           end
 
-        clean_output =
-          output
-          |> String.replace(~r/\e\[[0-9;]*m/, "")
-          |> String.trim()
+          {_, captured} = StringIO.close(string_io)
+          captured
+        rescue
+          e -> "Error: #{Exception.message(e)}"
+        end
 
-        body = Jason.encode!(%{output: clean_output, command: command})
-        conn |> put_resp_content_type("application/json") |> send_resp(200, body)
-      end
+      clean_output =
+        output
+        |> String.replace(~r/\e\[[0-9;]*m/, "")
+        |> String.trim()
+
+      body = Jason.encode!(%{output: clean_output, command: command})
+      conn |> put_resp_content_type("application/json") |> send_resp(200, body)
+    end
   end
 
   # ── POST /:name/execute (tools) ────────────────────────────────────

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -56,8 +56,10 @@ impl App {
                 // restart, mirroring the same commands enter_overdrive sends.
                 let mode = self.status.permission_mode();
                 self.spawn_backend_command("permission_mode", mode.backend_token());
-                let dangerous =
-                    matches!(mode, crate::components::status_bar::PermissionMode::BypassPermissions);
+                let dangerous = matches!(
+                    mode,
+                    crate::components::status_bar::PermissionMode::BypassPermissions
+                );
                 self.spawn_backend_command("dangerous_mode", if dangerous { "on" } else { "off" });
                 // Coordinator state is backend-authoritative (sticky per-session
                 // store), the opposite direction from permission mode. Query it on
@@ -376,7 +378,10 @@ impl App {
                         // SSE reconnect/replay the same ToolCallStart can arrive
                         // twice; without this guard `bg_shell_count` drifted up
                         // (one completion event can only decrement it once).
-                        if self.counted_bg_shells.insert(bg_shell_signature(&name, &args)) {
+                        if self
+                            .counted_bg_shells
+                            .insert(bg_shell_signature(&name, &args))
+                        {
                             self.bg_shell_count += 1;
                             self.refresh_bg_indicators();
                         }
@@ -444,8 +449,12 @@ impl App {
                     }
                 }
                 let pending_key = pending_key(&name, tool_call_id.as_deref());
-                self.activity
-                    .tool_end_with_id(&name, duration_ms, success, tool_call_id.as_deref());
+                self.activity.tool_end_with_id(
+                    &name,
+                    duration_ms,
+                    success,
+                    tool_call_id.as_deref(),
+                );
                 self.activity.set_phase(ProcessingPhase::Waiting);
                 // Item 3 — after a tool completes we're blocked on the model to
                 // resume streaming; name that wait instead of a flavor verb.
@@ -549,11 +558,8 @@ impl App {
                     if !results.is_empty() {
                         let (res, _succ) = results.remove(0);
                         if built_tool_message && !res.is_empty() {
-                            self.chat.update_last_tool_result(
-                                &name,
-                                tool_call_id.as_deref(),
-                                &res,
-                            );
+                            self.chat
+                                .update_last_tool_result(&name, tool_call_id.as_deref(), &res);
                         }
                         self.chat.finalize_tool(&name, tool_call_id.as_deref());
                     }
@@ -598,7 +604,10 @@ impl App {
                 }
                 debug!("Tool result: {} (success={})", name, success);
             }
-            BackendEvent::LlmRequest { iteration, max_iterations } => {
+            BackendEvent::LlmRequest {
+                iteration,
+                max_iterations,
+            } => {
                 self.activity.set_iteration(iteration as u32);
                 self.activity.set_max_iterations(max_iterations);
                 self.status.set_iteration(iteration as u32);
@@ -635,7 +644,11 @@ impl App {
                 // a 0-100 percentage. If it's absent/zero but the token counts are
                 // present, derive the ratio from estimated/max so the meter still
                 // reflects real usage instead of sticking at 0%.
-                let mut ratio = if utilization > 1.0 { utilization / 100.0 } else { utilization };
+                let mut ratio = if utilization > 1.0 {
+                    utilization / 100.0
+                } else {
+                    utilization
+                };
                 if ratio <= 0.0 && max_tokens > 0 && estimated_tokens > 0 {
                     ratio = estimated_tokens as f64 / max_tokens as f64;
                 }
@@ -657,7 +670,8 @@ impl App {
                 subject,
                 active_form,
             } => {
-                self.tasks.add(task_id.clone(), subject.clone(), String::new());
+                self.tasks
+                    .add(task_id.clone(), subject.clone(), String::new());
                 self.task_checklist.add(task_id, subject, Some(active_form));
                 self.recompute_layout();
             }
@@ -680,17 +694,23 @@ impl App {
                 self.task_checklist.clear();
                 for task in tasks {
                     let status = match task.status.as_str() {
-                        "completed" => crate::components::task_checklist::ChecklistStatus::Completed,
-                        "in_progress" => crate::components::task_checklist::ChecklistStatus::InProgress,
+                        "completed" => {
+                            crate::components::task_checklist::ChecklistStatus::Completed
+                        }
+                        "in_progress" => {
+                            crate::components::task_checklist::ChecklistStatus::InProgress
+                        }
                         "failed" => crate::components::task_checklist::ChecklistStatus::Failed,
                         _ => crate::components::task_checklist::ChecklistStatus::Pending,
                     };
                     let id = task.id.clone();
-                    self.task_checklist.add(task.id, task.subject, task.active_form);
+                    self.task_checklist
+                        .add(task.id, task.subject, task.active_form);
                     self.task_checklist.update(&id, status);
                 }
                 self.task_checklist.show();
-                self.activity.set_active_verb(self.task_checklist.current_active_form());
+                self.activity
+                    .set_active_verb(self.task_checklist.current_active_form());
                 self.recompute_layout();
             }
             BackendEvent::TaskChecklistHide => {
@@ -722,8 +742,7 @@ impl App {
                     self.header.set_tool_count(tools.len());
                     // Refresh the capability-gate: commands whose required tools are
                     // now present become visible; those still missing stay hidden.
-                    self.available_tools =
-                        tools.iter().map(|t| t.name.clone()).collect();
+                    self.available_tools = tools.iter().map(|t| t.name.clone()).collect();
                     self.refresh_command_completions();
                     self.sidebar.set_tool_count(tools.len());
                     self.chat.set_welcome_info(
@@ -793,14 +812,13 @@ impl App {
             },
             BackendEvent::ContextLoaded(result) => match result {
                 Ok(stats) => {
-                    self.context_stats =
-                        Some(crate::dialogs::context_breakdown::ContextStats {
-                            system_tokens: stats.system_tokens,
-                            conversation_tokens: stats.conversation_tokens,
-                            tool_result_tokens: stats.tool_result_tokens,
-                            max_tokens: stats.max_tokens,
-                            used_tokens: stats.used_tokens,
-                        });
+                    self.context_stats = Some(crate::dialogs::context_breakdown::ContextStats {
+                        system_tokens: stats.system_tokens,
+                        conversation_tokens: stats.conversation_tokens,
+                        tool_result_tokens: stats.tool_result_tokens,
+                        max_tokens: stats.max_tokens,
+                        used_tokens: stats.used_tokens,
+                    });
                     if self.state.can_transition_to(AppState::ContextBreakdown) {
                         self.enter_overlay(AppState::ContextBreakdown);
                     }
@@ -814,8 +832,7 @@ impl App {
             },
             BackendEvent::TrustLoaded(result) => match result {
                 Ok(status) => {
-                    let risks: Vec<String> =
-                        status.risks.iter().map(|r| r.label.clone()).collect();
+                    let risks: Vec<String> = status.risks.iter().map(|r| r.label.clone()).collect();
                     self.trust_dialog = Some(crate::dialogs::trust::TrustDialog::new(
                         status.path.clone(),
                         risks,
@@ -906,8 +923,7 @@ impl App {
                             tool_count: s.tool_count,
                         })
                         .collect();
-                    self.mcp_servers =
-                        Some(crate::dialogs::mcp_servers::McpServers::new(servers));
+                    self.mcp_servers = Some(crate::dialogs::mcp_servers::McpServers::new(servers));
                     // Only an explicit `/mcp` opens the dialog; the background
                     // chip refresh just updates the count above.
                     if open && self.state.can_transition_to(AppState::Mcp) {
@@ -1007,8 +1023,7 @@ impl App {
                             priority: t.priority,
                         })
                         .collect();
-                    self.tasks_panel =
-                        Some(crate::dialogs::tasks_panel::TasksPanel::new(tasks));
+                    self.tasks_panel = Some(crate::dialogs::tasks_panel::TasksPanel::new(tasks));
                     if self.state.can_transition_to(AppState::Tasks) {
                         self.enter_overlay(AppState::Tasks);
                     }
@@ -1043,8 +1058,9 @@ impl App {
                             })
                             .collect(),
                     };
-                    self.metrics_dashboard =
-                        Some(crate::dialogs::metrics_dashboard::MetricsDashboard::new(data));
+                    self.metrics_dashboard = Some(
+                        crate::dialogs::metrics_dashboard::MetricsDashboard::new(data),
+                    );
                     if self.state.can_transition_to(AppState::Metrics) {
                         self.enter_overlay(AppState::Metrics);
                     }
@@ -1091,8 +1107,9 @@ impl App {
                             current: b.current,
                         })
                         .collect();
-                    self.sandbox_picker =
-                        Some(crate::dialogs::sandbox_picker::SandboxPicker::new(backends, mode));
+                    self.sandbox_picker = Some(crate::dialogs::sandbox_picker::SandboxPicker::new(
+                        backends, mode,
+                    ));
                     if self.state.can_transition_to(AppState::Sandbox) {
                         self.enter_overlay(AppState::Sandbox);
                     }
@@ -1112,7 +1129,11 @@ impl App {
                             crate::dialogs::channels_panel::ChannelEntry {
                                 name: ch.name,
                                 connected,
-                                status: if connected { "connected".into() } else { "not connected".into() },
+                                status: if connected {
+                                    "connected".into()
+                                } else {
+                                    "not connected".into()
+                                },
                                 kind: ch
                                     .module
                                     .and_then(|m| m.rsplit('.').next().map(|s| s.to_lowercase()))
@@ -1252,13 +1273,12 @@ impl App {
                 Ok(resp) => {
                     let current_provider = self.header.provider().to_string();
                     let current_model = self.header.model_name().to_string();
-                    let picker =
-                        crate::dialogs::model_picker::ModelPicker::new_provider_first(
-                            resp.providers,
-                            resp.detected,
-                            current_provider,
-                            current_model,
-                        );
+                    let picker = crate::dialogs::model_picker::ModelPicker::new_provider_first(
+                        resp.providers,
+                        resp.detected,
+                        current_provider,
+                        current_model,
+                    );
                     self.model_picker = Some(picker);
                     self.enter_overlay(AppState::ModelPicker);
                 }
@@ -1275,10 +1295,11 @@ impl App {
                     );
                     let current_provider = self.header.provider().to_string();
                     let current_model = self.header.model_name().to_string();
-                    self.model_picker = Some(crate::dialogs::model_picker::ModelPicker::new_fallback(
-                        current_provider,
-                        current_model,
-                    ));
+                    self.model_picker =
+                        Some(crate::dialogs::model_picker::ModelPicker::new_fallback(
+                            current_provider,
+                            current_model,
+                        ));
                     self.enter_overlay(AppState::ModelPicker);
                 }
             },
@@ -1401,7 +1422,9 @@ impl App {
                 self.agents.on_agents_spawning(&agents);
                 self.recompute_layout();
             }
-            BackendEvent::OrchestratorTaskAppraised { estimated_cost_usd, .. } => {
+            BackendEvent::OrchestratorTaskAppraised {
+                estimated_cost_usd, ..
+            } => {
                 // Record the task-level cost estimate so the agents dashboard can
                 // surface it. There is no per-agent cost signal from the backend,
                 // so this whole-task figure is the only cost we can honestly show.
@@ -1409,16 +1432,41 @@ impl App {
                     self.agents.set_estimated_cost(estimated_cost_usd);
                 }
             }
-            BackendEvent::OrchestratorAgentStarted { agent_name, role, model, subject, batch_id } => {
-                self.agents.agent_started(&agent_name, &role, &model, &subject, batch_id);
+            BackendEvent::OrchestratorAgentStarted {
+                agent_name,
+                role,
+                model,
+                subject,
+                batch_id,
+            } => {
+                self.agents
+                    .agent_started(&agent_name, &role, &model, &subject, batch_id);
                 // Short human label, never the raw `agent:session-…:osa-x` key.
                 let short = crate::components::agents::short_agent_label(&agent_name);
-                let display = if role.is_empty() { short } else { format!("{}/{}", short, role) };
+                let display = if role.is_empty() {
+                    short
+                } else {
+                    format!("{}/{}", short, role)
+                };
                 self.sidebar.set_current_agent(display);
                 self.recompute_layout();
             }
-            BackendEvent::OrchestratorAgentProgress { agent_name, current_action, tool_uses, tokens_used, subject, recent_actions } => {
-                self.agents.agent_progress(&agent_name, &current_action, tool_uses, tokens_used, &subject, recent_actions);
+            BackendEvent::OrchestratorAgentProgress {
+                agent_name,
+                current_action,
+                tool_uses,
+                tokens_used,
+                subject,
+                recent_actions,
+            } => {
+                self.agents.agent_progress(
+                    &agent_name,
+                    &current_action,
+                    tool_uses,
+                    tokens_used,
+                    &subject,
+                    recent_actions,
+                );
                 // Codex-style live naming: during orchestration the leader spinner
                 // otherwise shows a generic flavor verb while sub-agents do the
                 // real work. Surface the running sub-agent by name + subject on the
@@ -1441,25 +1489,46 @@ impl App {
                 // Trail length can change the panel height — keep layout in sync.
                 self.recompute_layout();
             }
-            BackendEvent::OrchestratorAgentCompleted { agent_name, tool_uses, tokens_used, summary, .. } => {
-                self.agents.agent_completed(&agent_name, tool_uses, tokens_used, summary);
+            BackendEvent::OrchestratorAgentCompleted {
+                agent_name,
+                tool_uses,
+                tokens_used,
+                summary,
+                ..
+            } => {
+                self.agents
+                    .agent_completed(&agent_name, tool_uses, tokens_used, summary);
                 self.sidebar.set_current_agent("");
                 // Clear the stale "@agent: subject" spinner label set on every
                 // progress tick — otherwise the leader spinner keeps naming a
                 // finished sub-agent until some unrelated event overwrites it.
                 self.activity.set_active_verb(None);
             }
-            BackendEvent::OrchestratorAgentFailed { agent_name, error, tool_uses, tokens_used, summary } => {
+            BackendEvent::OrchestratorAgentFailed {
+                agent_name,
+                error,
+                tool_uses,
+                tokens_used,
+                summary,
+            } => {
                 // Fall back to the (truncated) error text when the backend sent no
                 // dedicated summary, so a failed row still previews what went wrong.
                 let fail_summary = summary.or_else(|| {
                     let e = error.trim();
-                    if e.is_empty() { None } else { Some(e.chars().take(140).collect()) }
+                    if e.is_empty() {
+                        None
+                    } else {
+                        Some(e.chars().take(140).collect())
+                    }
                 });
-                self.agents.agent_failed(&agent_name, &error, tool_uses, tokens_used, fail_summary);
+                self.agents
+                    .agent_failed(&agent_name, &error, tool_uses, tokens_used, fail_summary);
                 self.sidebar.set_current_agent("");
             }
-            BackendEvent::OrchestratorWaveStarted { wave_number, total_waves } => {
+            BackendEvent::OrchestratorWaveStarted {
+                wave_number,
+                total_waves,
+            } => {
                 self.agents.wave_started(wave_number, total_waves);
                 self.recompute_layout();
             }
@@ -1478,8 +1547,14 @@ impl App {
             // === Fleet events → Agents component (CC FleetView roster) ===
             // Full-power background nodes drive the same roster mutation API as
             // orchestrator workers, so they appear inline identically.
-            BackendEvent::FleetNodeStarted { node_id, agent_type, task, .. } => {
-                self.agents.agent_started(&node_id, &agent_type, "", &task, None);
+            BackendEvent::FleetNodeStarted {
+                node_id,
+                agent_type,
+                task,
+                ..
+            } => {
+                self.agents
+                    .agent_started(&node_id, &agent_type, "", &task, None);
                 self.recompute_layout();
             }
             BackendEvent::FleetNodeProgress {
@@ -1499,18 +1574,33 @@ impl App {
                 );
                 self.recompute_layout();
             }
-            BackendEvent::FleetNodeCompleted { node_id, summary, status } => {
+            BackendEvent::FleetNodeCompleted {
+                node_id,
+                summary,
+                status,
+            } => {
                 self.agents.fleet_node_completed(&node_id, &status, summary);
                 self.recompute_layout();
             }
-            BackendEvent::FleetSummary { running, queued, cap, total_spawned, warn } => {
+            BackendEvent::FleetSummary {
+                running,
+                queued,
+                cap,
+                total_spawned,
+                warn,
+            } => {
                 self.agents
                     .set_fleet_summary(running, queued, cap, total_spawned, warn);
                 self.recompute_layout();
             }
 
             // === Swarm events → Agents component ===
-            BackendEvent::SwarmStarted { swarm_id, pattern, agent_count, .. } => {
+            BackendEvent::SwarmStarted {
+                swarm_id,
+                pattern,
+                agent_count,
+                ..
+            } => {
                 self.agents.swarm_started(&swarm_id, &pattern, agent_count);
                 self.recompute_layout();
             }
@@ -1544,8 +1634,9 @@ impl App {
                             text: transcript,
                         },
                     ];
-                    self.transcript =
-                        Some(crate::dialogs::transcript_viewer::TranscriptViewer::open(&entries));
+                    self.transcript = Some(
+                        crate::dialogs::transcript_viewer::TranscriptViewer::open(&entries),
+                    );
                     self.transcript_override = Some(entries);
                 }
                 Err(e) => {
@@ -1562,7 +1653,11 @@ impl App {
             // announces the lifecycle transition, and completion/failure also
             // drop a short system note into chat with the result/error preview.
             BackendEvent::BackgroundAgentStarted { agent_id, role } => {
-                let label = if role.is_empty() { "background".to_string() } else { role.clone() };
+                let label = if role.is_empty() {
+                    "background".to_string()
+                } else {
+                    role.clone()
+                };
                 self.agents.agent_started(
                     agent_id.clone(),
                     role,
@@ -1576,11 +1671,28 @@ impl App {
                 );
                 self.recompute_layout();
             }
-            BackendEvent::BackgroundAgentCompleted { agent_id, role, result, duration_ms } => {
-                let label = if role.is_empty() { "background".to_string() } else { role };
+            BackendEvent::BackgroundAgentCompleted {
+                agent_id,
+                role,
+                result,
+                duration_ms,
+            } => {
+                let label = if role.is_empty() {
+                    "background".to_string()
+                } else {
+                    role
+                };
                 let panel_summary: Option<String> = {
-                    let first = result.trim().lines().find(|l| !l.trim().is_empty()).unwrap_or("");
-                    if first.is_empty() { None } else { Some(first.chars().take(140).collect()) }
+                    let first = result
+                        .trim()
+                        .lines()
+                        .find(|l| !l.trim().is_empty())
+                        .unwrap_or("");
+                    if first.is_empty() {
+                        None
+                    } else {
+                        Some(first.chars().take(140).collect())
+                    }
                 };
                 self.agents.agent_completed(&agent_id, 0, 0, panel_summary);
                 let preview: String = result.trim().chars().take(200).collect();
@@ -1590,7 +1702,10 @@ impl App {
                 let note = if preview.is_empty() {
                     format!("\u{23fa} Teammate @{} finished \u{00b7} {}", label, elapsed)
                 } else {
-                    format!("\u{23fa} Teammate @{} finished \u{00b7} {} \u{2014} {}", label, elapsed, preview)
+                    format!(
+                        "\u{23fa} Teammate @{} finished \u{00b7} {} \u{2014} {}",
+                        label, elapsed, preview
+                    )
                 };
                 self.chat.add_system_message(&note, "info");
                 self.toasts.push(
@@ -1600,17 +1715,38 @@ impl App {
                 self.refresh_bg_indicators();
                 self.recompute_layout();
             }
-            BackendEvent::BackgroundAgentFailed { agent_id, role, error, duration_ms } => {
-                let label = if role.is_empty() { "background".to_string() } else { role };
-                let panel_summary: Option<String> = {
-                    let first = error.trim().lines().find(|l| !l.trim().is_empty()).unwrap_or("");
-                    if first.is_empty() { None } else { Some(first.chars().take(140).collect()) }
+            BackendEvent::BackgroundAgentFailed {
+                agent_id,
+                role,
+                error,
+                duration_ms,
+            } => {
+                let label = if role.is_empty() {
+                    "background".to_string()
+                } else {
+                    role
                 };
-                self.agents.agent_failed(&agent_id, error.clone(), 0, 0, panel_summary);
+                let panel_summary: Option<String> = {
+                    let first = error
+                        .trim()
+                        .lines()
+                        .find(|l| !l.trim().is_empty())
+                        .unwrap_or("");
+                    if first.is_empty() {
+                        None
+                    } else {
+                        Some(first.chars().take(140).collect())
+                    }
+                };
+                self.agents
+                    .agent_failed(&agent_id, error.clone(), 0, 0, panel_summary);
                 let preview: String = error.trim().chars().take(200).collect();
                 let elapsed = crate::util::fmt_elapsed(duration_ms / 1000);
                 self.chat.add_system_message(
-                    &format!("\u{23fa} Teammate @{} failed \u{00b7} {} \u{2014} {}", label, elapsed, preview),
+                    &format!(
+                        "\u{23fa} Teammate @{} failed \u{00b7} {} \u{2014} {}",
+                        label, elapsed, preview
+                    ),
                     "error",
                 );
                 self.toasts.push(
@@ -1624,7 +1760,11 @@ impl App {
             // === Multi-agent workflow (Claude Code parity) ===
             // Teammate/sub-agent lifecycle + inbound messages + background-command
             // completion + turn recap, decoded from the session SSE stream.
-            BackendEvent::AgentFinished { display_name, duration_ms, .. } => {
+            BackendEvent::AgentFinished {
+                display_name,
+                duration_ms,
+                ..
+            } => {
                 let name = if display_name.is_empty() {
                     "agent".to_string()
                 } else {
@@ -1641,12 +1781,22 @@ impl App {
                 self.recompute_layout();
             }
             BackendEvent::AgentMessage { from, text } => {
-                let who = if from.is_empty() { "agent".to_string() } else { from };
-                self.chat
-                    .add_system_message(&format!("\u{203a} Message from @{}: {}", who, text), "info");
+                let who = if from.is_empty() {
+                    "agent".to_string()
+                } else {
+                    from
+                };
+                self.chat.add_system_message(
+                    &format!("\u{203a} Message from @{}: {}", who, text),
+                    "info",
+                );
                 self.recompute_layout();
             }
-            BackendEvent::BackgroundCommandCompleted { exit_code, command, task_id } => {
+            BackendEvent::BackgroundCommandCompleted {
+                exit_code,
+                command,
+                task_id,
+            } => {
                 if self.bg_shell_count > 0 {
                     self.bg_shell_count -= 1;
                 }
@@ -1665,8 +1815,10 @@ impl App {
                 } else {
                     command.clone()
                 };
-                let note =
-                    format!("Background command '{}' completed (exit code {})", label, exit_code);
+                let note = format!(
+                    "Background command '{}' completed (exit code {})",
+                    label, exit_code
+                );
                 let (severity, level) = if exit_code == 0 {
                     ("info", crate::components::toast::ToastLevel::Success)
                 } else {
@@ -1680,7 +1832,10 @@ impl App {
                 // WS6: the backend just folded completed background task(s) into
                 // the agent's context — show why the agent is about to pivot.
                 let note = if summary.trim().is_empty() {
-                    format!("\u{2699} Reacting to {} completed background task(s)", count)
+                    format!(
+                        "\u{2699} Reacting to {} completed background task(s)",
+                        count
+                    )
                 } else {
                     format!(
                         "\u{2699} Reacting to {} completed background task(s) \u{2014} {}",
@@ -1722,7 +1877,11 @@ impl App {
                 }
                 self.recompute_layout();
             }
-            BackendEvent::TurnRecap { elapsed_ms, tool_calls, tools_used } => {
+            BackendEvent::TurnRecap {
+                elapsed_ms,
+                tool_calls,
+                tools_used,
+            } => {
                 // Only surface the recap when the turn did substantive, user-visible
                 // work — a real tool ran (shell/file/web/dir/git/…) OR the turn took
                 // a noticeable amount of wall-clock time. `tool_calls` is the
@@ -1748,8 +1907,10 @@ impl App {
                     .take()
                     .unwrap_or(elapsed_ms / 1000);
                 if tool_count > 0 || elapsed_secs >= crate::util::RECAP_ELAPSED_THRESHOLD_SECS {
-                    let mut text =
-                        format!("\u{273b} Worked for {}", crate::util::fmt_elapsed(elapsed_secs));
+                    let mut text = format!(
+                        "\u{273b} Worked for {}",
+                        crate::util::fmt_elapsed(elapsed_secs)
+                    );
                     if tool_count > 0 {
                         text.push_str(&format!(
                             " \u{00b7} {} tool use{}",
@@ -1777,21 +1938,28 @@ impl App {
                 tokio::spawn(async move {
                     if client.try_refresh_token().await {
                         // Signal the app to restart SSE with refreshed token
-                        let _ = tx.send(crate::event::Event::Backend(BackendEvent::SseDisconnected {
-                            error: Some("token_refreshed".into()),
-                        }));
+                        let _ = tx.send(crate::event::Event::Backend(
+                            BackendEvent::SseDisconnected {
+                                error: Some("token_refreshed".into()),
+                            },
+                        ));
                     } else {
                         // Refresh failed — tell user to login manually
-                        let _ = tx.send(crate::event::Event::Backend(BackendEvent::SseDisconnected {
-                            error: Some("auth_failed".into()),
-                        }));
+                        let _ = tx.send(crate::event::Event::Backend(
+                            BackendEvent::SseDisconnected {
+                                error: Some("auth_failed".into()),
+                            },
+                        ));
                     }
                 });
             }
             BackendEvent::ParseWarning { message } => {
                 warn!("SSE parse warning: {}", message);
             }
-            BackendEvent::AutoModePaused { blocked_count, message } => {
+            BackendEvent::AutoModePaused {
+                blocked_count,
+                message,
+            } => {
                 // The auto-mode guardian paused for human review. Surface a clear
                 // status note telling the user how many dangerous actions were
                 // blocked and how to proceed (/resume or approve).
@@ -1806,10 +1974,8 @@ impl App {
                     format!("auto-mode paused: {} — /resume or approve", message)
                 };
                 self.chat.add_system_message(&note, "warning");
-                self.toasts.push(
-                    note,
-                    crate::components::toast::ToastLevel::Warning,
-                );
+                self.toasts
+                    .push(note, crate::components::toast::ToastLevel::Warning);
             }
             BackendEvent::HookBlocked { hook_name, reason } => {
                 self.toasts.push(
@@ -1817,7 +1983,10 @@ impl App {
                     crate::components::toast::ToastLevel::Warning,
                 );
             }
-            BackendEvent::BudgetWarning { utilization, message } => {
+            BackendEvent::BudgetWarning {
+                utilization,
+                message,
+            } => {
                 self.toasts.push(
                     format!("Budget {}%: {}", (utilization * 100.0) as u32, message),
                     crate::components::toast::ToastLevel::Warning,
@@ -1829,12 +1998,20 @@ impl App {
                     crate::components::toast::ToastLevel::Error,
                 );
             }
-            BackendEvent::ProviderRetry { attempt, max_attempts, delay_ms, reason } => {
+            BackendEvent::ProviderRetry {
+                attempt,
+                max_attempts,
+                delay_ms,
+                reason,
+            } => {
                 // Surface "Retrying in Ns…" so a mid-turn network drop is
                 // visible instead of a silent stall (WS1 item 8).
                 let secs = ((delay_ms + 999) / 1000).max(1);
                 let note = if reason.is_empty() {
-                    format!("Retrying in {}s\u{2026} (attempt {}/{})", secs, attempt, max_attempts)
+                    format!(
+                        "Retrying in {}s\u{2026} (attempt {}/{})",
+                        secs, attempt, max_attempts
+                    )
                 } else {
                     format!(
                         "Retrying in {}s\u{2026} (attempt {}/{}) \u{2014} {}",
@@ -1846,15 +2023,14 @@ impl App {
                 // the stall is visible on the status line (with a countdown),
                 // not just as a one-shot scrollback note. Cleared automatically
                 // when the turn resumes (tokens/stream/non-Waiting phase).
-                self.activity.set_retry(Some(
-                    crate::components::activity::RetryState {
+                self.activity
+                    .set_retry(Some(crate::components::activity::RetryState {
                         attempt,
                         max_attempts,
                         reason: reason.clone(),
                         resume_at: std::time::Instant::now()
                             + std::time::Duration::from_millis(delay_ms),
-                    },
-                ));
+                    }));
             }
             BackendEvent::TurnError { kind, reason } => {
                 // Red error line for turn-fatal failures (llm_error /
@@ -1874,9 +2050,8 @@ impl App {
                             providers: resp.providers,
                             system_info: resp.system_info,
                         };
-                        self.onboarding = Some(
-                            crate::dialogs::onboarding::OnboardingWizard::new(data),
-                        );
+                        self.onboarding =
+                            Some(crate::dialogs::onboarding::OnboardingWizard::new(data));
                         if self.state.can_transition_to(AppState::Onboarding) {
                             self.enter_overlay(AppState::Onboarding);
                         }
@@ -1975,7 +2150,11 @@ impl App {
             },
 
             // === Swarm Intelligence events ===
-            BackendEvent::SwarmIntelligenceStarted { swarm_id, intelligence_type, .. } => {
+            BackendEvent::SwarmIntelligenceStarted {
+                swarm_id,
+                intelligence_type,
+                ..
+            } => {
                 self.agents.swarm_started(&swarm_id, &intelligence_type, 0);
                 // U-B5 — drive the live status-bar swarm chip.
                 self.status.set_swarm(Some(intelligence_type.clone()));
@@ -1989,7 +2168,8 @@ impl App {
                 // round on the status-bar swarm chip so the swarm's progress is
                 // actually visible ("✻ swarm · round N").
                 debug!("SI round {}: {}", round, swarm_id);
-                self.status.set_swarm(Some(format!("swarm \u{00b7} round {}", round)));
+                self.status
+                    .set_swarm(Some(format!("swarm \u{00b7} round {}", round)));
             }
             BackendEvent::SwarmIntelligenceConverged { round, .. } => {
                 self.status.set_swarm(None);
@@ -2038,12 +2218,22 @@ impl App {
             }
 
             // === Shared scratchpad activity → Agents panel ===
-            BackendEvent::ScratchpadActivity { agent, entry, action, bytes } => {
+            BackendEvent::ScratchpadActivity {
+                agent,
+                entry,
+                action,
+                bytes,
+            } => {
                 // Feed the visual panel (dim, capped recent-writes section).
-                self.agents.scratchpad_activity(&agent, &entry, &action, bytes);
+                self.agents
+                    .scratchpad_activity(&agent, &entry, &action, bytes);
                 // Screen-reader path: announce a plain-text note instead of the
                 // glyph-decorated panel line (no-op for sighted users).
-                let verb = if action == "append" { "appended" } else { "wrote" };
+                let verb = if action == "append" {
+                    "appended"
+                } else {
+                    "wrote"
+                };
                 self.announce_a11y(&format!(
                     "@{} {} {} to the shared scratchpad ({} bytes)",
                     agent, verb, entry, bytes
@@ -2072,7 +2262,8 @@ impl App {
             BackendEvent::ClassifyResult(result) => match result {
                 Ok(resp) => {
                     self.status.set_signal(resp.signal.clone());
-                    self.sidebar.set_signal_info(&resp.signal.mode, &resp.signal.genre);
+                    self.sidebar
+                        .set_signal_info(&resp.signal.mode, &resp.signal.genre);
                 }
                 Err(e) => {
                     self.toasts.push(
@@ -2106,7 +2297,10 @@ impl App {
             },
             BackendEvent::TaskProgressResult(result) => match result {
                 Ok(progress) => {
-                    debug!("Task progress: {} status={}", progress.task_id, progress.status);
+                    debug!(
+                        "Task progress: {} status={}",
+                        progress.task_id, progress.status
+                    );
                     self.tasks.update(&progress.task_id, &progress.status);
                 }
                 Err(e) => {
@@ -2120,11 +2314,8 @@ impl App {
                 Ok(tasks) => {
                     self.tasks.clear();
                     for t in &tasks {
-                        self.tasks.add(
-                            t.task_id.clone(),
-                            t.task.clone(),
-                            String::new(),
-                        );
+                        self.tasks
+                            .add(t.task_id.clone(), t.task.clone(), String::new());
                         if t.status != "pending" {
                             self.tasks.update(&t.task_id, &t.status);
                         }
@@ -2166,7 +2357,10 @@ impl App {
             },
             BackendEvent::SwarmStatusResult(result) => match result {
                 Ok(status) => {
-                    let msg = format!("Swarm {} [{}]: {}", status.id, status.pattern, status.status);
+                    let msg = format!(
+                        "Swarm {} [{}]: {}",
+                        status.id, status.pattern, status.status
+                    );
                     self.chat.add_system_message(&msg, "info");
                 }
                 Err(e) => {
@@ -2294,10 +2488,7 @@ impl App {
                         .onboarding
                         .as_ref()
                         .and_then(|w| w.selected_provider_id());
-                    let wiz_model = self
-                        .onboarding
-                        .as_ref()
-                        .and_then(|w| w.selected_model_id());
+                    let wiz_model = self.onboarding.as_ref().and_then(|w| w.selected_model_id());
                     let prov = resp
                         .provider
                         .clone()
@@ -2337,7 +2528,9 @@ impl App {
                             if resp.status == "ok" {
                                 wizard.set_verify_success(resp.latency_ms.unwrap_or(0));
                             } else {
-                                let msg = resp.message.unwrap_or_else(|| resp.error.unwrap_or_else(|| "Unknown error".into()));
+                                let msg = resp.message.unwrap_or_else(|| {
+                                    resp.error.unwrap_or_else(|| "Unknown error".into())
+                                });
                                 wizard.set_verify_failed(msg);
                             }
                         }
@@ -2376,7 +2569,10 @@ impl App {
                     self.enter_overlay(AppState::Permissions);
                 }
             }
-            BackendEvent::PlanProposed { plan, request_id: _ } => {
+            BackendEvent::PlanProposed {
+                plan,
+                request_id: _,
+            } => {
                 // Show the plan review dialog — backend paused for user approval.
                 let mut review = crate::dialogs::plan_review::PlanReview::new();
                 review.set_plan(plan);
@@ -2403,23 +2599,32 @@ impl App {
                         crate::components::toast::ToastLevel::Warning,
                     );
                 }
-            },
+            }
 
             // Survey events
-            BackendEvent::AskUserQuestion { survey_id, questions, skippable } => {
-                use crate::dialogs::survey::{SurveyDialog, SurveyQuestion, SurveyOption};
-                let qs: Vec<SurveyQuestion> = questions.into_iter().map(|q| {
-                    SurveyQuestion {
+            BackendEvent::AskUserQuestion {
+                survey_id,
+                questions,
+                skippable,
+            } => {
+                use crate::dialogs::survey::{SurveyDialog, SurveyOption, SurveyQuestion};
+                let qs: Vec<SurveyQuestion> = questions
+                    .into_iter()
+                    .map(|q| SurveyQuestion {
                         text: q.text,
                         header: q.header,
                         multi_select: q.multi_select,
-                        options: q.options.into_iter().map(|o| SurveyOption {
-                            label: o.label,
-                            description: o.description,
-                        }).collect(),
+                        options: q
+                            .options
+                            .into_iter()
+                            .map(|o| SurveyOption {
+                                label: o.label,
+                                description: o.description,
+                            })
+                            .collect(),
                         skippable: q.skippable,
-                    }
-                }).collect();
+                    })
+                    .collect();
                 self.survey = Some(SurveyDialog::new(survey_id, qs, skippable));
                 // Item 5 — waiting on the user's answer → pulse the pending cue.
                 self.activity.set_pending_user(true);
@@ -2439,7 +2644,10 @@ impl App {
             }
 
             // === Proactive Mode ===
-            BackendEvent::ProactiveMessage { message, message_type } => {
+            BackendEvent::ProactiveMessage {
+                message,
+                message_type,
+            } => {
                 let level = match message_type.as_str() {
                     "alert" | "work_failed" => crate::components::toast::ToastLevel::Warning,
                     "work_complete" => crate::components::toast::ToastLevel::Success,
@@ -2457,28 +2665,42 @@ impl App {
                 self.toasts.push(preview, level);
             }
             BackendEvent::ProactiveModeChanged { enabled } => {
-                let msg = if enabled { "Proactive mode: ON" } else { "Proactive mode: OFF" };
-                self.toasts.push(
-                    msg.into(),
-                    crate::components::toast::ToastLevel::Info,
-                );
+                let msg = if enabled {
+                    "Proactive mode: ON"
+                } else {
+                    "Proactive mode: OFF"
+                };
+                self.toasts
+                    .push(msg.into(), crate::components::toast::ToastLevel::Info);
                 self.sidebar.set_proactive(enabled);
             }
             BackendEvent::CoordinatorMode { active } => {
                 // The backend is authoritative for coordinator state (sticky
                 // per-session store): reflect it on the status-bar chip, toast the
                 // transition, and announce it for screen readers.
+                //
+                // Only toast when the state ACTUALLY changed. The TUI sends a
+                // `coordinator status` query on every SSE (re)connect
+                // (SseConnected handler), and the backend's `set_coordinator/2`
+                // unconditionally emits a `coordinator_mode` system_event — even
+                // for a status-only read. Without this guard, every reconnect
+                // produces a redundant "Coordinator mode off: full tool access"
+                // toast, which stacks in small tmux panes and triggers viewport
+                // rebuild churn (each toast appearance/expiry changes
+                // `toast_slot()`, rebuilding the inline viewport via a DSR cursor
+                // query that tmux can drop, leaving stale chrome on screen).
+                let changed = self.status.coordinator() != active;
                 self.status.set_coordinator(active);
-                let msg = if active {
-                    "Coordinator mode on: delegation and messaging only"
-                } else {
-                    "Coordinator mode off: full tool access"
-                };
-                self.toasts.push(
-                    msg.into(),
-                    crate::components::toast::ToastLevel::Info,
-                );
-                self.announce_a11y(msg);
+                if changed {
+                    let msg = if active {
+                        "Coordinator mode on: delegation and messaging only"
+                    } else {
+                        "Coordinator mode off: full tool access"
+                    };
+                    self.toasts
+                        .push(msg.into(), crate::components::toast::ToastLevel::Info);
+                    self.announce_a11y(msg);
+                }
             }
         }
         false
@@ -2627,9 +2849,7 @@ impl App {
 fn merge_tui_native_commands(commands: &mut Vec<crate::client::types::CommandEntry>) {
     use crate::client::types::CommandEntry;
     for &(name, desc) in crate::app::commands::BUILTIN_SLASH_COMMANDS {
-        let already = commands
-            .iter()
-            .any(|c| c.name.eq_ignore_ascii_case(name));
+        let already = commands.iter().any(|c| c.name.eq_ignore_ascii_case(name));
         if !already {
             commands.push(CommandEntry {
                 name: name.to_string(),
@@ -2697,7 +2917,10 @@ mod handle_backend_tests {
         // Paths are not ids.
         assert_eq!(humanize_task_hint("read src/app/mod.rs", any), None);
         // An empty subject is not an improvement.
-        assert_eq!(humanize_task_hint("complete abc", |_| Some("  ".to_string())), None);
+        assert_eq!(
+            humanize_task_hint("complete abc", |_| Some("  ".to_string())),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The TUI shows stacked/duplicated toasts ("Coordinator mode off: full tool access", "New session") in small tmux panes, even when the user is not doing anything.

## Root Cause

The TUI sends a `coordinator status` query to the backend on every SSE (re)connect (`handle_backend.rs:67`). The backend's `handle_coordinator_command` was calling `set_coordinator/2` even for `status` reads, which **unconditionally emits a `coordinator_mode` system_event** via `Bus.emit`. The TUI received that event and pushed a toast every reconnect — even though the coordinator state never changed.

In a tiny tmux pane (~5 rows), each toast appearance/expiry changes `toast_slot()`, which changes `desired_inline_height`, which triggers a viewport rebuild. Each rebuild issues a DSR cursor query that tmux can drop in small panes, leaving stale chrome on screen — the stacking the user reported.

## Fix

Two changes, defense in depth:

### 1. Backend: `status` is read-only (`tool_routes.ex`)

The `handle_coordinator_command` function now branches on the verb:
- `status` / empty: returns current state **without** calling `set_coordinator/2` (no `Bus.emit`, no system_event)
- `on`/`off`/`toggle`: calls `set_coordinator/2` as before (emits the event, TUI toasts the transition)

A read should not have side effects.

### 2. TUI: only toast on actual state changes (`handle_backend.rs`)

The `BackendEvent::CoordinatorMode` handler now checks `self.status.coordinator() != active` before pushing a toast. Even if a redundant event arrives (from some other path), no toast fires unless the state actually changed.

## What was confirmed NOT the bug

- The render path is sound — `draw_inline` does a full `Clear` every frame, no stale pixels survive within a stable viewport
- Toasts are silently dropped (not drawn over the composer) when the band height is 0
- The viewport height is hard-clamped to `term_rows - 1` — no overflow
- The real issue on tiny panes is content starvation (status bar eats 2 of 5 rows), but that is a design tradeoff, not a bug

## Testing

- 1002 Rust tests pass (including all layout invariant tests)
- 89 Elixir HTTP route tests pass
- Both Rust and Elixir compile clean

## Files Changed

- `lib/optimal_system_agent/channels/http/api/tool_routes.ex` — backend coordinator status read-only path
- `priv/rust/tui/src/app/handle_backend.rs` — TUI coordinator toast guard (includes rustfmt formatting)