### PR TITLE
fix: osa update could not restart the backend (port reclaim + TIME_WAIT preflight)

### DIFF
--- a/bin/osa
+++ b/bin/osa
@@ -402,6 +402,15 @@ daemon_pid() {
   fi
 }
 
+# Every PID holding a LISTEN socket on :$PORT, newline-separated, or nothing.
+# Unlike `daemon_pid` this ignores the pidfile and ignores lineage: it answers
+# "who would the next bind collide with", which is the only question the
+# stop/restart path actually needs. Empty when lsof is unavailable.
+_port_owners() {
+  command -v lsof >/dev/null 2>&1 || return 0
+  lsof -ti ":${PORT}" -sTCP:LISTEN 2>/dev/null || true
+}
+
 clear_stale_pid() {
   # Drop a pidfile whose process is gone and whose port is dead.
   if [ -f "$PID_FILE" ]; then
@@ -459,6 +468,41 @@ _stop_backend_confirmed() {
     sleep 0.25
     n=$((n + 1))
   done
+
+  # Escalate to whatever still OWNS the socket. `stop_daemon` signals the
+  # pidfile PID's process group, but the BEAM child does not always stay in
+  # that group: `mix` can re-exec `beam.smp` into a group of its own, so the
+  # launcher dies, the group kill finds nothing left to reap, and the BEAM
+  # keeps :$PORT open. That is the "backend stopped / would not stop" pair
+  # users see — both lines are true, they are just about different processes.
+  # The PORT is the contract (see above), so reclaim it by port ownership
+  # rather than by lineage. No-op when the port is already free.
+  if command -v lsof >/dev/null 2>&1; then
+    local sig
+    for sig in TERM KILL; do
+      [ -z "$(_port_owners)" ] && break
+      # shellcheck disable=SC2086
+      kill -"$sig" $(_port_owners) 2>/dev/null || true
+      n=0
+      while [ $n -lt 20 ] && [ -n "$(_port_owners)" ]; do
+        sleep 0.25; n=$((n + 1))
+      done
+    done
+    rm -f "$PID_FILE" "$PORT_FILE" 2>/dev/null || true
+  fi
+
+  # Wait for the LISTEN socket itself to go, not just for /health to stop
+  # answering. A shutting-down BEAM stops serving requests well before it
+  # closes the listener, so a health-only check reports "stopped" while the
+  # port is still bound — and the relaunch then dies with "Port 9089 is in
+  # use by another process". The socket is the thing the next bind contends
+  # for, so the socket is the thing we wait on.
+  n=0
+  while [ $n -lt 40 ] && [ -n "$(_port_owners)" ]; do
+    sleep 0.25; n=$((n + 1))
+  done
+
+  [ -n "$(_port_owners)" ] && return 1
   if backend_healthy; then return 1; fi
   return 0
 }

--- a/lib/optimal_system_agent/net/port.ex
+++ b/lib/optimal_system_agent/net/port.ex
@@ -59,9 +59,18 @@ defmodule OptimalSystemAgent.Net.Port do
   """
   @spec available?(non_neg_integer()) :: boolean()
   def available?(port) when is_integer(port) and port >= 0 do
-    # Mirror Bandit/ThousandIsland's loopback bind. No `reuseaddr` so that an
-    # already-listening socket reliably surfaces `:eaddrinuse`.
-    case :gen_tcp.listen(port, [:binary, ip: {127, 0, 0, 1}, active: false]) do
+    # Mirror Bandit/ThousandIsland's loopback bind EXACTLY, `reuseaddr` and all
+    # (ThousandIsland.Transports.TCP hard-defaults it to true).
+    #
+    # Omitting it does not make the check stricter in a useful way, it makes it
+    # WRONG: `SO_REUSEADDR` does not allow binding over a socket that is
+    # actively LISTENing, so a live server is still detected either way. What it
+    # does allow is binding past a `TIME_WAIT` left by a closed CLIENT
+    # connection to this port. Those linger ~30s after every restart, so a
+    # freshly stopped backend with a TUI still attached looked "occupied" while
+    # Bandit would have bound fine, and startup aborted with
+    # "Port 9089 is in use by another process" when nothing was listening at all.
+    case :gen_tcp.listen(port, [:binary, ip: {127, 0, 0, 1}, active: false, reuseaddr: true]) do
       {:ok, socket} ->
         :gen_tcp.close(socket)
         true

--- a/test/optimal_system_agent/net/port_test.exs
+++ b/test/optimal_system_agent/net/port_test.exs
@@ -68,6 +68,44 @@ defmodule OptimalSystemAgent.Net.PortTest do
     test "port 0 (ephemeral) is always available" do
       assert Port.available?(0)
     end
+
+    # Regression: the preflight must mirror Bandit's bind, not be stricter than
+    # it. ThousandIsland.Transports.TCP hard-defaults `reuseaddr: true`, so a
+    # TIME_WAIT left behind by a closed CLIENT connection does NOT stop Bandit
+    # from binding. When `available?/1` omitted `reuseaddr` it reported such a
+    # port as occupied, and boot aborted with "Port 9089 is in use by another
+    # process" seconds after a restart, with nothing listening at all.
+    test "a TIME_WAIT from a closed client connection does not mark the port occupied" do
+      {:ok, listener} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}, active: false])
+      {:ok, port} = :inet.port(listener)
+
+      {:ok, client} = :gen_tcp.connect({127, 0, 0, 1}, port, [:binary, active: false])
+      {:ok, accepted} = :gen_tcp.accept(listener, 1_000)
+
+      # The SERVER side must close first. TIME_WAIT lands on whichever peer
+      # performs the active close, and it is the dying backend that closes its
+      # accepted sockets - which is why the real netstat shows the lingering
+      # entry on local port 9089 rather than on the client's ephemeral port.
+      :gen_tcp.close(accepted)
+      :gen_tcp.close(listener)
+      :gen_tcp.close(client)
+
+      assert Port.available?(port),
+             "expected port #{port} to be bindable despite a lingering TIME_WAIT"
+    end
+
+    # The other half of the same contract: `reuseaddr` must not make the check
+    # blind. SO_REUSEADDR never permits binding over an actively LISTENing
+    # socket, so a genuinely occupied port is still reported occupied.
+    test "reuseaddr does not hide an actively listening socket" do
+      {:ok, holder} = :gen_tcp.listen(0, [:binary, ip: {127, 0, 0, 1}, active: false])
+      {:ok, port} = :inet.port(holder)
+
+      refute Port.available?(port),
+             "expected an actively listening port #{port} to still be detected"
+
+      :gen_tcp.close(holder)
+    end
   end
 
   describe "holder_kind/1" do


### PR DESCRIPTION
`osa update` rebuilt correctly but could not bring the new build live. Two
independent bugs, in sequence.

## 1. The stop signalled a process that was not holding the port

    → Stopping OSA backend (pid 95326)…
    ✓ Backend stopped.
    ✗ The old backend on :9089 would not stop.

Both lines were true, about different processes. `stop_daemon` signals the
pidfile PID's process group, but `mix` can re-exec `beam.smp` into a group of
its own: the launcher dies, the group kill finds nothing to reap, and the BEAM
keeps the listener.

The script already documents that the PORT is the contract, not the PID, so the
stop path now acts on it - `_port_owners/0` plus TERM-then-KILL escalation, and
a final wait on the LISTEN socket rather than on `/health` (a shutting-down BEAM
stops serving well before it closes the listener).

## 2. The preflight was stricter than the bind it gates

With #1 fixed the stop succeeded, then startup died anyway:

    ✗ OSA cannot start
    Port 9089 is in use by another process

with nothing listening on 9089 at all. `netstat` showed only the TIME_WAIT
entries the dying backend left on its own port.

`Port.available?/1` claimed to mirror Bandit's bind but deliberately omitted
`reuseaddr`. `ThousandIsland.Transports.TCP` hard-defaults it to `true`, so the
check was stricter than the real bind - and `SO_REUSEADDR` never permits binding
over an actively LISTENing socket, so omitting it bought no extra detection. It
only counted a closed connection's TIME_WAIT, which lingers ~30s after every
restart, as an occupied port.

## Tests

Two tests pin both halves of the preflight contract: a server-side TIME_WAIT
must not mark the port occupied, and a live listener must still be detected.
The first was confirmed to fail without this change and pass with it.

`mix test test/optimal_system_agent/net/port_test.exs` - 11 tests, 0 failures.

## Verification

Reproduced the original failure, applied both fixes, then stopped a live backend
with client connections open and restarted immediately: 0 port-in-use errors,
backend healthy on v1.0.59.