### PR TITLE
feat(mcp): make /mcp actually do something — enable/disable from the panel

### DIFF
--- a/lib/optimal_system_agent/channels/http/api/mcp_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/mcp_routes.ex
@@ -36,7 +36,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.MCPRoutes do
   # ── GET / — list configured MCP servers ─────────────────────────────
 
   get "/" do
-    servers =
+    loaded =
       try do
         OptimalSystemAgent.MCP.Client.Manager.list_servers()
         |> Enum.map(&serialize_server/1)
@@ -48,7 +48,39 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.MCPRoutes do
         :exit, _ -> []
       end
 
-    json(conn, 200, %{servers: servers})
+    json(conn, 200, %{servers: loaded ++ offered(loaded)})
+  end
+
+  # ── POST /:name/toggle — turn a discovered server on or off ──────────
+  #
+  # Writes the `mcp_import_only` allow list in USER settings, which is the
+  # same key `MCP.Config.import_allowed?/1` reads. Toggling is only meaningful
+  # for servers inherited from another tool: OSA's own `mcp.json` entries are
+  # ones the operator wrote deliberately, and this endpoint will not silently
+  # rewrite that file.
+  post "/:name/toggle" do
+    name = to_string(name)
+
+    case toggle_import(name) do
+      {:ok, enabled?} ->
+        # Re-read config so the change is live without a restart.
+        _ = safe_reload()
+        json(conn, 200, %{name: name, enabled: enabled?, restart_required: false})
+
+      {:error, :native} ->
+        json_error(
+          conn,
+          409,
+          "native_server",
+          "#{name} is defined in your own ~/.osa/mcp.json — edit that file to change it."
+        )
+
+      {:error, :unknown} ->
+        json_error(conn, 404, "unknown_server", "No discoverable MCP server named #{name}.")
+
+      {:error, reason} ->
+        json_error(conn, 500, "toggle_failed", "Could not update settings: #{inspect(reason)}")
+    end
   end
 
   # ── catch-all ────────────────────────────────────────────────────────
@@ -69,11 +101,103 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.MCPRoutes do
       status: stringify(server[:status]),
       source: stringify(server[:source] || :osa),
       scope: stringify(server[:scope] || :user),
-      tool_count: server[:tool_count] || 0
+      tool_count: server[:tool_count] || 0,
+      # Native entries are the operator's own mcp.json and are not toggleable
+      # from here; imported ones are.
+      toggleable: stringify(server[:source] || :osa) != "osa"
     }
   end
 
   defp serialize_server(_), do: %{}
+
+  # Servers OSA can SEE in another tool's config but is not currently running,
+  # because the `mcp_import_only` allow list does not name them.
+  #
+  # Without these the panel could only ever show what is already on, so there
+  # was nothing to turn ON — the list looked complete while hiding most of the
+  # choices. They are reported with `status: "available"` and `enabled: false`
+  # so a UI can render them as off rather than as broken.
+  defp offered(loaded) do
+    have = MapSet.new(loaded, & &1.name)
+
+    OptimalSystemAgent.MCP.Discovery.available()
+    |> Enum.reject(&MapSet.member?(have, &1.name))
+    |> Enum.map(fn s ->
+      %{
+        name: stringify(s.name),
+        transport: stringify(s.transport),
+        enabled: false,
+        status: "available",
+        source: stringify(s.source || :osa),
+        scope: stringify(s.scope || :user),
+        tool_count: 0,
+        toggleable: true
+      }
+    end)
+  rescue
+    _ -> []
+  catch
+    _, _ -> []
+  end
+
+  # Add or remove `name` from the user-scope `mcp_import_only` allow list.
+  # Returns {:ok, now_enabled?}.
+  defp toggle_import(name) do
+    alias OptimalSystemAgent.MCP.{Config, Discovery}
+
+    native? = Enum.any?(Config.load_all(), &(&1.name == name and (&1.source || :osa) == :osa))
+    known? = Enum.any?(Discovery.available(), &(&1.name == name))
+
+    cond do
+      native? ->
+        {:error, :native}
+
+      not known? ->
+        {:error, :unknown}
+
+      true ->
+        current = current_allow_list()
+
+        # An EMPTY allow list means "no restriction", so everything discovered
+        # is already on. Turning one off from that state has to first make the
+        # list explicit — otherwise removing a name from [] is a no-op and the
+        # toggle would silently do nothing.
+        base =
+          if current == [],
+            do: Enum.map(Discovery.available(), & &1.name),
+            else: current
+
+        {updated, enabled?} =
+          if name in base,
+            do: {List.delete(base, name), false},
+            else: {Enum.sort([name | base]), true}
+
+        case OptimalSystemAgent.Settings.set_user("mcp_import_only", updated) do
+          :ok -> {:ok, enabled?}
+          other -> {:error, other}
+        end
+    end
+  end
+
+  defp current_allow_list do
+    case OptimalSystemAgent.Settings.get_trusted("mcp_import_only") do
+      list when is_list(list) -> Enum.filter(list, &is_binary/1)
+      _ -> []
+    end
+  rescue
+    _ -> []
+  end
+
+  # Re-read config and reconcile running sessions so a toggle takes effect
+  # without a restart. Never allowed to fail the request: the settings write
+  # already succeeded, and reporting an error here would imply it had not.
+  defp safe_reload do
+    OptimalSystemAgent.Tools.Registry.register_mcp_tools()
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
 
   # Stringify atom values (nil-safe) so the TUI never sees raw atoms.
   defp stringify(nil), do: nil

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -912,6 +912,8 @@ impl App {
                             enabled: s.enabled,
                             status: s.status,
                             tool_count: s.tool_count,
+                            source: s.source,
+                            toggleable: s.toggleable,
                         })
                         .collect();
                     self.mcp_servers =

--- a/priv/rust/tui/src/app/handle_dialogs.rs
+++ b/priv/rust/tui/src/app/handle_dialogs.rs
@@ -553,6 +553,27 @@ impl App {
         self.fetch_mcp_servers(false);
     }
 
+    /// Switch an inherited MCP server on or off from the `/mcp` dialog.
+    ///
+    /// The backend edits the `mcp_import_only` allow list and reloads its MCP
+    /// client, so the only thing to do afterwards is refetch. Deliberately no
+    /// optimistic local flip: a server can refuse to start, and a row that
+    /// says "on" while nothing is running is worse than a brief delay. On
+    /// failure we still refetch, so the list falls back to the truth.
+    pub(crate) fn toggle_mcp_server(&mut self, name: String) {
+        let (client, tx) = (self.client.clone(), self.event_tx.clone());
+        tokio::spawn(async move {
+            let _ = client.toggle_mcp_server(&name).await;
+            let ev = match client.get_mcp_servers().await {
+                Ok(r) => crate::event::backend::BackendEvent::McpServersLoaded(Ok(r), true),
+                Err(e) => {
+                    crate::event::backend::BackendEvent::McpServersLoaded(Err(e.to_string()), true)
+                }
+            };
+            let _ = tx.send(crate::event::Event::Backend(ev));
+        });
+    }
+
     /// Shared fetch for both the `/mcp` dialog and the background chip refresh.
     /// `open` routes the result: `true` opens the dialog, `false` only updates
     /// the chip count.

--- a/priv/rust/tui/src/app/update.rs
+++ b/priv/rust/tui/src/app/update.rs
@@ -259,12 +259,18 @@ impl App {
             }
             AppState::Mcp => {
                 use crate::dialogs::mcp_servers::McpServersAction;
-                if matches!(
-                    self.mcp_servers.as_mut().map(|d| d.handle_key(key)),
-                    Some(McpServersAction::Close)
-                ) {
-                    self.mcp_servers = None;
-                    self.exit_overlay();
+                match self.mcp_servers.as_mut().map(|d| d.handle_key(key)) {
+                    Some(McpServersAction::Close) => {
+                        self.mcp_servers = None;
+                        self.exit_overlay();
+                    }
+                    Some(McpServersAction::Toggle(name)) => {
+                        // The backend owns the allow-list edit and reloads the
+                        // client; refetch so the row reflects reality rather
+                        // than an optimistic guess that could disagree with it.
+                        self.toggle_mcp_server(name);
+                    }
+                    _ => {}
                 }
                 false
             }

--- a/priv/rust/tui/src/client/http.rs
+++ b/priv/rust/tui/src/client/http.rs
@@ -355,6 +355,16 @@ impl ApiClient {
         Ok(resp.json().await?)
     }
 
+    /// POST /api/v1/mcp/:name/toggle — flip an inherited server on or off.
+    ///
+    /// The backend owns the allow-list edit (`mcp_import_only` in user
+    /// settings) and reloads the client, so the caller only has to refetch.
+    pub async fn toggle_mcp_server(&self, name: &str) -> Result<()> {
+        let path = format!("/api/v1/mcp/{name}/toggle");
+        let _ = self.post(&path, &serde_json::json!({})).await?;
+        Ok(())
+    }
+
     /// GET /api/v1/cost — spend + token accounting.
     pub async fn get_cost(&self) -> Result<crate::client::types::CostResponse> {
         let resp = self.get("/api/v1/cost").await?;

--- a/priv/rust/tui/src/client/types.rs
+++ b/priv/rust/tui/src/client/types.rs
@@ -70,6 +70,14 @@ pub struct McpServerDto {
     pub status: String,
     #[serde(default)]
     pub tool_count: i64,
+    /// Which tool's config this came from: "osa" for the operator's own
+    /// mcp.json, otherwise the tool it was inherited from.
+    #[serde(default)]
+    pub source: String,
+    /// Whether `/mcp` may switch this server on and off. False for OSA's own
+    /// entries, which are edited in mcp.json rather than through the allow list.
+    #[serde(default)]
+    pub toggleable: bool,
 }
 #[derive(Debug, Clone, Deserialize)]
 pub struct McpServersResponse {

--- a/priv/rust/tui/src/dialogs/mcp_servers.rs
+++ b/priv/rust/tui/src/dialogs/mcp_servers.rs
@@ -34,6 +34,10 @@ pub struct McpServer {
     pub enabled: bool,
     pub status: String,
     pub tool_count: i64,
+    /// Where it came from ("osa" = the operator's own mcp.json).
+    pub source: String,
+    /// Whether space can switch it on/off here.
+    pub toggleable: bool,
 }
 
 /// The full `/mcp` view: the server list plus cursor + scroll state.
@@ -46,10 +50,13 @@ pub struct McpServers {
 }
 
 /// Bubble-up result of `/mcp` key handling.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum McpServersAction {
     /// The overlay should be dismissed.
     Close,
+    /// Switch this server on or off, then refetch. Carries the name rather
+    /// than the row index so the caller is not coupled to sort order.
+    Toggle(String),
     /// Key consumed; keep the overlay open.
     None,
 }
@@ -87,6 +94,17 @@ impl McpServers {
             }
             KeyCode::Home => self.cursor = 0,
             KeyCode::End => self.cursor = last,
+            // Space switches the highlighted server on or off. Only inherited
+            // servers are toggleable: OSA's own mcp.json entries are the
+            // operator's deliberate config and are not rewritten from here, so
+            // the key is a no-op on those rather than a silent failure.
+            KeyCode::Char(' ') | KeyCode::Enter => {
+                if let Some(s) = self.servers.get(self.cursor) {
+                    if s.toggleable {
+                        return McpServersAction::Toggle(s.name.clone());
+                    }
+                }
+            }
             _ => {}
         }
         McpServersAction::None
@@ -133,10 +151,25 @@ impl McpServers {
         // ── header count ────────────────────────────────────────────────────
         let total = self.servers.len();
         let connected = self.connected_count();
-        let header = format!(
-            "{total} server{} ({connected} connected)",
-            if total == 1 { "" } else { "s" }
-        );
+        // "available" rows are servers found in another tool's config that the
+        // allow list does not name yet. Counting them separately answers the
+        // question the old header could not: how many could I turn on?
+        let off = self
+            .servers
+            .iter()
+            .filter(|s| s.status.eq_ignore_ascii_case("available"))
+            .count();
+        let header = if off > 0 {
+            format!(
+                "{} on ({connected} connected) \u{00b7} {off} available to enable",
+                total - off
+            )
+        } else {
+            format!(
+                "{total} server{} ({connected} connected)",
+                if total == 1 { "" } else { "s" }
+            )
+        };
         put(
             frame,
             Paragraph::new(Line::from(Span::styled(
@@ -194,6 +227,11 @@ impl McpServers {
                     Style::default().fg(c.secondary).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(" nav  ", Style::default().fg(c.dim)),
+                Span::styled(
+                    "space",
+                    Style::default().fg(c.secondary).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" enable/disable  ", Style::default().fg(c.dim)),
                 Span::styled(
                     "esc",
                     Style::default().fg(c.secondary).add_modifier(Modifier::BOLD),
@@ -318,11 +356,11 @@ mod mcp_servers_tests {
 
     fn sample() -> Vec<McpServer> {
         vec![
-            McpServer { name: "filesystem".into(), transport: "stdio".into(), enabled: true, status: "connected".into(), tool_count: 12 },
-            McpServer { name: "github".into(), transport: "stdio".into(), enabled: true, status: "connecting".into(), tool_count: 0 },
-            McpServer { name: "postgres".into(), transport: "http".into(), enabled: false, status: "disabled".into(), tool_count: 3 },
-            McpServer { name: "sentry".into(), transport: "sse".into(), enabled: true, status: "error".into(), tool_count: 1 },
-            McpServer { name: "\u{4e2d}\u{6587}\u{670d}\u{52a1}\u{5668}".into(), transport: "\u{20ac}".repeat(40), enabled: true, status: "ready".into(), tool_count: 99 },
+            McpServer { name: "filesystem".into(), transport: "stdio".into(), enabled: true, status: "connected".into(), tool_count: 12, source: "claude_code".into(), toggleable: true },
+            McpServer { name: "github".into(), transport: "stdio".into(), enabled: true, status: "connecting".into(), tool_count: 0, source: "claude_code".into(), toggleable: true },
+            McpServer { name: "postgres".into(), transport: "http".into(), enabled: false, status: "disabled".into(), tool_count: 3, source: "claude_code".into(), toggleable: true },
+            McpServer { name: "sentry".into(), transport: "sse".into(), enabled: true, status: "error".into(), tool_count: 1, source: "claude_code".into(), toggleable: true },
+            McpServer { name: "\u{4e2d}\u{6587}\u{670d}\u{52a1}\u{5668}".into(), transport: "\u{20ac}".repeat(40), enabled: true, status: "ready".into(), tool_count: 99, source: "claude_code".into(), toggleable: true },
         ]
     }
 


### PR DESCRIPTION
## The problem

`/mcp` listed servers and nothing else. Its footer read `↑↓ nav  esc close`
because those were genuinely the only two things it could do.

Worse, it only showed servers **already loaded**, so the ones you had not
enabled were invisible — the list looked complete while hiding most of the
choices. v1.0.65 added the `mcp_import_only` allow list but left editing it to
hand-written JSON.

## Backend

- `GET /api/v1/mcp` also returns discovered-but-not-imported servers as
  `status: "available"`, plus `source` and `toggleable` per row.
- `POST /api/v1/mcp/:name/toggle` edits `mcp_import_only` in user settings and
  reloads the MCP client, so a toggle is live without a restart.

Two details that would otherwise bite:

- **Native servers are refused**, with an explanation, not silently rewritten.
  `~/.osa/mcp.json` is config the operator wrote deliberately.
- **An empty allow list is expanded before removal.** Empty means "no
  restriction", so deleting a name from `[]` is a no-op and the toggle would
  appear to do nothing.

## TUI

- `space`/`enter` toggles the highlighted server; the footer now says so.
- Header separates `N on (M connected)` from `K available to enable`.
- **No optimistic flip.** It refetches, because a server can refuse to start,
  and a row claiming "on" while nothing runs is worse than a brief delay.

## Verified live

```
--- toggle airtable ON ---   {"enabled":true, ...}   allow-list 9 → 10
--- toggle airtable OFF ---  {"enabled":false, ...}  allow-list 10 → 9
--- native ---   409 "sorx is defined in your own ~/.osa/mcp.json"
--- unknown ---  404 "No discoverable MCP server named nope."
```

GET now surfaces 20 servers: 12 running + 8 available to enable (was 12, with
no way to see or reach the other 8).

- `test/optimal_system_agent/mcp/` — 123 tests, 0 failures
- `cargo test --bin osagent mcp_servers` — 5 passed
- `cargo check --all-targets` — clean

## Sequencing

Rebased onto **v1.0.67**. Four files overlapped with that release
(`handle_backend.rs`, `handle_dialogs.rs`, `client/http.rs`, `client/types.rs`)
and the rebase applied with **zero conflicts**; both suites re-run green on top
of it.