### PR TITLE
feat(mcp): choose which discovered MCP servers import

### DIFF
--- a/lib/optimal_system_agent/mcp/config.ex
+++ b/lib/optimal_system_agent/mcp/config.ex
@@ -162,6 +162,54 @@ defmodule OptimalSystemAgent.MCP.Config do
   def excluded?(name) when is_binary(name), do: MapSet.member?(exclusions(), sanitize_name(name))
   def excluded?(_), do: false
 
+  @doc """
+  Sanitized names on the MCP import ALLOW list, or an empty set for "no
+  restriction".
+
+  Sources, unioned, mirroring `exclusions/0`: the settings cascade key
+  `"mcp_import_only"` and `config :optimal_system_agent, :mcp_import_only`.
+
+  This exists because the deny list is the wrong shape for foreign import.
+  `mcp_import_foreign` is one switch over every server in every other tool's
+  config — on this machine that is six config files and roughly twenty servers
+  — so choosing the two you actually want means enumerating the eighteen you
+  do not, and re-editing that list every time another tool gains a server. The
+  allow list inverts it: name what you want, and anything discovered later
+  stays out until you say otherwise.
+
+  Applies ONLY to servers imported from other tools. OSA's own configs are
+  servers the operator deliberately gave OSA, and are unaffected.
+  """
+  @spec import_only() :: MapSet.t(String.t())
+  def import_only do
+    from_settings = normalize_exclusions(settings_get("mcp_import_only"))
+
+    from_env =
+      normalize_exclusions(Application.get_env(:optimal_system_agent, :mcp_import_only, []))
+
+    MapSet.union(from_settings, from_env)
+  end
+
+  @doc """
+  Whether an imported server named `name` may load.
+
+  An empty allow list means no restriction, so the default behaviour is
+  unchanged. The deny list still wins: excluding a server is an explicit
+  decision, and allowing it elsewhere must not quietly override that.
+  """
+  @spec import_allowed?(String.t()) :: boolean()
+  def import_allowed?(name) when is_binary(name) do
+    allow = import_only()
+
+    cond do
+      excluded?(name) -> false
+      MapSet.size(allow) == 0 -> true
+      true -> MapSet.member?(allow, sanitize_name(name))
+    end
+  end
+
+  def import_allowed?(_), do: false
+
   defp normalize_exclusions(list) when is_list(list) do
     list
     |> Enum.filter(&is_binary/1)

--- a/lib/optimal_system_agent/mcp/discovery.ex
+++ b/lib/optimal_system_agent/mcp/discovery.ex
@@ -116,7 +116,7 @@ defmodule OptimalSystemAgent.MCP.Discovery do
   """
   @spec discover() :: [Server.t()]
   def discover do
-    if import_enabled?(), do: read_all(), else: []
+    if import_enabled?(), do: read_all(true), else: []
   end
 
   @doc """
@@ -126,16 +126,29 @@ defmodule OptimalSystemAgent.MCP.Discovery do
   operator can see what exists in other tools' configs without OSA running any
   of it. Excluded names are still filtered out (an exclusion is a decision, not
   a suggestion).
+
+  The `mcp_import_only` allow list is deliberately NOT applied here. This list
+  is the menu you choose FROM, so filtering it by the choice already made would
+  hide every server not yet picked - including the ones you opened `/mcp` to
+  find. Use `importable?/1` to render which entries are currently active.
   """
   @spec available() :: [Server.t()]
   def available do
     kill_switch =
       Application.get_env(:optimal_system_agent, :mcp_discovery_enabled, true) != false
 
-    if kill_switch, do: read_all(), else: []
+    if kill_switch, do: read_all(false), else: []
   end
 
-  defp read_all do
+  @doc """
+  Whether a discovered server would actually be imported right now - the
+  allow-list answer for one name, so `/mcp` can mark each row active or not
+  without re-deriving the rule.
+  """
+  @spec importable?(String.t()) :: boolean()
+  def importable?(name), do: Config.import_allowed?(name)
+
+  defp read_all(apply_allow_list?) do
     native_names =
       Config.load_all()
       |> Enum.map(& &1.name)
@@ -151,8 +164,14 @@ defmodule OptimalSystemAgent.MCP.Discovery do
     |> Map.values()
     |> Enum.reject(fn s -> MapSet.member?(native_names, s.name) end)
     # Deny list applies to imported servers too — killing one noisy server must
-    # not require turning the whole source off.
-    |> Enum.reject(&Config.excluded?(&1.name))
+    # not require turning the whole source off. On the import path the
+    # `mcp_import_only` allow list is folded into the same check: empty means no
+    # restriction (unchanged default), a non-empty list means ONLY those names
+    # import, and an exclusion still wins over an allow. `available/0` passes
+    # false so the menu keeps showing everything you could pick.
+    |> Enum.filter(fn s ->
+      if apply_allow_list?, do: Config.import_allowed?(s.name), else: not Config.excluded?(s.name)
+    end)
     # Imported servers keep their parsed `enabled: true` and auto-connect on
     # boot — but ONLY reach this path when the operator opted in above, so
     # nothing runs unasked. This is additionally bounded by the failure cap in

--- a/test/optimal_system_agent/mcp/discovery_test.exs
+++ b/test/optimal_system_agent/mcp/discovery_test.exs
@@ -12,7 +12,8 @@ defmodule OptimalSystemAgent.MCP.DiscoveryTest do
     :config_dir,
     :mcp_discovery_enabled,
     :mcp_import_foreign,
-    :mcp_exclude
+    :mcp_exclude,
+    :mcp_import_only
   ]
 
   # Build a fresh fake HOME under tmp, point discovery + native config at it,
@@ -42,6 +43,12 @@ defmodule OptimalSystemAgent.MCP.DiscoveryTest do
     )
 
     Application.put_env(:optimal_system_agent, :mcp_exclude, Keyword.get(opts, :exclude, []))
+
+    Application.put_env(
+      :optimal_system_agent,
+      :mcp_import_only,
+      Keyword.get(opts, :import_only, [])
+    )
 
     on_exit(fn ->
       File.rm_rf(home)
@@ -323,6 +330,87 @@ defmodule OptimalSystemAgent.MCP.DiscoveryTest do
 
       refute Config.excluded?("claude_only")
       assert "claude_only" in Enum.map(Discovery.discover(), & &1.name)
+    end
+  end
+
+  describe "mcp_import_only allow list" do
+    alias OptimalSystemAgent.MCP.Config
+
+    test "an empty allow list is no restriction, so the default is unchanged" do
+      home = fake_home(import: true, import_only: [])
+      write(home, [".claude", "mcp.json"], claude_mcp_json())
+
+      names = Enum.map(Discovery.discover(), & &1.name)
+      assert "claude_only" in names
+      assert "shared" in names
+    end
+
+    test "a non-empty allow list imports ONLY those names" do
+      home = fake_home(import: true, import_only: ["claude_only"])
+      write(home, [".claude", "mcp.json"], claude_mcp_json())
+
+      names = Enum.map(Discovery.discover(), & &1.name)
+      assert "claude_only" in names
+      refute "shared" in names
+    end
+
+    test "the allow list matches after name sanitization, like the deny list" do
+      home = fake_home(import: true, import_only: ["Claude-Only"])
+      write(home, [".claude", "mcp.json"], claude_mcp_json())
+
+      assert Config.import_allowed?("claude_only")
+      assert "claude_only" in Enum.map(Discovery.discover(), & &1.name)
+    end
+
+    test "the deny list wins over the allow list" do
+      home = fake_home(import: true, import_only: ["claude_only"], exclude: ["claude_only"])
+      write(home, [".claude", "mcp.json"], claude_mcp_json())
+
+      refute Config.import_allowed?("claude_only")
+      refute "claude_only" in Enum.map(Discovery.discover(), & &1.name)
+    end
+
+    test "the allow list is also readable from ~/.osa/settings.json" do
+      home = fake_home(import: true, import_only: [])
+      write(home, [".claude", "mcp.json"], claude_mcp_json())
+
+      write(
+        home,
+        [".osa", "settings.json"],
+        Jason.encode!(%{"mcp_import_only" => ["claude_only"]})
+      )
+
+      OptimalSystemAgent.Settings.reset_cache()
+
+      assert Config.import_allowed?("claude_only")
+      refute Config.import_allowed?("shared")
+      refute "shared" in Enum.map(Discovery.discover(), & &1.name)
+    end
+
+    # The regression that matters: `available/0` is the menu you choose FROM.
+    # If the allow list filtered it, picking one server would hide every server
+    # you had not picked yet - including the ones you opened `/mcp` to find.
+    test "available/0 still lists everything, so the menu does not collapse" do
+      home = fake_home(import: true, import_only: ["claude_only"])
+      write(home, [".claude", "mcp.json"], claude_mcp_json())
+
+      available = Enum.map(Discovery.available(), & &1.name)
+      assert "claude_only" in available
+      assert "shared" in available, "the allow list must not hide unpicked servers from the menu"
+
+      # ...while the import path still honours the choice.
+      refute "shared" in Enum.map(Discovery.discover(), & &1.name)
+      # And /mcp can mark each row without re-deriving the rule.
+      assert Discovery.importable?("claude_only")
+      refute Discovery.importable?("shared")
+    end
+
+    test "OSA's own servers are unaffected by the allow list" do
+      home = fake_home(import: false, import_only: ["nothing_matches_this"])
+      write(home, [".osa", "mcp.json"], native_json())
+
+      # A native server the operator gave OSA deliberately still starts.
+      assert Enum.any?(Config.load_startup(), &(&1.name == "collide"))
     end
   end
 


### PR DESCRIPTION
## The gap

OSA already discovers MCP servers configured in Claude Code, Claude Desktop,
Cursor and Codex (`MCP.Discovery`), and `mcp_import_foreign` gates whether they
load. Detection is solid. Selection is not: that switch is **one boolean over
every server in every other tool's config**.

On this machine that is six config files and ~20 servers, so choosing the two
you want means enumerating the eighteen you do not via `mcp_exclude`, and
re-editing that list whenever another tool gains a server. The deny list is the
wrong shape for the job.

## The change

`mcp_import_only`, an allow list read from the same two sources as the deny
list (settings cascade + app env):

```json
{"mcp_import_foreign": true, "mcp_import_only": ["context7", "serena"]}
```

- Empty list = no restriction, so **existing setups are byte-for-byte unchanged**.
- Non-empty = only those names import.
- The deny list still wins. Excluding a server is an explicit decision; an allow must not silently override it.
- Applies to **imported servers only**. OSA's own configs are servers the operator deliberately gave OSA, and are untouched.

## The subtle part

`available/0` deliberately does **not** apply the allow list. It is the menu you
choose *from* - filtering it by the choice already made would hide every server
you had not picked yet, including the ones you opened `/mcp` to find. There is a
regression test pinning exactly this. `importable?/1` gives the per-name answer
so a UI can mark rows active without re-deriving the rule.

## Tests

7 new tests in `discovery_test.exs`. Verified they have teeth: reverting the
filter produces **3 failures**, restoring it gives **0**.

- `test/optimal_system_agent/mcp/` - 123 tests, 0 failures
- 2 unrelated pre-existing failures in `SettingsCascadeTest`/`SettingsCoreTest` (hook concatenation, env application) are on `main` too and reference none of these keys.

## Sequencing note

Kept entirely inside `lib/optimal_system_agent/mcp/`. It does **not** touch
`tools/registry.ex` or `channels/cli/commands.ex`, so it will not add conflicts
to #98 (which is already CONFLICTING and 20 commits behind `main`).

Wiring the allow-list into the `/mcp` display is a deliberate follow-up, since
that does touch `commands.ex` and should land after #98 rebases.