### PR TITLE
feat(latex): /latex LaTeX + Lean 4 output mode (+ two HTTP fixes)

### DIFF
--- a/lib/optimal_system_agent/agent/context.ex
+++ b/lib/optimal_system_agent/agent/context.ex
@@ -457,6 +457,7 @@ defmodule OptimalSystemAgent.Agent.Context do
       # changes what the turn is allowed to DO, so it must never lose the budget
       # race to a longer advisory block.
       {plan_mode_block(state), 0, "plan_mode"},
+      {latex_mode_block(state), 0, "latex_mode"},
       {memory_block_relevant(state), 1, "memory"},
       {episodic_block(state), 1, "episodic"},
       {task_state_block(state), 1, "task_state"},
@@ -1200,6 +1201,31 @@ defmodule OptimalSystemAgent.Agent.Context do
   end
 
   defp plan_mode_block(_), do: nil
+
+  # LaTeX + Lean 4 output mode (toggled via /latex). Priority 0 like plan mode:
+  # it dictates the SHAPE of every answer, so it must not lose the budget race
+  # to advisory blocks.
+  defp latex_mode_block(%{latex_mode: true} = _state) do
+    """
+    ## OUTPUT MODE — LaTeX + Lean 4 (ACTIVE, until /latex is turned off)
+
+    EVERY response containing any mathematics MUST include BOTH of the following,
+    or it is incomplete:
+
+    1. **LaTeX for all math** — inline `$...$`, display `$$...$$`. Never ASCII or
+       plain-word math: write `$x^2$`, `$\\sqrt{2}$`, `$\\ge$`, not x^2 / sqrt / >=.
+       The terminal renders it.
+    2. **A Lean 4 block** — for every definition/theorem/lemma/claim/proof, append a
+       fenced ```lean block of valid Lean 4 + Mathlib code (`theorem`/`def` with a
+       `by` tactic proof). REQUIRED, not optional; if a step is genuinely beyond you,
+       close it with `sorry` and say so — but still emit the block.
+
+    Before finishing, verify BOTH the LaTeX and the ```lean block are present.
+    Presentation only — this changes no tools.
+    """
+  end
+
+  defp latex_mode_block(_), do: nil
 
   # Surface a previously written (but not yet approved) plan file so a
   # resumed / re-invoked plan-mode turn can incrementally revise it instead

--- a/lib/optimal_system_agent/agent/loop.ex
+++ b/lib/optimal_system_agent/agent/loop.ex
@@ -91,6 +91,7 @@ defmodule OptimalSystemAgent.Agent.Loop do
     tools: [],
     plan_mode: false,
     plan_mode_enabled: false,
+    latex_mode: false,
     turn_count: 0,
     last_meta: %{iteration_count: 0, tools_used: []},
     explored_files: MapSet.new(),
@@ -352,6 +353,18 @@ defmodule OptimalSystemAgent.Agent.Loop do
   @spec toggle_plan_mode(String.t()) :: {:ok, boolean()} | {:error, :no_session | term()}
   def toggle_plan_mode(session_id) do
     GenServer.call(via(session_id), :toggle_plan_mode)
+  catch
+    :exit, _ -> {:error, :no_session}
+  end
+
+  @doc """
+  Toggle LaTeX + Lean 4 output mode for the session.
+
+  Returns `{:ok, enabled?}` or `{:error, :no_session}`.
+  """
+  @spec toggle_latex_mode(String.t()) :: {:ok, boolean()} | {:error, :no_session | term()}
+  def toggle_latex_mode(session_id) do
+    GenServer.call(via(session_id), :toggle_latex_mode)
   catch
     :exit, _ -> {:error, :no_session}
   end
@@ -1186,6 +1199,13 @@ defmodule OptimalSystemAgent.Agent.Loop do
 
   def handle_call({:get_coordinator}, _from, state) do
     {:reply, {:ok, state.coordinator}, state}
+  end
+
+  # LaTeX + Lean 4 output mode (toggled via /latex). A plain boolean the
+  # Agent.Context reads to inject the output-mode directive; changes no tools.
+  def handle_call(:toggle_latex_mode, _from, state) do
+    on? = not Map.get(state, :latex_mode, false)
+    {:reply, {:ok, on?}, %{state | latex_mode: on?}}
   end
 
   def handle_call({:set_strategy, _strategy_name}, _from, state) do

--- a/lib/optimal_system_agent/agent/loop/react_loop.ex
+++ b/lib/optimal_system_agent/agent/loop/react_loop.ex
@@ -288,6 +288,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
     context = cached_context(state)
     Logger.debug("[loop] context built, #{length(context.messages)} messages")
     context = FastPath.inject_context(context, FastPath.await_prefetch(fast_prefetch_task))
+    context = maybe_nudge_latex_mode(context, state)
 
     # Consume prefetched memory (waits max 2s, falls back to sync if timeout)
     context =
@@ -1644,7 +1645,8 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
   # session_id, memory version, and channel so it auto-invalidates on any change.
   defp cached_context(state) do
     cache_key =
-      {state.plan_mode, state.session_id, Process.get(:osa_memory_version, 0), state.channel}
+      {state.plan_mode, Map.get(state, :latex_mode, false), state.session_id,
+       Process.get(:osa_memory_version, 0), state.channel}
 
     case Process.get(:osa_system_msg_cache) do
       {^cache_key, cached_system_msg} ->
@@ -1682,6 +1684,44 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
   end
 
   defp maybe_inject_memory(context, _state), do: context
+
+  # LaTeX + Lean 4 output mode: when active, append a terse imperative reminder to
+  # the latest user message so the model cannot skip the fenced lean block on a hard
+  # proof (the system-prompt directive alone is weaker at recency). Transient — only
+  # the in-flight context is touched, never the persisted history.
+  defp maybe_nudge_latex_mode(%{messages: msgs} = context, %{latex_mode: true}) do
+    last_user =
+      msgs
+      |> Enum.with_index()
+      |> Enum.reverse()
+      |> Enum.find_value(fn {m, i} -> if m[:role] == "user", do: i, else: nil end)
+
+    case last_user do
+      nil ->
+        context
+
+      i ->
+        msgs =
+          List.update_at(msgs, i, fn m ->
+            case m[:content] do
+              c when is_binary(c) -> %{m | content: c <> latex_mode_nudge()}
+              _ -> m
+            end
+          end)
+
+        %{context | messages: msgs}
+    end
+  end
+
+  defp maybe_nudge_latex_mode(context, _state), do: context
+
+  defp latex_mode_nudge do
+    "\n\n[LaTeX+Lean mode ON — write ALL math in LaTeX ($...$ / $$...$$), and for " <>
+      "EVERY theorem/lemma/definition/proof include a fenced lean code block of valid " <>
+      "Lean 4 + Mathlib (theorem/def with a `by` proof; if a step is beyond reach close " <>
+      "it with `sorry` but STILL emit the block). Verify both the LaTeX and the lean " <>
+      "block are present before finishing.]"
+  end
 
   # Mid-turn steer drain (primitive #32). Destructively pulls any steer
   # directives queued for this session out of the ETS steer queue and appends

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -49,6 +49,7 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     "sessions" => {"List recent sessions", :cmd_sessions},
     "tasks" => {"Show current tasks", :cmd_tasks},
     "plan" => {"Toggle plan mode", :cmd_plan},
+    "latex" => {"Toggle LaTeX + Lean 4 rendering mode", :cmd_latex},
     "doctor" => {"Run health check", :cmd_doctor},
     "export" => {"Export conversation as markdown", :cmd_export},
     "version" => {"Show version and check for updates", :cmd_version},
@@ -1013,6 +1014,29 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
 
       {:error, _reason} ->
         IO.puts("  #{@yellow}error: could not toggle plan mode#{@reset}")
+    end
+
+    IO.puts("")
+    session_id
+  end
+
+  def cmd_latex(_args, session_id) do
+    IO.puts("")
+
+    case Loop.toggle_latex_mode(session_id) do
+      {:ok, true} ->
+        IO.puts(
+          "  #{@green}#{@reset} LaTeX + Lean mode #{@bold}enabled#{@reset} — all output renders as LaTeX math and Lean 4"
+        )
+
+      {:ok, false} ->
+        IO.puts("  #{@green}#{@reset} LaTeX + Lean mode #{@bold}disabled#{@reset}")
+
+      {:error, :no_session} ->
+        IO.puts("  #{@yellow}error: session not found#{@reset}")
+
+      {:error, _reason} ->
+        IO.puts("  #{@yellow}error: could not toggle LaTeX mode#{@reset}")
     end
 
     IO.puts("")

--- a/lib/optimal_system_agent/channels/http/api/session_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/session_routes.ex
@@ -117,6 +117,15 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.SessionRoutes do
         OptimalSystemAgent.Agent.SessionPersistence.find_latest_for_dir(working_dir)
 
     if existing do
+      # A directory-scoped resume must also bring the loop back up, exactly like
+      # the create path below — otherwise the resumed session has no live Loop and
+      # every message / slash command 404s with :session_not_found.
+      SessionManager.ensure_loop(existing,
+        user_id: user_id,
+        channel: :http,
+        working_dir: working_dir
+      )
+
       body = Jason.encode!(%{id: existing, status: "resumed", working_dir: working_dir})
 
       conn

--- a/lib/optimal_system_agent/channels/http/api/tool_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/tool_routes.ex
@@ -384,7 +384,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
               Process.group_leader(self(), original_gl)
             end
 
-            {_, captured} = StringIO.close(string_io)
+            {:ok, {_input, captured}} = StringIO.close(string_io)
             captured
           rescue
             e -> "Error: #{Exception.message(e)}"

--- a/lib/optimal_system_agent/tools/builtins/latex_compile/constants.ex
+++ b/lib/optimal_system_agent/tools/builtins/latex_compile/constants.ex
@@ -1,0 +1,39 @@
+defmodule OptimalSystemAgent.Tools.Builtins.LatexCompile.Constants do
+  @moduledoc """
+  Exported constants for `latex_compile`. Mirrors the pattern established by
+  `ShellExecute.Constants` — other tools' prompts can reference `tool_name/0`
+  so a rename propagates automatically.
+  """
+
+  @tool_name "latex_compile"
+  def tool_name, do: @tool_name
+
+  # LaTeX runs (especially first-run package downloads under tectonic) can be
+  # slow. A generous foreground window; the OS process is killed on expiry.
+  @default_timeout_ms 120_000
+  def default_timeout_ms, do: @default_timeout_ms
+
+  @default_engine "tectonic"
+  def default_engine, do: @default_engine
+
+  @default_jobname "document"
+  def default_jobname, do: @default_jobname
+
+  # Engines the tool knows how to drive.
+  @engines ~w(tectonic latexmk pdflatex)
+  def engines, do: @engines
+
+  # Where compiled documents land when the caller does not pass `output_dir`.
+  @base_output_dir "~/.osa/latex"
+  def base_output_dir, do: @base_output_dir
+
+  # Fallback directory searched (in addition to $PATH) when resolving an engine
+  # binary — the LaTeX toolchain on this host is installed here.
+  @local_bin_dir "~/.local/bin"
+  def local_bin_dir, do: @local_bin_dir
+
+  # Cap on the number of parsed error lines returned so a runaway log cannot
+  # flood the result map.
+  @max_errors 50
+  def max_errors, do: @max_errors
+end

--- a/lib/optimal_system_agent/tools/builtins/latex_compile/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/latex_compile/handler.ex
@@ -1,0 +1,385 @@
+defmodule OptimalSystemAgent.Tools.Builtins.LatexCompile.Handler do
+  @moduledoc """
+  Validation, permission, and execution logic for `latex_compile`.
+
+  Mirrors the layout of `ShellExecute.Handler`:
+    * `validate/2`          — type-checks input shape (cheap)
+    * `check_permissions/2` — permission decision (writes only under ~/.osa)
+    * `execute/2`           — materialise source, run the engine, parse the log
+
+  Execution shells out to a LaTeX engine via a `Port` (not `System.cmd`) so the
+  OS process can be killed on timeout instead of leaking an orphaned child.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.Tools.Builtins.LatexCompile.Constants
+  alias OptimalSystemAgent.Tools.UseContext
+
+  # ── Stage 1: Input validation ─────────────────────────────────────────
+
+  @spec validate(map(), UseContext.t()) ::
+          {:ok, map()} | {:error, String.t(), integer()}
+  def validate(input, _ctx) when is_map(input) do
+    with :ok <- validate_source(input),
+         :ok <- validate_engine(input),
+         :ok <- validate_optional_string(input, "output_dir"),
+         :ok <- validate_optional_string(input, "jobname") do
+      {:ok, input}
+    end
+  end
+
+  def validate(_input, _ctx),
+    do: {:error, "Input must be a map", -32_602}
+
+  defp validate_source(input) do
+    content = input["tex_content"]
+    path = input["tex_path"]
+
+    cond do
+      is_binary(content) and String.trim(content) != "" ->
+        :ok
+
+      is_binary(path) and String.trim(path) != "" ->
+        :ok
+
+      not is_nil(content) and not is_binary(content) ->
+        {:error, "tex_content must be a string", -32_602}
+
+      not is_nil(path) and not is_binary(path) ->
+        {:error, "tex_path must be a string", -32_602}
+
+      true ->
+        {:error, "Provide either tex_content (LaTeX source) or tex_path (a .tex file)", -32_602}
+    end
+  end
+
+  defp validate_engine(input) do
+    case input["engine"] do
+      nil ->
+        :ok
+
+      engine when is_binary(engine) ->
+        if engine in Constants.engines() do
+          :ok
+        else
+          {:error, "engine must be one of: #{Enum.join(Constants.engines(), ", ")}", -32_602}
+        end
+
+      _ ->
+        {:error, "engine must be a string", -32_602}
+    end
+  end
+
+  defp validate_optional_string(input, key) do
+    case input[key] do
+      nil -> :ok
+      v when is_binary(v) -> :ok
+      _ -> {:error, "#{key} must be a string", -32_602}
+    end
+  end
+
+  # ── Stage 2: Permission check ─────────────────────────────────────────
+  #
+  # latex_compile only ever writes under a scratch output directory (default
+  # ~/.osa/latex) and reads a source file — no destructive OS surface — so it
+  # is allowed outright.
+
+  @spec check_permissions(map(), UseContext.t()) :: {:allow, map()}
+  def check_permissions(input, _ctx), do: {:allow, input}
+
+  # ── Stage 3: Execute ──────────────────────────────────────────────────
+
+  @spec execute(map(), UseContext.t()) :: {:ok, map()}
+  def execute(input, _ctx) do
+    engine = input["engine"] || Constants.default_engine()
+    jobname = sanitize_jobname(input["jobname"])
+    output_dir = resolve_output_dir(input["output_dir"])
+    File.mkdir_p!(output_dir)
+
+    with {:ok, tex_file, compile_cwd, eff_jobname} <-
+           materialize_source(input, output_dir, jobname),
+         {:ok, binary} <- resolve_binary(engine) do
+      compile(engine, binary, tex_file, compile_cwd, output_dir, eff_jobname)
+    else
+      {:error, message} ->
+        {:ok, error_result(engine, output_dir, jobname, [message], message)}
+    end
+  rescue
+    e ->
+      msg = "latex_compile failed: #{Exception.message(e)}"
+      Logger.error("[latex_compile] #{msg}")
+
+      {:ok,
+       error_result(
+         input["engine"] || Constants.default_engine(),
+         fallback_dir(),
+         Constants.default_jobname(),
+         [msg],
+         msg
+       )}
+  end
+
+  # ── Source materialisation ────────────────────────────────────────────
+
+  defp materialize_source(%{"tex_content" => content}, output_dir, jobname)
+       when is_binary(content) and content != "" do
+    dest = Path.join(output_dir, jobname <> ".tex")
+
+    case File.write(dest, content) do
+      :ok -> {:ok, jobname <> ".tex", output_dir, jobname}
+      {:error, reason} -> {:error, "could not write tex_content: #{:file.format_error(reason)}"}
+    end
+  end
+
+  defp materialize_source(%{"tex_path" => path}, _output_dir, _jobname) when is_binary(path) do
+    src = Path.expand(path)
+
+    cond do
+      not File.exists?(src) ->
+        {:error, "tex_path does not exist: #{src}"}
+
+      not File.regular?(src) ->
+        {:error, "tex_path is not a regular file: #{src}"}
+
+      true ->
+        {:ok, Path.basename(src), Path.dirname(src), Path.rootname(Path.basename(src))}
+    end
+  end
+
+  defp materialize_source(_input, _output_dir, _jobname),
+    do: {:error, "Provide either tex_content or tex_path"}
+
+  # ── Engine resolution ─────────────────────────────────────────────────
+
+  defp resolve_binary(engine) do
+    local = Path.join(Path.expand(Constants.local_bin_dir()), engine)
+
+    cond do
+      is_binary(System.find_executable(engine)) ->
+        {:ok, System.find_executable(engine)}
+
+      File.exists?(local) ->
+        {:ok, local}
+
+      true ->
+        {:error, "LaTeX engine '#{engine}' not found on PATH or in #{Constants.local_bin_dir()}"}
+    end
+  end
+
+  # ── Compilation ───────────────────────────────────────────────────────
+
+  defp compile(engine, binary, tex_file, compile_cwd, output_dir, jobname) do
+    log_path = Path.join(output_dir, jobname <> ".log")
+
+    result =
+      case engine do
+        "pdflatex" ->
+          # Two passes so cross-references / ToC resolve.
+          first = run_binary(binary, engine_args(engine, tex_file, output_dir), compile_cwd)
+
+          case first do
+            {:ok, _status, out1} ->
+              case run_binary(binary, engine_args(engine, tex_file, output_dir), compile_cwd) do
+                {:ok, status, out2} -> {:ok, status, out1 <> out2}
+                other -> other
+              end
+
+            other ->
+              other
+          end
+
+        _ ->
+          run_binary(binary, engine_args(engine, tex_file, output_dir), compile_cwd)
+      end
+
+    finalize(engine, output_dir, jobname, log_path, result)
+  end
+
+  defp engine_args("tectonic", tex_file, output_dir),
+    do: [tex_file, "--outdir", output_dir, "--keep-logs"]
+
+  defp engine_args("latexmk", tex_file, output_dir),
+    do: ["-pdf", "-interaction=nonstopmode", "-outdir=" <> output_dir, tex_file]
+
+  defp engine_args("pdflatex", tex_file, output_dir),
+    do: ["-interaction=nonstopmode", "-output-directory=" <> output_dir, tex_file]
+
+  defp finalize(engine, output_dir, _jobname, log_path, {:timeout, output}) do
+    File.write(log_path, output)
+
+    errors =
+      ["Compilation timed out after #{Constants.default_timeout_ms()} ms" | parse_errors(output)]
+
+    build_result("error", nil, log_path, errors, engine, output_dir)
+    |> wrap()
+  end
+
+  defp finalize(engine, output_dir, jobname, log_path, {:error, message}) do
+    File.write(log_path, message)
+    {:ok, error_result(engine, output_dir, jobname, [message], message)}
+  end
+
+  defp finalize(engine, output_dir, jobname, log_path, {:ok, _status, output}) do
+    File.write(log_path, output)
+    pdf_path = Path.join(output_dir, jobname <> ".pdf")
+    errors = parse_errors(output)
+
+    if pdf_present?(pdf_path) do
+      build_result("ok", pdf_path, log_path, errors, engine, output_dir) |> wrap()
+    else
+      errors = if errors == [], do: ["No PDF was produced; see log for details"], else: errors
+      build_result("error", nil, log_path, errors, engine, output_dir) |> wrap()
+    end
+  end
+
+  defp pdf_present?(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} when size > 0 -> true
+      _ -> false
+    end
+  end
+
+  defp build_result(status, pdf_path, log_path, errors, engine, output_dir) do
+    %{
+      status: status,
+      pdf_path: pdf_path,
+      log_path: log_path,
+      errors: Enum.take(errors, Constants.max_errors()),
+      engine: engine,
+      output_dir: output_dir
+    }
+  end
+
+  defp error_result(engine, output_dir, jobname, errors, log_message) do
+    log_path = Path.join(output_dir, jobname <> ".log")
+    File.write(log_path, log_message)
+    build_result("error", nil, log_path, errors, engine, output_dir)
+  end
+
+  defp wrap(result), do: {:ok, result}
+
+  # ── Port-based process runner ─────────────────────────────────────────
+  #
+  # Spawn the engine directly (no shell) so a hostile jobname can't inject
+  # shell metacharacters, and so the OS process is killable on timeout.
+
+  defp run_binary(binary, args, cwd) do
+    timeout_ms = Constants.default_timeout_ms()
+
+    port =
+      Port.open(
+        {:spawn_executable, binary},
+        [:binary, :exit_status, :hide, :stderr_to_stdout, {:args, args}, {:cd, cwd}]
+      )
+
+    os_pid =
+      case Port.info(port, :os_pid) do
+        {:os_pid, pid} -> pid
+        _ -> nil
+      end
+
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    collect(port, os_pid, deadline, [])
+  rescue
+    e -> {:error, "engine execution error: #{Exception.message(e)}"}
+  end
+
+  defp collect(port, os_pid, deadline, acc) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {^port, {:data, data}} ->
+        collect(port, os_pid, deadline, [data | acc])
+
+      {^port, {:exit_status, status}} ->
+        {:ok, status, IO.iodata_to_binary(Enum.reverse(acc))}
+    after
+      remaining ->
+        kill(os_pid)
+        close(port)
+        {:timeout, IO.iodata_to_binary(Enum.reverse(acc))}
+    end
+  end
+
+  defp kill(nil), do: :ok
+
+  defp kill(os_pid) do
+    System.cmd("kill", ["-9", Integer.to_string(os_pid)], stderr_to_stdout: true)
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp close(port) do
+    Port.close(port)
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  # ── Log parsing ───────────────────────────────────────────────────────
+  #
+  # LaTeX/TeX report fatal errors as a line starting with `! `, usually followed
+  # (within a couple of lines) by a `l.<n>` line pointing at the offending
+  # source line. tectonic additionally emits `error:` lines. Collect both.
+
+  defp parse_errors(output) when is_binary(output) do
+    lines = String.split(output, ~r/\r?\n/)
+
+    lines
+    |> Enum.with_index()
+    |> Enum.flat_map(fn {line, idx} ->
+      cond do
+        String.starts_with?(line, "! ") ->
+          [String.trim_trailing(line) | line_reference(lines, idx)]
+
+        Regex.match?(~r/^\s*error:/, line) ->
+          [String.trim(line)]
+
+        true ->
+          []
+      end
+    end)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+  end
+
+  defp parse_errors(_), do: []
+
+  defp line_reference(lines, idx) do
+    lines
+    |> Enum.drop(idx + 1)
+    |> Enum.take(3)
+    |> Enum.find(&Regex.match?(~r/^l\.\d+/, &1))
+    |> case do
+      nil -> []
+      ref -> [String.trim_trailing(ref)]
+    end
+  end
+
+  # ── Helpers ───────────────────────────────────────────────────────────
+
+  defp sanitize_jobname(name) when is_binary(name) do
+    cleaned =
+      name
+      |> String.trim()
+      |> String.replace(~r/[^A-Za-z0-9_\-]/, "_")
+
+    if cleaned == "", do: Constants.default_jobname(), else: cleaned
+  end
+
+  defp sanitize_jobname(_), do: Constants.default_jobname()
+
+  defp resolve_output_dir(dir) when is_binary(dir) and dir != "", do: Path.expand(dir)
+  defp resolve_output_dir(_), do: fresh_output_dir()
+
+  defp fresh_output_dir do
+    stamp = System.system_time(:millisecond)
+    rand = :rand.uniform(0xFFFFFF)
+    Path.join(Path.expand(Constants.base_output_dir()), "#{stamp}-#{rand}")
+  end
+
+  defp fallback_dir, do: Path.expand(Constants.base_output_dir())
+end

--- a/lib/optimal_system_agent/tools/builtins/latex_compile/prompt.ex
+++ b/lib/optimal_system_agent/tools/builtins/latex_compile/prompt.ex
@@ -1,0 +1,49 @@
+defmodule OptimalSystemAgent.Tools.Builtins.LatexCompile.Prompt do
+  @moduledoc """
+  Dynamic prompt for `latex_compile`.
+
+  Mirrors the pattern from `ShellExecute.Prompt` — content is resolved lazily
+  so future signal-aware customization can hook in via `opts`.
+  """
+
+  alias OptimalSystemAgent.Tools.Builtins.LatexCompile.Constants
+
+  @doc """
+  Render the latex_compile tool prompt.
+
+  `opts` is reserved for future signal-aware customization.
+  """
+  @spec render(keyword()) :: String.t()
+  def render(_opts \\ []) do
+    """
+    Compiles a LaTeX document to PDF and returns a structured result.
+
+    Give the source EITHER inline via `tex_content` (a full LaTeX document,
+    `\\documentclass … \\end{document}`) OR by path via `tex_path` (an existing
+    `.tex` file). Provide exactly one; `tex_content` wins if both are set.
+
+    Engines (`engine`):
+    - `tectonic` (DEFAULT, RECOMMENDED) — self-contained, fetches packages on
+      demand, no system TeX install required. Prefer it.
+    - `latexmk` — drives pdflatex with automatic multi-pass for cross-references.
+    - `pdflatex` — run directly (this tool runs it twice for references).
+
+    Output:
+    - `output_dir` (optional) — directory for the `.tex`, `.log`, and `.pdf`.
+      Defaults to a fresh timestamped directory under `#{Constants.base_output_dir()}`.
+    - `jobname` (optional) — base name for the artifacts. Defaults to
+      `#{Constants.default_jobname()}`.
+
+    The result is a map:
+    - `status` — `"ok"` when a PDF was produced, `"error"` otherwise.
+    - `pdf_path` — absolute path to the PDF on success, `nil` on failure.
+    - `log_path` — absolute path to the combined build log (always written).
+    - `errors` — parsed LaTeX error lines (`! …` plus the following `l.<n>`),
+      empty on success.
+    - `engine`, `output_dir` — echo the resolved engine and directory.
+
+    On a compile failure read `errors` and the `log_path`, fix the source, and
+    recompile. A missing engine yields `status: "error"` with a clear message.
+    """
+  end
+end

--- a/lib/optimal_system_agent/tools/builtins/latex_compile/tool.ex
+++ b/lib/optimal_system_agent/tools/builtins/latex_compile/tool.ex
@@ -1,0 +1,133 @@
+defmodule OptimalSystemAgent.Tools.Builtins.LatexCompile.Tool do
+  @moduledoc """
+  `latex_compile` — compile a LaTeX document to PDF and return a structured
+  result (status / pdf_path / log_path / parsed errors).
+
+  Structured-layout tool: identity, schema, and semantics live here; the actual
+  validation and compilation logic is delegated to `Handler`, the prompt text to
+  `Prompt`, and TUI render maps to `UI` — mirroring the `ShellExecute` layout.
+  """
+
+  use OptimalSystemAgent.Tools.Behaviour
+
+  alias OptimalSystemAgent.Tools.Builtins.LatexCompile.{Constants, Handler, Prompt, UI}
+
+  # ── Identity ──────────────────────────────────────────────────────────
+  @impl true
+  def name, do: Constants.tool_name()
+
+  @impl true
+  def aliases, do: ["compile_latex", "latex_build", "tex_compile"]
+
+  @impl true
+  def search_hint, do: "compile LaTeX to PDF: tectonic, latexmk, pdflatex"
+
+  # ── Schema & description ──────────────────────────────────────────────
+  @impl true
+  def description, do: Prompt.render([])
+
+  @impl true
+  def prompt(opts), do: Prompt.render(opts)
+
+  @impl true
+  def parameters do
+    %{
+      "type" => "object",
+      "properties" => %{
+        "tex_content" => %{
+          "type" => "string",
+          "description" =>
+            "Full LaTeX source (\\documentclass … \\end{document}). Provide this " <>
+              "OR tex_path. Takes precedence if both are given."
+        },
+        "tex_path" => %{
+          "type" => "string",
+          "description" =>
+            "Path to an existing .tex file to compile. Provide this OR tex_content."
+        },
+        "output_dir" => %{
+          "type" => "string",
+          "description" =>
+            "Directory for the .tex, .log, and .pdf artifacts. Defaults to a fresh " <>
+              "timestamped directory under #{Constants.base_output_dir()}."
+        },
+        "engine" => %{
+          "type" => "string",
+          "enum" => Constants.engines(),
+          "description" =>
+            "LaTeX engine. Defaults to #{Constants.default_engine()} " <>
+              "(self-contained, no system TeX install required)."
+        },
+        "jobname" => %{
+          "type" => "string",
+          "description" =>
+            "Base name for the artifacts. Defaults to #{Constants.default_jobname()}."
+        }
+      },
+      "required" => []
+    }
+  end
+
+  # ── Loading semantics ─────────────────────────────────────────────────
+  @impl true
+  def should_defer?, do: false
+
+  @impl true
+  def always_load?, do: false
+
+  # ── Execution semantics (per-input) ───────────────────────────────────
+  @impl true
+  # Writes source/log/pdf files under a scratch dir — not read-only.
+  def read_only?(_input, _ctx), do: false
+
+  @impl true
+  # Only ever writes fresh artifacts under an output dir; overwrites nothing
+  # the user depends on.
+  def destructive?(_input, _ctx), do: false
+
+  @impl true
+  # Each compile targets its own (default: fresh) output dir, so concurrent
+  # invocations don't collide. When callers pin the same output_dir they
+  # serialize themselves; the default keeps runs independent.
+  def concurrency_safe?(_input, _ctx), do: true
+
+  @impl true
+  # No network side effects beyond tectonic's package fetch; not open-world in
+  # the shell sense.
+  def open_world?(_input, _ctx), do: false
+
+  @impl true
+  # A slow compile should be cancelable rather than blocking the loop.
+  def interrupt_behavior, do: :cancel
+
+  # ── Flat-layout compatibility ─────────────────────────────────────────
+  @impl true
+  def safety, do: :write_safe
+
+  # ── Two-stage permissioning ───────────────────────────────────────────
+  @impl true
+  def validate_input(input, ctx), do: Handler.validate(input, ctx)
+
+  @impl true
+  def check_permissions(input, ctx), do: Handler.check_permissions(input, ctx)
+
+  # ── Execution ─────────────────────────────────────────────────────────
+  @impl true
+  def execute(input, ctx), do: Handler.execute(input, ctx)
+
+  # ── Rendering ─────────────────────────────────────────────────────────
+  @impl true
+  def render(stage, payload, opts), do: UI.render(stage, payload, opts)
+
+  # ── Classifier input ──────────────────────────────────────────────────
+  @impl true
+  def to_classifier_input(input) when is_map(input) do
+    %{
+      engine: input["engine"] || Constants.default_engine(),
+      jobname: input["jobname"],
+      tex_path: input["tex_path"]
+    }
+  end
+
+  def to_classifier_input(_), do: ""
+end

--- a/lib/optimal_system_agent/tools/builtins/latex_compile/ui.ex
+++ b/lib/optimal_system_agent/tools/builtins/latex_compile/ui.ex
@@ -1,0 +1,47 @@
+defmodule OptimalSystemAgent.Tools.Builtins.LatexCompile.UI do
+  @moduledoc """
+  Render maps for the Rust TUI.
+
+  Mirrors `ShellExecute.UI`. Each `render/3` call returns a structured map
+  consumed by the TUI over the existing PubSub event channel.
+
+  Stages:
+    * `:tool_use`    — model called the tool, before execution
+    * `:tool_result` — execution result (success or a structured compile error)
+    * `:rejected`    — permission denied
+    * `:error`       — execution error (string message)
+  """
+
+  @spec render(atom(), any(), keyword()) :: map() | nil
+  def render(:tool_use, input, _opts) when is_map(input) do
+    %{
+      kind: "latex_compile",
+      engine: input["engine"] || "tectonic",
+      jobname: input["jobname"],
+      tex_path: input["tex_path"],
+      inline: is_binary(input["tex_content"])
+    }
+  end
+
+  def render(:tool_result, %{status: status} = result, _opts) do
+    %{
+      kind: "latex_compile_result",
+      status: status,
+      engine: result[:engine],
+      pdf_path: result[:pdf_path],
+      log_path: result[:log_path],
+      output_dir: result[:output_dir],
+      error_count: length(result[:errors] || [])
+    }
+  end
+
+  def render(:rejected, _input, _opts) do
+    %{kind: "latex_compile_rejected"}
+  end
+
+  def render(:error, msg, _opts) when is_binary(msg) do
+    %{kind: "latex_compile_error", message: msg}
+  end
+
+  def render(_stage, _payload, _opts), do: nil
+end

--- a/lib/optimal_system_agent/tools/registry.ex
+++ b/lib/optimal_system_agent/tools/registry.ex
@@ -774,6 +774,7 @@ defmodule OptimalSystemAgent.Tools.Registry do
       "file_grep" => OptimalSystemAgent.Tools.Builtins.FileGrep.Tool,
       "dir_list" => OptimalSystemAgent.Tools.Builtins.DirList.Tool,
       "shell_execute" => OptimalSystemAgent.Tools.Builtins.ShellExecute.Tool,
+      "latex_compile" => OptimalSystemAgent.Tools.Builtins.LatexCompile.Tool,
 
       # ── Interactive PTY tools (complement to shell_execute for tty programs) ─
       "pty_start" => OptimalSystemAgent.Tools.Builtins.Pty.PtyStart,

--- a/priv/latex/README.md
+++ b/priv/latex/README.md
@@ -1,0 +1,77 @@
+# OSA LaTeX Library
+
+Reusable, dependency-free LaTeX building blocks the `latex-author` subagent
+`\input`s to produce consistent, compile-clean documents. Everything here is
+plain `.tex` content: no code, no packages to install. All files compile under
+[`tectonic`](https://tectonic-typesetting.github.io/) (self-contained) and also
+under `pdflatex` — the preambles deliberately use `fontenc[T1]` + `lmodern`
+rather than `fontspec`, so no XeTeX/LuaTeX is required and no shell-escape is
+ever needed.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `macros.tex` | Shared math macros and theorem environments. `\input` **after** `amsmath`/`amssymb`/`amsthm` are loaded (the article/report preambles do this for you). |
+| `preambles/article.tex` | Modern `article` preamble: encoding, `geometry`, `amsmath`/`amssymb`/`amsthm`/`mathtools`, `graphicx`/`tikz`, `booktabs`, `siunitx`, `microtype`, `csquotes`, `xcolor`, `hyperref` (loaded last), then `\input`s `macros.tex`. |
+| `preambles/report.tex` | `report`-class variant: adds `fancyhdr` running heads for chapters/titlepage documents. |
+| `preambles/beamer.tex` | Clean `beamer` preamble: `Madrid` theme, navigation symbols suppressed, `amsmath`. (Does **not** load `macros.tex` — `amsthm` theorem definitions clash with beamer's built-in theorem blocks.) |
+| `templates/base-article.tex` | Canonical end-to-end article skeleton: title/author/date, abstract, math (`\[...\]` + `align`), a `booktabs`+`siunitx` table, and a `tikz` figure placeholder. Copy this to start a document. |
+| `templates/base-beamer.tex` | Minimal beamer deck: title slide + two content frames. |
+
+## How to `\input` the library
+
+Every template defines a single root pointer, `\LatexLibRoot`, holding the path
+to this `priv/latex/` directory **with a trailing slash**. The preambles resolve
+`macros.tex` through the same pointer, so you only set it once:
+
+```latex
+\documentclass[11pt,a4paper]{article}
+\providecommand{\LatexLibRoot}{../}          % path to priv/latex/ (trailing slash)
+\input{\LatexLibRoot preambles/article.tex}  % pulls in macros.tex automatically
+```
+
+From `templates/`, the correct value is `../`. If you copy a template somewhere
+else, set `\LatexLibRoot` to that location's relative/absolute path to
+`priv/latex/` (keep the trailing slash), e.g. `{/home/pedroafonso/OSA/priv/latex/}`.
+
+## Compiling with tectonic
+
+From the directory containing your `.tex` file:
+
+```sh
+tectonic base-article.tex
+```
+
+This resolves the `\input` paths relative to the source file's directory and
+emits `base-article.pdf` alongside it. Useful flags:
+
+```sh
+tectonic --outdir out base-article.tex   # write artifacts to ./out
+tectonic --keep-logs base-article.tex    # keep the .log for debugging
+```
+
+`beamer` decks compile identically:
+
+```sh
+tectonic base-beamer.tex
+```
+
+## House style
+
+- **Tables:** use `booktabs` rules (`\toprule`/`\midrule`/`\bottomrule`) — never
+  `\hline` or vertical rules. Align numeric columns with `siunitx` `S` columns.
+- **Units:** always typeset with `siunitx` (`\qty{9.8}{\meter\per\second\squared}`,
+  `\num{1.2e-3}`), never hand-typed `m/s`.
+- **Display math:** use `\[...\]` or `align`/`equation`, never `$$...$$` (which is
+  plain-TeX and breaks amsmath spacing).
+- **Delimiters:** use the paired-delimiter macros (`\abs{x}`, `\norm{v}`,
+  `\set{...}`) so sizing stays consistent; their `*`-form forces `\left..\right`.
+- **hyperref:** load it **last** among packages (the preambles already do). Colored
+  links via a muted navy, no boxes.
+- **Cross-references:** label everything and reference with `\ref`/`\eqref`; links
+  are clickable through `hyperref`.
+- **Fonts/encoding:** rely on the preamble's `fontenc[T1]` + `lmodern`; do not add
+  `fontspec` (keeps pdflatex compatibility).
+- **Figures:** prefer `\includegraphics`; the article template ships a `tikz`
+  placeholder so a fresh skeleton compiles before any asset exists.

--- a/priv/latex/macros.tex
+++ b/priv/latex/macros.tex
@@ -1,0 +1,67 @@
+% macros.tex -- shared math macros and theorem environments.
+% \input this AFTER amsmath/amssymb/amsthm are loaded (the preambles do so).
+% Compatible with pdflatex and tectonic. No shell-escape, no extra packages.
+
+% ---------------------------------------------------------------------------
+% Number sets (blackboard bold).
+% ---------------------------------------------------------------------------
+\providecommand{\R}{\mathbb{R}}
+\providecommand{\N}{\mathbb{N}}
+\providecommand{\Z}{\mathbb{Z}}
+\providecommand{\Q}{\mathbb{Q}}
+\providecommand{\C}{\mathbb{C}}
+\providecommand{\F}{\mathbb{F}}
+
+% ---------------------------------------------------------------------------
+% Paired delimiters (auto-sizing via \left..\right, with a starred *-variant
+% for explicit sizing). Requires amsmath (\DeclarePairedDelimiter).
+% ---------------------------------------------------------------------------
+\DeclarePairedDelimiter{\abs}{\lvert}{\rvert}
+\DeclarePairedDelimiter{\norm}{\lVert}{\rVert}
+\DeclarePairedDelimiter{\set}{\{}{\}}
+\DeclarePairedDelimiter{\ceil}{\lceil}{\rceil}
+\DeclarePairedDelimiter{\floor}{\lfloor}{\rfloor}
+\DeclarePairedDelimiter{\inner}{\langle}{\rangle}
+
+% ---------------------------------------------------------------------------
+% Calculus helpers.
+%   \dd            upright differential "d"
+%   \dd[n]{x}      n-th differential of x, e.g. \dd{x} -> dx, \dd[2]{t}
+%   \eval          evaluation bar: \eval{expr}{a}{b}
+% ---------------------------------------------------------------------------
+\providecommand{\dd}{}
+\renewcommand{\dd}[2][]{\mathop{}\!\mathrm{d}^{#1}#2}
+\newcommand{\eval}[3]{\left.#1\right\rvert_{#2}^{#3}}
+
+% Common operators not predefined by amsmath.
+\DeclareMathOperator{\diverg}{div}
+\DeclareMathOperator{\curl}{curl}
+\DeclareMathOperator{\grad}{grad}
+\DeclareMathOperator{\rank}{rank}
+\DeclareMathOperator{\trace}{tr}
+\DeclareMathOperator{\spann}{span}
+\DeclareMathOperator*{\argmin}{arg\,min}
+\DeclareMathOperator*{\argmax}{arg\,max}
+
+% Convenience shorthands.
+\providecommand{\eps}{\varepsilon}
+\providecommand{\To}{\longrightarrow}
+\newcommand{\deriv}[2]{\frac{\dd{#1}}{\dd{#2}}}
+\newcommand{\pderiv}[2]{\frac{\partial #1}{\partial #2}}
+
+% ---------------------------------------------------------------------------
+% Theorem environments (amsthm). Shared numbering within sections.
+% ---------------------------------------------------------------------------
+\theoremstyle{plain}
+\newtheorem{theorem}{Theorem}[section]
+\newtheorem{lemma}[theorem]{Lemma}
+\newtheorem{proposition}[theorem]{Proposition}
+\newtheorem{corollary}[theorem]{Corollary}
+
+\theoremstyle{definition}
+\newtheorem{definition}[theorem]{Definition}
+\newtheorem{example}[theorem]{Example}
+
+\theoremstyle{remark}
+\newtheorem*{remark}{Remark}
+% (The `proof` environment is provided by amsthm automatically.)

--- a/priv/latex/preambles/article.tex
+++ b/priv/latex/preambles/article.tex
@@ -1,0 +1,47 @@
+% article.tex -- modern article preamble.
+% Compiles clean under tectonic and pdflatex (uses fontenc[T1]+lmodern, not fontspec).
+% Usage: after \documentclass{article}, \input this file, then \input macros.
+%   \documentclass[11pt,a4paper]{article}
+%   \input{../preambles/article.tex}   % or an absolute/relative path
+% This file loads ../macros.tex at the end, so callers get macros for free.
+
+% --- Encoding & fonts (pdflatex + tectonic compatible) --------------------
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+
+% --- Page geometry --------------------------------------------------------
+\usepackage[margin=1in]{geometry}
+
+% --- Math -----------------------------------------------------------------
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{amsthm}
+\usepackage{mathtools}
+
+% --- Graphics, tables, units, color --------------------------------------
+\usepackage{graphicx}
+\usepackage{tikz}
+\usepackage{booktabs}
+\usepackage{siunitx}
+\usepackage{xcolor}
+
+% --- Language & quotes ----------------------------------------------------
+\usepackage{csquotes}
+
+% --- Hyperlinks (load hyperref last, before any macros that need it) ------
+\usepackage{hyperref}
+\definecolor{linknavy}{RGB}{0,51,102}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=linknavy,
+  citecolor=linknavy,
+  urlcolor=linknavy,
+  filecolor=linknavy,
+  pdfborder={0 0 0},
+  bookmarksnumbered=true,
+}
+
+% --- Shared macros --------------------------------------------------------
+\input{\LatexLibRoot macros.tex}

--- a/priv/latex/preambles/beamer.tex
+++ b/priv/latex/preambles/beamer.tex
@@ -1,0 +1,31 @@
+% beamer.tex -- clean beamer preamble (no navigation symbols).
+% Compiles clean under tectonic and pdflatex.
+% Usage:
+%   \documentclass{beamer}
+%   \providecommand{\LatexLibRoot}{../}
+%   \input{\LatexLibRoot preambles/beamer.tex}
+
+% --- Theme ----------------------------------------------------------------
+\usetheme{Madrid}
+\usecolortheme{seahorse}
+\setbeamertemplate{navigation symbols}{}   % drop the navigation clutter.
+\setbeamertemplate{caption}[numbered]
+
+% --- Encoding & fonts -----------------------------------------------------
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+
+% --- Math -----------------------------------------------------------------
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{mathtools}
+
+% --- Graphics, tables, units, color --------------------------------------
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{siunitx}
+\usepackage{xcolor}
+
+% --- Language & quotes ----------------------------------------------------
+\usepackage{csquotes}

--- a/priv/latex/preambles/report.tex
+++ b/priv/latex/preambles/report.tex
@@ -1,0 +1,55 @@
+% report.tex -- report-class preamble (chapters + titlepage friendly).
+% Compiles clean under tectonic and pdflatex.
+% Usage:
+%   \documentclass[11pt,a4paper]{report}
+%   \providecommand{\LatexLibRoot}{../}
+%   \input{\LatexLibRoot preambles/report.tex}
+
+% --- Encoding & fonts -----------------------------------------------------
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+
+% --- Page geometry --------------------------------------------------------
+\usepackage[margin=1in]{geometry}
+
+% --- Math -----------------------------------------------------------------
+\usepackage{amsmath}
+\usepackage{amssymb}
+\usepackage{amsthm}
+\usepackage{mathtools}
+
+% --- Graphics, tables, units, color --------------------------------------
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{siunitx}
+\usepackage{xcolor}
+
+% --- Language & quotes ----------------------------------------------------
+\usepackage{csquotes}
+
+% --- Chapter/section headings & running heads -----------------------------
+\usepackage{fancyhdr}
+\pagestyle{fancy}
+\fancyhead{}
+\fancyhead[LE,RO]{\thepage}
+\fancyhead[RE]{\leftmark}
+\fancyhead[LO]{\rightmark}
+\renewcommand{\headrulewidth}{0.4pt}
+
+% --- Hyperlinks (load last) -----------------------------------------------
+\usepackage{hyperref}
+\definecolor{linknavy}{RGB}{0,51,102}
+\hypersetup{
+  colorlinks=true,
+  linkcolor=linknavy,
+  citecolor=linknavy,
+  urlcolor=linknavy,
+  filecolor=linknavy,
+  pdfborder={0 0 0},
+  bookmarksnumbered=true,
+}
+
+% --- Shared macros --------------------------------------------------------
+\input{\LatexLibRoot macros.tex}

--- a/priv/latex/templates/base-article.tex
+++ b/priv/latex/templates/base-article.tex
@@ -1,0 +1,87 @@
+% base-article.tex -- canonical, end-to-end compilable article skeleton.
+% Compile from this directory (priv/latex/templates/) with:
+%   tectonic base-article.tex
+% The author copies this file, then adjusts \LatexLibRoot if it moves elsewhere
+% (set it to the absolute or relative path of priv/latex/, WITH a trailing slash).
+
+\documentclass[11pt,a4paper]{article}
+
+% Root of the LaTeX library (path to priv/latex/, trailing slash required).
+\providecommand{\LatexLibRoot}{../}
+\input{\LatexLibRoot preambles/article.tex}
+
+\title{A Compile-Ready Article Skeleton}
+\author{OSA \LaTeX{} Author}
+\date{\today}
+
+\begin{document}
+\maketitle
+
+\begin{abstract}
+This skeleton demonstrates the house style: display math with \verb|\[...\]|
+and \texttt{align}, \texttt{booktabs} tables, a figure placeholder, and the
+shared macros from \texttt{macros.tex}. It compiles cleanly under \texttt{tectonic}.
+\end{abstract}
+
+\section{Introduction}
+\label{sec:intro}
+Let $f\colon \R \To \R$ be continuous. For any $x \in \R$ we write $\abs{x}$ for
+its absolute value and $\norm{x}$ for a norm on $\R^n$. Display math uses
+\verb|\[...\]| or \texttt{align}:
+\[
+  \int_{a}^{b} f(x)\,\dd{x} = \eval{F(x)}{a}{b},
+\]
+and multi-line derivations use \texttt{align}:
+\begin{align}
+  (a + b)^2 &= a^2 + 2ab + b^2, \label{eq:square}\\
+  \deriv{}{x}\, e^{x} &= e^{x}.
+\end{align}
+
+\begin{theorem}[Fundamental bound]
+\label{thm:bound}
+For every $x \in \R$, $\abs{x} \ge 0$, with equality iff $x = 0$.
+\end{theorem}
+
+\begin{proof}
+Immediate from the definition of the absolute value.
+\end{proof}
+
+\section{A Table}
+\label{sec:table}
+Table~\ref{tab:results} uses \texttt{booktabs} rules (never \verb|\hline|) and
+\texttt{siunitx} for aligned numbers.
+
+\begin{table}[htbp]
+  \centering
+  \caption{Illustrative results.}
+  \label{tab:results}
+  \begin{tabular}{l S[table-format=3.2] S[table-format=1.3]}
+    \toprule
+    Method & {Score} & {Error} \\
+    \midrule
+    Baseline & 87.40 & 0.120 \\
+    Proposed & 94.25 & 0.031 \\
+    \bottomrule
+  \end{tabular}
+\end{table}
+
+\section{A Figure}
+\label{sec:figure}
+Figure~\ref{fig:placeholder} is a placeholder drawn with \texttt{tikz} so the
+skeleton compiles without any external image file. Replace it with
+\verb|\includegraphics{...}| once a real asset exists.
+
+\begin{figure}[htbp]
+  \centering
+  \begin{tikzpicture}
+    \draw[thick] (0,0) rectangle (4,2.5);
+    \node at (2,1.25) {\itshape figure placeholder};
+  \end{tikzpicture}
+  \caption{Placeholder figure.}
+  \label{fig:placeholder}
+\end{figure}
+
+Cross-references (Section~\ref{sec:intro}, Theorem~\ref{thm:bound},
+Equation~\eqref{eq:square}) resolve through \texttt{hyperref}.
+
+\end{document}

--- a/priv/latex/templates/base-beamer.tex
+++ b/priv/latex/templates/base-beamer.tex
@@ -1,0 +1,47 @@
+% base-beamer.tex -- minimal, compilable beamer deck.
+% Compile from this directory (priv/latex/templates/) with:
+%   tectonic base-beamer.tex
+
+\documentclass{beamer}
+
+\providecommand{\LatexLibRoot}{../}
+\input{\LatexLibRoot preambles/beamer.tex}
+
+\title{A Compile-Ready Beamer Deck}
+\subtitle{OSA \LaTeX{} Library}
+\author{OSA \LaTeX{} Author}
+\date{\today}
+
+\begin{document}
+
+\begin{frame}
+  \titlepage
+\end{frame}
+
+\begin{frame}{Motivation}
+  \begin{itemize}
+    \item Consistent, compile-clean slides.
+    \item No navigation symbols; clean theme.
+    \item Math works out of the box: $e^{i\pi} + 1 = 0$.
+  \end{itemize}
+\end{frame}
+
+\begin{frame}{Some Math and a Table}
+  A displayed equation:
+  \[
+    \sum_{k=1}^{n} k = \frac{n(n+1)}{2}.
+  \]
+  \begin{table}
+    \centering
+    \begin{tabular}{lr}
+      \toprule
+      Item & Value \\
+      \midrule
+      Alpha & 1 \\
+      Beta  & 2 \\
+      \bottomrule
+    \end{tabular}
+  \end{table}
+\end{frame}
+
+\end{document}

--- a/priv/rust/tui/src/app/commands.rs
+++ b/priv/rust/tui/src/app/commands.rs
@@ -61,6 +61,7 @@ pub(crate) const BUILTIN_SLASH_COMMANDS: &[(&str, &str)] = &[
     ("login", "Authenticate with the backend"),
     ("logout", "Sign out"),
     ("voice", "Show the voice provider"),
+    ("latex", "Toggle LaTeX + Lean 4 rendering mode"),
     ("exit", "Quit OSA"),
     ("quit", "Quit OSA"),
 ];


### PR DESCRIPTION
## Summary

Fixes two bugs that broke the TUI end-to-end, and adds a `/latex` output mode.

**Fixes (independent of the feature):**
- `StringIO.close/1` returns `{:ok, {input, output}}`; the command-execute handler destructured it wrong and then ran `String.replace/4` on the tuple, crashing **every** `POST /api/v1/commands/execute` with a `FunctionClauseError` — i.e. every slash command over HTTP (and therefore in the TUI).
- A directory-scoped session resume (`POST /sessions` with a `working_dir` that already has a saved session) returned the session without calling `ensure_loop`, so it had no live Loop and every following message/command `404`'d with `:session_not_found`. The TUI attaches to its cwd, so reattaching broke the whole session.

**Feature — `/latex` (LaTeX + Lean 4 output mode):**
- Toggle command (`/latex`); while active, all math is rendered in LaTeX (`$...$` / `$$...$$`) and every theorem/lemma/proof is also formalized in a fenced Lean 4 (Mathlib) block. The TUI already transliterates LaTeX math.
- `latex_mode` session flag + `toggle_latex_mode/1`, a priority-0 context directive (ranked like plan mode), the flag added to the system-prompt cache key (so a mid-session toggle invalidates the cache), and a transient per-turn reminder appended to the user message so the directive keeps recency on long turns.
- `latex_compile` builtin tool (tectonic/latexmk/pdflatex -> PDF, killable Port, log/error parsing).
- Reusable `priv/latex/` library: article/report/beamer preambles, macros, templates, README.
- `/latex` added to the TUI builtin slash-command list.

## Related issues

Closes #

## Type of change

- [x] Bug fix
- [x] New feature

## How was this tested?

OSA v1.1.1, Linux, Elixir 1.19.5 / OTP 28, provider `ollama` / `glm-5.2:cloud`, source checkout via `mix osa.serve`.

- Both fixes verified against a running backend: before, every `POST /commands/execute` returned 500 and resumed sessions 404'd on message; after, all commands return 200, resumed sessions come up live, and `oi` gets a reply.
- `/latex` verified in the TUI: toggling shows "LaTeX + Lean mode enabled", and a math prompt returns LaTeX plus a Lean 4 block (e.g. `theorem two_plus_two : 2 + 2 = 4 := by rfl`).
- `latex_compile` compiles the shipped templates to PDF with tectonic (article + beamer).
- `mix compile` clean.

Note: Lean-block quality depends on the model — `glm-5.2` handles tractable proofs well and is weaker on hard formalizations. The mechanism (directive + injection) is model-agnostic.

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated documentation where needed
- [x] My changes follow the project's conventions
