### PR TITLE
Re-resolve all ~/.osa paths from config_dir at runtime, not just config_dir itself

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -24,25 +24,48 @@ import Config
 # (`OSA_HTTP_PORT`, falling back to the OS pid) so two concurrent suites never
 # clobber each other, and the same age-based sweep so per-run naming does not
 # leak directories forever.
-if config_env() == :test do
-  test_home_tag = System.get_env("OSA_HTTP_PORT") || System.pid()
-  test_home = Path.join(System.tmp_dir!(), "osa-test-home-#{test_home_tag}")
+config_dir =
+  if config_env() == :test do
+    test_home_tag = System.get_env("OSA_HTTP_PORT") || System.pid()
+    test_home = Path.join(System.tmp_dir!(), "osa-test-home-#{test_home_tag}")
 
-  _ = File.rm_rf(test_home)
-  _ = File.mkdir_p(test_home)
+    _ = File.rm_rf(test_home)
+    _ = File.mkdir_p(test_home)
 
-  stale_home_before = System.os_time(:second) - 86_400
+    stale_home_before = System.os_time(:second) - 86_400
 
-  for stale <- Path.wildcard(Path.join(System.tmp_dir!(), "osa-test-home-*")),
-      match?({:ok, %{mtime: mtime}} when mtime < stale_home_before, File.stat(stale, time: :posix)) do
-    _ = File.rm_rf(stale)
+    for stale <- Path.wildcard(Path.join(System.tmp_dir!(), "osa-test-home-*")),
+        match?({:ok, %{mtime: mtime}} when mtime < stale_home_before, File.stat(stale, time: :posix)) do
+      _ = File.rm_rf(stale)
+    end
+
+    test_home
+  else
+    System.get_env("OSA_HOME") || Path.expand("~/.osa")
   end
 
-  config :optimal_system_agent, config_dir: test_home
-else
-  config :optimal_system_agent,
-    config_dir: System.get_env("OSA_HOME") || Path.expand("~/.osa")
-end
+# config/config.exs derives skills_dir, episodic_dir, mcp_config_path,
+# bootstrap_dir, data_dir, sessions_dir and Store.Repo's database path from
+# the SAME Path.expand("~/.osa/...") pattern as config_dir above — but only
+# config_dir gets re-resolved here at boot. The other six are still whatever
+# HOME was on the machine that ran `mix release` (e.g. /Users/runner on CI),
+# so every fresh install boots pointed at a directory that only exists on the
+# build host: Exqlite.Connection fails with `enoent` opening the sqlite file,
+# the backend crash-loops before it can ever save onboarding state, and
+# `osa doctor` reports missing workspace files it's looking for in the wrong
+# place. Re-derive all of them from the same runtime-resolved config_dir so
+# they track the operator's actual home like config_dir already does.
+config :optimal_system_agent,
+  config_dir: config_dir,
+  skills_dir: Path.join(config_dir, "skills"),
+  episodic_dir: Path.join(config_dir, "memory/episodic"),
+  mcp_config_path: Path.join(config_dir, "mcp.json"),
+  bootstrap_dir: config_dir,
+  data_dir: Path.join(config_dir, "data"),
+  sessions_dir: Path.join(config_dir, "sessions")
+
+config :optimal_system_agent, OptimalSystemAgent.Store.Repo,
+  database: Path.join(config_dir, "osa.db")
 
 # ── Logger level override via env var ────────────────────────────────────
 case System.get_env("LOGGER_LEVEL") do


### PR DESCRIPTION
## What broke

`config/config.exs` derives `config_dir`, `skills_dir`, `episodic_dir`, `mcp_config_path`, `bootstrap_dir`, `data_dir`, `sessions_dir`, and `Store.Repo`'s sqlite `database` path all from `Path.expand("~/.osa/...")`, which is evaluated at **compile time** during `mix release` — baking in whatever `$HOME` was on the build host (e.g. `/Users/runner` on CI).

`config/runtime.exs` already has a comment explaining exactly this bug class and re-resolves `config_dir` at boot from `OSA_HOME`/the real `~`:

```elixir
# config/config.exs sets config_dir with Path.expand("~/.osa"), which is
# evaluated during `mix release` on the build host (HOME=/home/runner on CI)
# and would otherwise bake that path into the release. Resolve it here at boot
# so it tracks the running user's home (or OSA_HOME override).
```

But that fix only covers `config_dir` itself — the other six settings never got the same treatment, so they keep the compile-time CI-host path on every install of the released build.

## Impact

Every fresh install of a published release crash-loops on first launch:

```
[error] Exqlite.Connection ... failed to connect: ** (Exqlite.Error) enoent
[warning] [Memory.Store] failed to load from SQLite: ... connection not available ...
[error] Could not create schema migrations table ...
```

The backend can't open its sqlite database (wrong host's path), crashes before it can persist anything from onboarding, and any provider-key setup attempt surfaces as a generic network/API error because the process dies mid-request. `osa doctor` additionally reports the seeded workspace files (`BOOTSTRAP.md`, `IDENTITY.md`, `USER.md`, `SOUL.md`) as missing, because it's looking for them in the CI host's directory instead of the real one.

I hit this on a completely fresh macOS install and traced it back to the compiled `sys.config` literally containing `/Users/runner/.osa/...` for all seven settings.

## Fix

Derive all seven from the same runtime-resolved `config_dir`, the same way it already works for `config_dir` itself.

Not run against the project's test suite locally (no Elixir toolchain in the environment this was written in) — logic mirrors the existing pattern one block above it, but please double check in CI before merging.