### PR TITLE
feat(memory): bias auto-extraction to precision over recall

### DIFF
--- a/lib/optimal_system_agent/memory/auto_extract.ex
+++ b/lib/optimal_system_agent/memory/auto_extract.ex
@@ -2,90 +2,170 @@ defmodule OptimalSystemAgent.Memory.AutoExtract do
   @moduledoc """
   Automatic memory extraction from conversation turns.
 
-  After each agent response, scans the conversation for extractable
-  memories: user preferences, decisions made, architectural choices,
-  important facts, and corrections. Uses pattern matching for fast
-  extraction without an LLM call.
+  After each user turn, scans the message for extractable memories: user
+  preferences, decisions made, important facts, and corrections. Uses pattern
+  matching for fast extraction without an LLM call.
+
+  ## Precision over recall
+
+  A false positive here is expensive and permanent: junk memories are injected
+  into every future turn's context, where they mislead the agent until a human
+  notices and deletes them. A false negative costs nothing — the agent can
+  always call `memory_save` explicitly.
+
+  Three guards enforce that bias:
+
+    1. `machine_generated?/1` rejects text that is not a human talking —
+       subagent task briefs, injected system context, reviewer prompts. The
+       turn pipeline runs for subagent sessions too, where the "user message"
+       is a machine-authored prompt; without this gate those get stored as
+       user preferences.
+    2. The patterns require an explicit standing-preference phrasing. Bare
+       `I am`, `I need`, `I want` and `actually` are deliberately excluded —
+       they match ordinary task requests ("I need help with this") far more
+       often than durable facts.
+    3. Only the matching SENTENCE is stored, never the whole message, and it
+       must fall within `#{12}..#{300}` characters to qualify.
   """
   require Logger
 
   alias OptimalSystemAgent.Memory
 
-  # Patterns that indicate saveable information
-  @preference_patterns ~r/\b(I prefer|I like|I want|I need|always use|never use|don't use|my preference|I usually|we always|our convention|our pattern|we use)\b/i
-  @decision_patterns ~r/\b(we decided|the decision is|I chose|let's go with|we'll use|the plan is|agreed to|committed to)\b/i
-  @correction_patterns ~r/\b(actually|no,? that's wrong|not like that|I meant|correction:|fix that|that's incorrect|wrong approach)\b/i
+  # A durable fact stated by a human is short. Anything longer is a task
+  # brief, a pasted document, or a system prompt.
+  @max_input_chars 1_500
+  @min_fact_chars 12
+  @max_fact_chars 300
+
+  # Markers of machine-authored text. Matched case-insensitively against the
+  # message. Any hit rejects the whole message.
+  @machine_markers [
+    "you are an ",
+    "you are a ",
+    "your job is to",
+    "[shared scratchpad]",
+    "<system-reminder>",
+    "<task-notification>",
+    "## handoff",
+    "you must not",
+    "do not reveal",
+    "system prompt"
+  ]
+
+  # Patterns that indicate saveable information. Each must express a STANDING
+  # fact, not a one-off request.
+  @preference_patterns ~r/\b(I prefer|I always|I never|always use|never use|don'?t use|my preference is|our convention|we always|we never)\b/i
+  @decision_patterns ~r/\b(we decided|the decision is|I chose|let'?s go with|we'?ll use|agreed to|committed to)\b/i
+  @correction_patterns ~r/\b(no,? that'?s wrong|I meant|correction:|that'?s incorrect|wrong approach|not like that)\b/i
   @fact_patterns ~r/\b(the (password|key|url|endpoint|port|database|schema|table|api) is|credentials are|located at|deployed to|runs on|configured as)\b/i
-  @name_patterns ~r/\b(my name is|I'm called|call me|I am)\b/i
+  @name_patterns ~r/\b(my name is|I'?m called|call me)\b/i
+
+  @patterns [
+    {:preference, @preference_patterns},
+    {:decision, @decision_patterns},
+    {:correction, @correction_patterns},
+    {:fact, @fact_patterns},
+    {:identity, @name_patterns}
+  ]
 
   @doc """
-  Extract memories from a user message. Returns a list of memory entries to save.
-  Called by the save_transcript hook after each turn.
+  Extract memories from a user message. Returns a list of memory entries to
+  save, each holding only the sentence that matched — never the full message.
+
+  Returns `[]` for machine-generated or oversized input.
   """
+  @spec extract(term()) :: [%{type: atom(), content: String.t()}]
   def extract(user_message) when is_binary(user_message) do
-    extractions = []
+    trimmed = String.trim(user_message)
 
-    extractions =
-      if Regex.match?(@preference_patterns, user_message) do
-        [%{type: :preference, content: user_message} | extractions]
-      else
-        extractions
-      end
+    if extractable?(trimmed) do
+      sentences = split_sentences(trimmed)
 
-    extractions =
-      if Regex.match?(@decision_patterns, user_message) do
-        [%{type: :decision, content: user_message} | extractions]
-      else
-        extractions
-      end
-
-    extractions =
-      if Regex.match?(@correction_patterns, user_message) do
-        [%{type: :correction, content: user_message} | extractions]
-      else
-        extractions
-      end
-
-    extractions =
-      if Regex.match?(@fact_patterns, user_message) do
-        [%{type: :fact, content: user_message} | extractions]
-      else
-        extractions
-      end
-
-    extractions =
-      if Regex.match?(@name_patterns, user_message) do
-        [%{type: :identity, content: user_message} | extractions]
-      else
-        extractions
-      end
-
-    extractions
+      @patterns
+      |> Enum.flat_map(fn {type, pattern} ->
+        case first_match(sentences, pattern) do
+          nil -> []
+          sentence -> [%{type: type, content: sentence}]
+        end
+      end)
+    else
+      []
+    end
   end
 
   def extract(_), do: []
 
   @doc """
-  Process extracted memories — deduplicate and save.
-  """
-  def save_extracted(extractions, session_id \\ "auto") do
-    Enum.each(extractions, fn %{type: type, content: content} ->
-      # Truncate to a reasonable size for memory storage
-      key = "[#{type}] #{String.slice(content, 0, 200)}"
+  Process extracted memories — persist each one under its mapped category.
 
+  Returns the number of entries successfully saved (which may be fewer than
+  the number supplied if the store rejects some).
+  """
+  @spec save_extracted([%{type: atom(), content: String.t()}], String.t()) :: non_neg_integer()
+  def save_extracted(extractions, session_id \\ "auto") do
+    Enum.count(extractions, fn %{type: type, content: content} ->
       try do
-        Memory.save(key,
-          category: category_for(type),
-          source: :agent,
-          session_id: session_id,
-          tags: ["auto_extract", to_string(type)]
-        )
+        case Memory.save(content,
+               category: category_for(type),
+               source: :agent,
+               session_id: session_id,
+               tags: ["auto_extract", to_string(type)]
+             ) do
+          {:error, reason} ->
+            Logger.debug("[AutoExtract] store rejected #{type}: #{inspect(reason)}")
+            false
+
+          _ ->
+            true
+        end
       rescue
-        _ -> :ok
+        e ->
+          Logger.debug("[AutoExtract] save failed for #{type}: #{Exception.message(e)}")
+          false
       end
     end)
+  end
 
-    length(extractions)
+  # ---------------------------------------------------------------------------
+  # Internals
+  # ---------------------------------------------------------------------------
+
+  @spec extractable?(String.t()) :: boolean()
+  defp extractable?(""), do: false
+
+  defp extractable?(message) do
+    String.length(message) <= @max_input_chars and not machine_generated?(message)
+  end
+
+  @doc false
+  # Public for testing: the turn pipeline persists subagent turns through the
+  # same path as human turns, so this gate is the only thing standing between
+  # a reviewer prompt and the user's permanent preference list.
+  @spec machine_generated?(String.t()) :: boolean()
+  def machine_generated?(message) do
+    downcased = String.downcase(message)
+    Enum.any?(@machine_markers, &String.contains?(downcased, &1))
+  end
+
+  @spec split_sentences(String.t()) :: [String.t()]
+  defp split_sentences(message) do
+    message
+    |> String.split(~r/(?<=[.!?])\s+|\n+/, trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  @spec first_match([String.t()], Regex.t()) :: String.t() | nil
+  defp first_match(sentences, pattern) do
+    Enum.find(sentences, fn sentence ->
+      Regex.match?(pattern, sentence) and well_sized?(sentence)
+    end)
+  end
+
+  @spec well_sized?(String.t()) :: boolean()
+  defp well_sized?(sentence) do
+    length = String.length(sentence)
+    length >= @min_fact_chars and length <= @max_fact_chars
   end
 
   defp category_for(:preference), do: :preference

--- a/test/optimal_system_agent/memory/auto_extract_test.exs
+++ b/test/optimal_system_agent/memory/auto_extract_test.exs
@@ -1,0 +1,137 @@
+defmodule OptimalSystemAgent.Memory.AutoExtractTest do
+  @moduledoc """
+  Regression tests for memory auto-extraction.
+
+  Every string in the "junk that reached production" block below was found
+  stored as a real user memory in a live `~/.osa/osa.db`, injected into the
+  agent's context on every subsequent turn. They are the specification: if
+  any of these starts extracting again, the pile refills.
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Memory.AutoExtract
+
+  describe "extract/1 rejects junk that reached production" do
+    test "an ordinary task request is not a standing preference" do
+      assert AutoExtract.extract("I need your help with some coding tasks tbh") == []
+    end
+
+    test "a subagent reviewer brief is not a user correction" do
+      brief = """
+      You are an ADVERSARIAL, INDEPENDENT reviewer (skeptic #2, VERIFIABILITY lens)
+      with NO access to how this change was produced. Your job is to try to REFUTE
+      the claim that the goal below was fully achieved.
+      """
+
+      assert AutoExtract.extract(brief) == []
+    end
+
+    test "an injected scratchpad brief is not a user preference" do
+      brief =
+        "[shared scratchpad] You are part of a coordinated team. " <>
+          "A real, shared directory is available at: /Users/rhl/.osa/scratchpad/session-123"
+
+      assert AutoExtract.extract(brief) == []
+    end
+
+    test "'I am' inside a rant does not become an identity memory" do
+      rant =
+        "well rigt now I am getting an alert that I am about to cap the storage " <>
+          "on this computer i legit have 1 terrabyte"
+
+      assert AutoExtract.extract(rant) == []
+    end
+
+    test "'fix that' does not become a correction memory" do
+      assert AutoExtract.extract("are u sure it i dcan u fix tht ?") == []
+    end
+
+    test "a vague question is not a preference" do
+      question =
+        "Well I want for you to check out my file tree. " <>
+          "Tell me what you think about this. Tell me if it's organized right"
+
+      assert AutoExtract.extract(question) == []
+    end
+
+    test "oversized input is rejected outright" do
+      blob = String.duplicate("I always use tabs. ", 200)
+
+      assert String.length(blob) > 1_500
+      assert AutoExtract.extract(blob) == []
+    end
+
+    test "non-binary input is rejected" do
+      assert AutoExtract.extract(nil) == []
+      assert AutoExtract.extract(%{content: "I always use tabs"}) == []
+    end
+
+    test "empty and whitespace-only input is rejected" do
+      assert AutoExtract.extract("") == []
+      assert AutoExtract.extract("   \n  ") == []
+    end
+  end
+
+  describe "extract/1 still captures genuine standing facts" do
+    test "captures an explicit preference" do
+      assert [%{type: :preference, content: content}] =
+               AutoExtract.extract("I always use tabs for indentation in Go.")
+
+      assert content == "I always use tabs for indentation in Go."
+    end
+
+    test "captures a decision" do
+      assert [%{type: :decision, content: content}] =
+               AutoExtract.extract("We decided to use Postgres for the primary store.")
+
+      assert content =~ "Postgres"
+    end
+
+    test "captures a name" do
+      assert [%{type: :identity, content: content}] = AutoExtract.extract("My name is Roberto.")
+      assert content == "My name is Roberto."
+    end
+
+    test "captures a configuration fact" do
+      assert [%{type: :fact, content: content}] =
+               AutoExtract.extract("The database is deployed to us-east-1 on port 5432.")
+
+      assert content =~ "us-east-1"
+    end
+  end
+
+  describe "extract/1 stores only the matching sentence" do
+    test "surrounding chatter is discarded" do
+      message =
+        "Hey, quick thing before we start. I always use tabs for indentation. " <>
+          "Anyway, can you look at the build failure and tell me what broke?"
+
+      assert [%{type: :preference, content: content}] = AutoExtract.extract(message)
+
+      assert content == "I always use tabs for indentation."
+      refute content =~ "build failure"
+      refute content =~ "Hey, quick thing"
+    end
+
+    test "a matching sentence buried in a long message is bounded in size" do
+      message = "Some lead-in. I always use tabs. " <> String.duplicate("filler words here. ", 20)
+
+      assert [%{content: content}] = AutoExtract.extract(message)
+      assert String.length(content) <= 300
+    end
+  end
+
+  describe "machine_generated?/1" do
+    test "flags subagent and system-authored text" do
+      assert AutoExtract.machine_generated?("You are a code-review agent.")
+      assert AutoExtract.machine_generated?("<system-reminder>do the thing</system-reminder>")
+      assert AutoExtract.machine_generated?("Your job is to refute the claim.")
+      assert AutoExtract.machine_generated?("[SHARED SCRATCHPAD] team directory")
+    end
+
+    test "does not flag ordinary human text" do
+      refute AutoExtract.machine_generated?("I always use tabs for indentation.")
+      refute AutoExtract.machine_generated?("can you fix the build please")
+    end
+  end
+end


### PR DESCRIPTION
Auto-extracted memories are injected into every future turn's context, so a
false positive is expensive and permanent - junk memories mislead the agent
until a human notices and deletes them. A false negative costs nothing, since
the agent can always call `memory_save` explicitly. The extractor was tuned the
wrong way round.

## Three guards

1. `machine_generated?/1` rejects text that is not a human talking. The turn
   pipeline also runs for subagent sessions, where the "user message" is a
   machine-authored task brief - those were being stored as user preferences.
2. Patterns now require explicit standing-preference phrasing. Bare `I am`,
   `I need`, `I want` and `actually` are excluded: they match ordinary task
   requests ("I need help with this") far more often than durable facts.
3. Only the matching sentence is stored, never the whole message, and it must
   fall within 12..300 characters.

## Tests

Adds `test/optimal_system_agent/memory/auto_extract_test.exs` - 17 tests,
0 failures.

## Provenance

This work was recovered from a stash left behind by an interrupted
`git stash pop` during an `osa update`. The same stash also contained a
half-finished `ContextEngine.Router` refactor of `loop.ex` and
`turn_pipeline.ex`; that part is deliberately NOT included here, because on top
of v1.0.59 it would remove `handle_cast({:persist_session, …})`, the message-id
finalization, and the real context-window threading. It remains in the stash and
belongs with `feat/pluggable-context-engine-plugins-trajectory`.