### PR TITLE
feat(providers): api.uncensored.com provider with x-api-key auth

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -173,6 +173,7 @@ provider_map = %{
   "hyperbolic" => :hyperbolic,
   "lmstudio" => :lmstudio,
   "llamacpp" => :llamacpp,
+  "uncensored" => :uncensored,
   "miosa" => :miosa,
   "replicate" => :replicate,
   "qwen" => :qwen,
@@ -241,6 +242,7 @@ config :optimal_system_agent,
   hyperbolic_api_key: System.get_env("HYPERBOLIC_API_KEY"),
   lmstudio_api_key: System.get_env("LMSTUDIO_API_KEY"),
   llamacpp_api_key: System.get_env("LLAMACPP_API_KEY"),
+  uncensored_api_key: System.get_env("UNCENSORED_API_KEY"),
   # Bedrock's key mode uses AWS's own variable name rather than a
   # `BEDROCK_API_KEY` of OSA's invention, so a user who already exported it
   # for the AWS CLI or an SDK does not have to export it twice under a second
@@ -269,6 +271,7 @@ config :optimal_system_agent,
   hyperbolic_model: System.get_env("HYPERBOLIC_MODEL"),
   lmstudio_model: System.get_env("LMSTUDIO_MODEL"),
   llamacpp_model: System.get_env("LLAMACPP_MODEL"),
+  uncensored_model: System.get_env("UNCENSORED_MODEL"),
 
   # ── Channel Adapters ────────────────────────────────────────────────
   # WhatsApp (Baileys bridge sidecar)
@@ -449,6 +452,9 @@ config :optimal_system_agent,
 
          :llamacpp ->
            System.get_env("LLAMACPP_MODEL")
+
+         :uncensored ->
+           System.get_env("UNCENSORED_MODEL")
 
          _ ->
            nil

--- a/desktop/src/lib/components/tasks/ScheduledTaskList.svelte
+++ b/desktop/src/lib/components/tasks/ScheduledTaskList.svelte
@@ -1,0 +1,280 @@
+<script lang="ts">
+  import { slide } from 'svelte/transition';
+  import { scheduledTasksStore } from '$lib/stores/scheduledTasks.svelte';
+  import ScheduledTaskCard from '$lib/components/tasks/ScheduledTaskCard.svelte';
+  import ScheduledTaskForm from '$lib/components/tasks/ScheduledTaskForm.svelte';
+  import type { ScheduledTask } from '$lib/stores/scheduledTasks.svelte';
+
+  // ── Types ─────────────────────────────────────────────────────────────────
+
+  type FilterTab = 'all' | 'active' | 'paused' | 'failed';
+
+  const FILTERS: { id: FilterTab; label: string }[] = [
+    { id: 'all',    label: 'All'    },
+    { id: 'active', label: 'Active' },
+    { id: 'paused', label: 'Paused' },
+    { id: 'failed', label: 'Failed' },
+  ];
+
+  // ── Props ──────────────────────────────────────────────────────────────────
+
+  interface Props {
+    showForm: boolean;
+    onCloseForm: () => void;
+    onOpenNewForm: () => void;
+    onPause: (id: string) => void;
+    onResume: (id: string) => void;
+    onDelete: (id: string) => void;
+    onEdit: (id: string) => void;
+    onRunNow: (id: string) => void;
+    onSubmit: (payload: Parameters<typeof scheduledTasksStore.createTask>[0]) => void;
+    editingTask: ScheduledTask | null;
+  }
+
+  let {
+    showForm,
+    onCloseForm,
+    onOpenNewForm,
+    onPause,
+    onResume,
+    onDelete,
+    onEdit,
+    onRunNow,
+    onSubmit,
+    editingTask,
+  }: Props = $props();
+
+  // ── State ──────────────────────────────────────────────────────────────────
+
+  let activeFilter = $state<FilterTab>('all');
+
+  // ── Derived ───────────────────────────────────────────────────────────────
+
+  let visibleTasks = $derived(
+    activeFilter === 'all'
+      ? scheduledTasksStore.tasks
+      : scheduledTasksStore.tasks.filter((t) => t.status === activeFilter),
+  );
+
+  function countFor(tab: FilterTab): number {
+    if (tab === 'all') return scheduledTasksStore.tasks.length;
+    return scheduledTasksStore.tasks.filter((t) => t.status === tab).length;
+  }
+</script>
+
+<!-- Filter tabs -->
+<nav class="stl-filter-nav" aria-label="Filter scheduled tasks by status">
+  {#each FILTERS as tab}
+    <button
+      class="stl-filter-tab"
+      class:stl-filter-tab--active={activeFilter === tab.id}
+      onclick={() => { activeFilter = tab.id; }}
+      aria-pressed={activeFilter === tab.id}
+      aria-label="Show {tab.label.toLowerCase()} tasks"
+    >
+      {tab.label}
+      {#if countFor(tab.id) > 0}
+        <span class="stl-filter-count" aria-hidden="true">{countFor(tab.id)}</span>
+      {/if}
+    </button>
+  {/each}
+</nav>
+
+<!-- Inline form -->
+{#if showForm}
+  <div transition:slide={{ duration: 180 }} class="stl-form-wrapper">
+    <ScheduledTaskForm
+      task={editingTask}
+      onSubmit={onSubmit}
+      onCancel={onCloseForm}
+    />
+  </div>
+{/if}
+
+<!-- Loading -->
+{#if scheduledTasksStore.loading && scheduledTasksStore.tasks.length === 0}
+  <div class="stl-empty" role="status" aria-label="Loading tasks">
+    <span class="stl-spinner" aria-hidden="true"></span>
+    <p class="stl-empty-title">Loading tasks</p>
+  </div>
+
+<!-- Empty -->
+{:else if visibleTasks.length === 0}
+  <div class="stl-empty" role="status">
+    <div class="stl-empty-icon" aria-hidden="true">
+      <svg width="44" height="44" viewBox="0 0 44 44" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="6" y="8" width="32" height="28" rx="4" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.3"/>
+        <circle cx="22" cy="22" r="7" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.5"/>
+        <line x1="22" y1="15" x2="22" y2="22" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+        <line x1="22" y1="22" x2="26" y2="25" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+      </svg>
+    </div>
+    {#if activeFilter === 'all'}
+      <p class="stl-empty-title">No scheduled tasks</p>
+      <p class="stl-empty-subtitle">
+        Create a task to automate recurring jobs using cron expressions.
+      </p>
+      <button class="stl-empty-cta" onclick={onOpenNewForm} aria-label="Create first scheduled task">
+        Create your first task
+      </button>
+    {:else}
+      <p class="stl-empty-title">No {activeFilter} tasks</p>
+      <p class="stl-empty-subtitle">No tasks match the "{activeFilter}" filter.</p>
+    {/if}
+  </div>
+
+<!-- Task list -->
+{:else}
+  <div class="stl-task-list" role="list" aria-label="Scheduled tasks">
+    {#each visibleTasks as task (task.id)}
+      <div role="listitem">
+        <ScheduledTaskCard
+          {task}
+          onPause={onPause}
+          onResume={onResume}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          onRunNow={onRunNow}
+        />
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  /* ── Filter nav ──────────────────────────────────────────────────────────── */
+  .stl-filter-nav {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-bottom: 4px;
+  }
+
+  .stl-filter-tab {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border-radius: var(--radius-sm);
+    background: none;
+    border: 1px solid transparent;
+    color: var(--text-tertiary);
+    font-size: 0.75rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+  }
+
+  .stl-filter-tab:hover:not(.stl-filter-tab--active) {
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  .stl-filter-tab--active {
+    color: var(--text-primary);
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
+  .stl-filter-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 5px;
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-full);
+    font-size: 0.625rem;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stl-filter-tab--active .stl-filter-count {
+    background: rgba(255, 255, 255, 0.12);
+    color: var(--text-secondary);
+  }
+
+  /* ── Form wrapper ────────────────────────────────────────────────────────── */
+  .stl-form-wrapper {
+    margin-bottom: 4px;
+  }
+
+  /* ── Task list ───────────────────────────────────────────────────────────── */
+  .stl-task-list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    align-content: start;
+  }
+
+  @media (max-width: 720px) {
+    .stl-task-list { grid-template-columns: 1fr; }
+  }
+
+  /* ── Empty state ─────────────────────────────────────────────────────────── */
+  .stl-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 300px;
+    gap: 10px;
+    color: var(--text-tertiary);
+    text-align: center;
+    padding: 48px 32px;
+  }
+
+  .stl-empty-icon {
+    color: rgba(255, 255, 255, 0.1);
+    margin-bottom: 8px;
+  }
+
+  .stl-empty-title {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  .stl-empty-subtitle {
+    font-size: 0.8125rem;
+    color: var(--text-tertiary);
+    max-width: 300px;
+    line-height: 1.55;
+  }
+
+  .stl-empty-cta {
+    margin-top: 8px;
+    padding: 8px 20px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .stl-empty-cta:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  /* ── Loading spinner ─────────────────────────────────────────────────────── */
+  .stl-spinner {
+    display: block;
+    width: 16px;
+    height: 16px;
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    border-top-color: rgba(255, 255, 255, 0.4);
+    border-radius: 50%;
+    animation: stl-spin 0.8s linear infinite;
+    margin-bottom: 4px;
+  }
+
+  @keyframes stl-spin {
+    to { transform: rotate(360deg); }
+  }
+</style>

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -35,6 +35,7 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     "new" => {"Start a new session (alias for /clear)", :cmd_clear},
     "compact" => {"Force context compaction", :cmd_compact},
     "model" => {"Show or switch the current model", :cmd_model},
+    "uncensored" => {"Hop the current model to its unfiltered twin (off to return)", :cmd_uncensored},
     "status" => {"Show session status", :cmd_status},
     "cost" => {"Show cost breakdown", :cmd_cost},
     "usage" => {"Show account quota and this session's token usage", :cmd_usage},
@@ -328,6 +329,111 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     _ ->
       IO.puts("  #{@yellow}error: model switch failed#{@reset}\n")
       session_id
+  end
+
+  # `/uncensored` — api.uncensored.com serves the SAME model ids OSA already
+  # uses (`claude-opus-5`, `grok-4-6`, `gpt-5.6-sol`), so the useful default is
+  # not "pick a model" but "keep this model, drop the filter": hop the current
+  # model id to the uncensored provider and remember where we came from.
+  #
+  #   /uncensored          hop the current model across, if it exists there
+  #   /uncensored <model>  switch to a specific uncensored model
+  #   /uncensored off      go back to the provider/model we came from
+  #   /uncensored list     show the advertised models
+  def cmd_uncensored(args, session_id) do
+    IO.puts("")
+
+    result =
+      case String.trim(args) do
+        arg when arg in ["off", "back", "return"] -> :restore
+        arg when arg in ["list", "models"] -> :list
+        "" -> :hop
+        model -> {:switch, model}
+      end
+
+    case result do
+      :list ->
+        IO.puts("  #{@bold}Uncensored models#{@reset}")
+
+        for m <- OptimalSystemAgent.Providers.OpenAICompatProvider.available_models(:uncensored) do
+          IO.puts("  #{@dim}•#{@reset} #{m}")
+        end
+
+        IO.puts("")
+        IO.puts("  #{@dim}Full live list: GET https://api.uncensored.com/api/v1/models#{@reset}")
+
+      :restore ->
+        case Application.get_env(:optimal_system_agent, :uncensored_previous) do
+          {prov, model} ->
+            Application.delete_env(:optimal_system_agent, :uncensored_previous)
+            swap_to(prov, model, session_id)
+
+          _ ->
+            IO.puts("  #{@yellow}nothing to go back to#{@reset}")
+        end
+
+      :hop ->
+        provider = Application.get_env(:optimal_system_agent, :default_provider, :unknown)
+        model = get_model_name(provider)
+
+        cond do
+          provider == :uncensored ->
+            IO.puts("  #{@dim}already on uncensored (#{model}) — /uncensored off to return#{@reset}")
+
+          model in OptimalSystemAgent.Providers.OpenAICompatProvider.available_models(:uncensored) ->
+            Application.put_env(:optimal_system_agent, :uncensored_previous, {provider, model})
+            IO.puts("  #{@dim}#{model} has an unfiltered twin — hopping#{@reset}")
+            swap_to(:uncensored, model, session_id)
+
+          true ->
+            IO.puts("  #{@yellow}no unfiltered twin for #{model}#{@reset}")
+            IO.puts("  #{@dim}/uncensored list to see what is available#{@reset}")
+        end
+
+      {:switch, model} ->
+        provider = Application.get_env(:optimal_system_agent, :default_provider, :unknown)
+
+        if provider != :uncensored do
+          Application.put_env(
+            :optimal_system_agent,
+            :uncensored_previous,
+            {provider, get_model_name(provider)}
+          )
+        end
+
+        swap_to(:uncensored, model, session_id)
+    end
+
+    IO.puts("")
+    session_id
+  rescue
+    _ ->
+      IO.puts("  #{@yellow}error: uncensored switch failed#{@reset}\n")
+      session_id
+  end
+
+  # Shared tail of /model and /uncensored: ask the session to swap and report.
+  defp swap_to(provider, model, session_id) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, session_id) do
+      [{pid, _}] ->
+        case GenServer.call(pid, {:swap_provider, provider, model}) do
+          {:ok, info} ->
+            ctx = ProviderRegistry.effective_context_window(info.model, info.provider)
+
+            IO.puts(
+              "  #{@green}#{@reset} Switched to #{info.model} #{@dim}(#{info.provider}, #{format_context_window(ctx)} ctx)#{@reset}"
+            )
+
+          {:error, reason} ->
+            IO.puts("  #{@yellow}error: #{reason}#{@reset}")
+
+          :ok ->
+            IO.puts("  #{@green}#{@reset} Switched to #{model}")
+        end
+
+      _ ->
+        IO.puts("  #{@yellow}error: session not found#{@reset}")
+    end
   end
 
   def cmd_status(_args, session_id) do

--- a/lib/optimal_system_agent/providers/openai_compat.ex
+++ b/lib/optimal_system_agent/providers/openai_compat.ex
@@ -80,13 +80,7 @@ defmodule OptimalSystemAgent.Providers.OpenAICompat do
     # by the thing written to report it.
     cache_fp = CacheAttribution.fingerprint(body)
 
-    extra_headers = Keyword.get(opts, :extra_headers, [])
-
-    headers =
-      [
-        {"Authorization", "Bearer #{api_key}"},
-        {"Content-Type", "application/json"}
-      ] ++ extra_headers
+    headers = build_headers(api_key, opts)
 
     url = "#{base_url}/chat/completions"
     # Reasoning models (o3, deepseek-reasoner, etc.) need 300+ s for chain-of-thought
@@ -302,6 +296,23 @@ defmodule OptimalSystemAgent.Providers.OpenAICompat do
 
   def prompt_cache_key_host?(_), do: false
 
+  # Auth header shape differs by provider. Default is the OpenAI convention,
+  # `Authorization: Bearer <key>`; a provider config may set `auth_style:
+  # :x_api_key` to send `x-api-key: <key>` instead (api.uncensored.com reads
+  # only that header and ignores a Bearer token entirely).
+  @doc false
+  # Public only so the auth-style matrix can be asserted directly; see
+  # test/providers/uncensored_provider_test.exs.
+  def build_headers(api_key, opts) do
+    auth =
+      case Keyword.get(opts, :auth_style, :bearer) do
+        :x_api_key -> [{"x-api-key", api_key}]
+        _ -> [{"Authorization", "Bearer #{api_key}"}]
+      end
+
+    auth ++ [{"Content-Type", "application/json"}] ++ Keyword.get(opts, :extra_headers, [])
+  end
+
   defp do_chat_stream(base_url, api_key, model, messages, callback, opts) do
     body = build_stream_body(model, messages, opts, base_url)
 
@@ -310,13 +321,7 @@ defmodule OptimalSystemAgent.Providers.OpenAICompat do
     # measured route dark even after wiring `do_chat/5`.
     cache_fp = CacheAttribution.fingerprint(body)
 
-    extra_headers = Keyword.get(opts, :extra_headers, [])
-
-    headers =
-      [
-        {"Authorization", "Bearer #{api_key}"},
-        {"Content-Type", "application/json"}
-      ] ++ extra_headers
+    headers = build_headers(api_key, opts)
 
     url = "#{base_url}/chat/completions"
     timeout = Keyword.get(opts, :receive_timeout, 600_000)

--- a/lib/optimal_system_agent/providers/openai_compat_provider.ex
+++ b/lib/optimal_system_agent/providers/openai_compat_provider.ex
@@ -177,6 +177,40 @@ defmodule OptimalSystemAgent.Providers.OpenAICompatProvider do
       default_url: "https://api.hyperbolic.xyz/v1",
       default_model: "meta-llama/Llama-3.3-70B-Instruct"
     },
+    # api.uncensored.com — an OpenAI chat-completions gateway fronting ~82
+    # frontier models with the refusal behaviour trained out. Two quirks that
+    # the rest of this table does not have:
+    #
+    #   * auth is `x-api-key`, NOT `Authorization: Bearer`. A Bearer token is
+    #     not merely rejected, it is ignored — the API answers exactly as it
+    #     does for an unauthenticated call, so a Bearer-only client fails with
+    #     a misleading "invalid key" and no hint that the header was wrong.
+    #   * the base URL carries an `/api` segment before `/v1`.
+    #
+    # Model IDs are the provider's own and do not match upstream vendor naming
+    # (`claude-opus-5`, not `claude-opus-5-20260219`). The live list is public
+    # and needs no key: GET https://api.uncensored.com/api/v1/models
+    uncensored: %{
+      default_url: "https://api.uncensored.com/api/v1",
+      default_model: "claude-opus-5",
+      auth_style: :x_api_key,
+      available_models: [
+        "claude-opus-5",
+        "claude-opus-4.8",
+        "claude-sonnet-4.6",
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gemini-3.1-pro-preview",
+        "grok-4-6",
+        "grok-4.5",
+        "kimi-k3",
+        "deepseek-v4-pro",
+        "glm-5.2",
+        "qwen3-coder",
+        "hermes-3-llama-3.1-405b"
+      ]
+    },
+
     # LM Studio — local, OpenAI-compatible server (no key needed)
     lmstudio: %{
       default_url: "http://localhost:1234/v1",
@@ -295,6 +329,9 @@ defmodule OptimalSystemAgent.Providers.OpenAICompatProvider do
   @spec keyless?(atom()) :: boolean()
   def keyless?(provider), do: Map.get(get_config!(provider), :keyless, false)
 
+  @doc "Auth header convention for a provider — `:bearer` unless it says otherwise."
+  def auth_style(provider), do: Map.get(get_config!(provider), :auth_style, :bearer)
+
   @doc false
   # Test/introspection seam for the private `resolve_api_key/2` — lets the
   # live-fallback resolution (P2/P3: Application snapshot → System.get_env →
@@ -323,6 +360,7 @@ defmodule OptimalSystemAgent.Providers.OpenAICompatProvider do
         # that knows the answer, so it says it.
         |> Keyword.put(:provider, provider)
         |> maybe_add_headers(config)
+        |> maybe_add_auth_style(config)
         |> maybe_extend_timeout(model)
 
       messages = demote_non_leading_system(messages)
@@ -363,6 +401,7 @@ defmodule OptimalSystemAgent.Providers.OpenAICompatProvider do
         # that knows the answer, so it says it.
         |> Keyword.put(:provider, provider)
         |> maybe_add_headers(config)
+        |> maybe_add_auth_style(config)
         |> maybe_extend_timeout(model)
 
       result =
@@ -561,6 +600,12 @@ defmodule OptimalSystemAgent.Providers.OpenAICompatProvider do
     do: Keyword.put(opts, :extra_headers, headers)
 
   defp maybe_add_headers(opts, _config), do: opts
+
+  # Providers that authenticate with something other than a Bearer token say so
+  # in their config; everything else keeps the OpenAI default in OpenAICompat.
+  defp maybe_add_auth_style(opts, %{auth_style: style}), do: Keyword.put(opts, :auth_style, style)
+
+  defp maybe_add_auth_style(opts, _config), do: opts
 
   # Reasoning models (o3, deepseek-reasoner, kimi) need 600s timeout
   defp maybe_extend_timeout(opts, model) do

--- a/lib/optimal_system_agent/providers/registry.ex
+++ b/lib/optimal_system_agent/providers/registry.ex
@@ -112,6 +112,7 @@ defmodule OptimalSystemAgent.Providers.Registry do
                  cerebras: {:compat, :cerebras},
                  sambanova: {:compat, :sambanova},
                  hyperbolic: {:compat, :hyperbolic},
+                 uncensored: {:compat, :uncensored},
                  lmstudio: {:compat, :lmstudio},
                  llamacpp: {:compat, :llamacpp},
 

--- a/test/providers/uncensored_provider_test.exs
+++ b/test/providers/uncensored_provider_test.exs
@@ -1,0 +1,75 @@
+defmodule OptimalSystemAgent.Providers.UncensoredProviderTest do
+  @moduledoc """
+  Locks in the `uncensored` provider wiring.
+
+  The interesting property is the auth header. api.uncensored.com reads
+  `x-api-key` and ignores `Authorization: Bearer` — and it ignores it
+  *silently*, answering a Bearer-authenticated call exactly as it answers an
+  unauthenticated one. A regression here would therefore not look like an auth
+  bug, it would look like the user's key being invalid, so it is worth a test.
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Providers.OpenAICompat
+  alias OptimalSystemAgent.Providers.OpenAICompatProvider
+  alias OptimalSystemAgent.Providers.Registry
+
+  describe "build_headers/2 auth style" do
+    test "defaults to the OpenAI Bearer convention" do
+      headers = OpenAICompat.build_headers("sk-abc", [])
+
+      assert {"Authorization", "Bearer sk-abc"} in headers
+      refute Enum.any?(headers, fn {k, _} -> k == "x-api-key" end)
+    end
+
+    test "an unknown auth style falls back to Bearer rather than sending nothing" do
+      headers = OpenAICompat.build_headers("sk-abc", auth_style: :something_new)
+
+      assert {"Authorization", "Bearer sk-abc"} in headers
+    end
+
+    test ":x_api_key sends x-api-key and no Authorization header at all" do
+      headers = OpenAICompat.build_headers("sk-abc", auth_style: :x_api_key)
+
+      assert {"x-api-key", "sk-abc"} in headers
+      refute Enum.any?(headers, fn {k, _} -> k == "Authorization" end)
+    end
+
+    test "content-type and extra_headers survive both auth styles" do
+      for style <- [:bearer, :x_api_key] do
+        headers =
+          OpenAICompat.build_headers("sk-abc",
+            auth_style: style,
+            extra_headers: [{"X-Title", "OSA"}]
+          )
+
+        assert {"Content-Type", "application/json"} in headers
+        assert {"X-Title", "OSA"} in headers
+      end
+    end
+  end
+
+  describe "provider config" do
+    test "uncensored is registered and routes through the compat provider" do
+      assert :uncensored in Registry.list_providers()
+      assert :uncensored in OpenAICompatProvider.providers()
+    end
+
+    test "carries the x-api-key auth style and the /api/v1 base URL" do
+      assert OpenAICompatProvider.auth_style(:uncensored) == :x_api_key
+      assert OpenAICompatProvider.base_url(:uncensored) == "https://api.uncensored.com/api/v1"
+    end
+
+    test "the default model is one of the advertised models" do
+      assert OpenAICompatProvider.default_model(:uncensored) in
+               OpenAICompatProvider.available_models(:uncensored)
+    end
+
+    test "no other compat provider was switched off Bearer by this change" do
+      for provider <- OpenAICompatProvider.providers(), provider != :uncensored do
+        assert OpenAICompatProvider.auth_style(provider) == :bearer,
+               "#{provider} unexpectedly changed auth style"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `api.uncensored.com` as an OpenAI-compatible provider, plus the `/uncensored` command.

Recovered from a stash that failed to reapply during `osa update` to v1.0.99 - the conflict in `openai_compat.ex` was upstream's `CacheAttribution.fingerprint/1` landing on the same lines as this branch's header refactor. Both are kept: the fingerprint still runs after every body transform, headers now come from `build_headers/2`.

## The one thing that is not boilerplate

The gateway authenticates with `x-api-key`, not `Authorization: Bearer`. The failure mode is quiet: a Bearer token is not rejected, it is **ignored** - the API answers exactly as it does for an unauthenticated call. A Bearer-only client reports "invalid key" and gives no hint that the header itself was wrong.

So auth header shape moves into provider config:

- `OpenAICompat.build_headers/2` reads `auth_style` (`:bearer` default, `:x_api_key` opt-in)
- both the sync and the streaming path now build headers through it - each previously inlined its own list, which is how the two could have drifted

## /uncensored

The gateway serves the same model ids OSA already uses (`claude-opus-5`, `grok-4-6`, `gpt-5.6-sol`), so the useful default is not "pick a model" but "keep this model, drop the filter".

```
/uncensored          hop the current model across, if it exists there
/uncensored <model>  switch to a specific uncensored model
/uncensored off      go back to where we came from
/uncensored list     show advertised models
```

## Second commit, unrelated but blocking

`desktop/src/routes/app/tasks/+page.svelte` has imported `ScheduledTaskList.svelte` since the god-file split (e4532670), but the component was never committed - it only ever existed in a working tree. A clean checkout hits an unresolved import. Committed as-is.

## Verification

- `MIX_ENV=prod mix compile` - `Generated optimal_system_agent app`, no new warnings
- `mix test test/providers/uncensored_provider_test.exs` - 8 tests, 0 failures (asserts the auth-style matrix directly, since a wrong header here fails silently rather than loudly)

Not included: `lib/mix/tasks/probe.serve.ex`, a local debug scratch task, left untracked.