### PR TITLE
fix(harness): stop first-meet loops and explorer nests

### DIFF
--- a/lib/optimal_system_agent/agent/context.ex
+++ b/lib/optimal_system_agent/agent/context.ex
@@ -1283,10 +1283,26 @@ defmodule OptimalSystemAgent.Agent.Context do
     end
   end
 
-  # True once USER.md has a name filled in (not the blank template).
-  defp user_known?(dir) do
+  # Completion signal for the first-meet ritual. A free-form "they're called X"
+  # note does NOT match — only the USER.md template line the seed writes:
+  # `- **Name:** Roberto`. Doctor and Onboarding.seed_workspace/0 must use this
+  # same check; a private copy is how known users get asked their name again.
+  @user_known_re ~r/-\s*\*\*Name:\*\*\s*\S+/
+
+  @doc "The regex `user_known?/1` applies to USER.md."
+  @spec user_known_regex() :: Regex.t()
+  def user_known_regex, do: @user_known_re
+
+  @doc """
+  True once `USER.md` in `dir` has a filled `- **Name:** …` line.
+
+  Missing or unreadable USER.md is unknown. The blank template
+  (`- **Name:**` with nothing after) is unknown.
+  """
+  @spec user_known?(Path.t()) :: boolean()
+  def user_known?(dir) do
     case File.read(Path.join(dir, "USER.md")) do
-      {:ok, content} -> Regex.match?(~r/-\s*\*\*Name:\*\*\s*\S+/, content)
+      {:ok, content} -> Regex.match?(@user_known_re, content)
       {:error, _} -> false
     end
   end

--- a/lib/optimal_system_agent/agent/loop.ex
+++ b/lib/optimal_system_agent/agent/loop.ex
@@ -1039,6 +1039,7 @@ defmodule OptimalSystemAgent.Agent.Loop do
         all_tools
         |> ToolFilter.filter_for_coordinator(coordinator?)
         |> AskUserMode.filter_tools(ask_user_enabled?)
+        |> ToolFilter.filter_for_role_allowlist(Keyword.get(opts, :allowed_tools))
         |> ToolFilter.filter_for_env_allowlist(),
       all_tools: all_tools,
       coordinator: coordinator?,
@@ -1510,9 +1511,7 @@ defmodule OptimalSystemAgent.Agent.Loop do
   # is also read by Agent.Context to inject the "Mode: coordinator" system note.
   def handle_call({:set_coordinator, on?}, _from, state) when is_boolean(on?) do
     tools =
-      state.all_tools
-      |> ToolFilter.filter_for_coordinator(on?)
-      |> AskUserMode.filter_tools(state.ask_user_enabled)
+      rebuild_advertised_tools(state, coordinator: on?, ask_user_enabled: state.ask_user_enabled)
 
     {:reply, {:ok, on?}, %{state | coordinator: on?, tools: tools}}
   end
@@ -1527,9 +1526,7 @@ defmodule OptimalSystemAgent.Agent.Loop do
   # cost (a single prompt-cache re-prime) is named in the reply text.
   def handle_call({:set_ask_user, on?}, _from, state) when is_boolean(on?) do
     tools =
-      state.all_tools
-      |> ToolFilter.filter_for_coordinator(state.coordinator)
-      |> AskUserMode.filter_tools(on?)
+      rebuild_advertised_tools(state, coordinator: state.coordinator, ask_user_enabled: on?)
 
     {:reply, {:ok, on?}, %{state | ask_user_enabled: on?, tools: tools}}
   end
@@ -1544,6 +1541,16 @@ defmodule OptimalSystemAgent.Agent.Loop do
 
   def handle_call(:get_strategy, _from, state) do
     {:reply, {:ok, :none, %{}}, state}
+  end
+
+  # Mid-session toggles must keep the role allowlist. Rebuilding from
+  # `all_tools` without it is how an explorer would get `delegate` back.
+  defp rebuild_advertised_tools(state, coordinator: coordinator?, ask_user_enabled: ask?) do
+    state.all_tools
+    |> ToolFilter.filter_for_coordinator(coordinator?)
+    |> AskUserMode.filter_tools(ask?)
+    |> ToolFilter.filter_for_role_allowlist(state.allowed_tools)
+    |> ToolFilter.filter_for_env_allowlist()
   end
 
   # Durable session save, serialized by THIS process' mailbox.

--- a/lib/optimal_system_agent/agent/loop/tool_filter.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_filter.ex
@@ -129,6 +129,23 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilter do
   end
 
   @doc """
+  Restrict the ADVERTISED tool array to a role's `tools_allowed`.
+
+  `state.allowed_tools` used to gate EXECUTION only. An explore/explorer
+  child still saw `delegate` and spawned another explorer — the nest that
+  never STOPs. This pass is what makes the role file true at prompt time.
+
+  `nil` or `[]` means unrestricted (parent session / generic agent).
+  Applied at session start next to the coordinator and env-allowlist gates.
+  """
+  @spec filter_for_role_allowlist(list(), [String.t()] | nil) :: list()
+  def filter_for_role_allowlist(tools, allowed) when is_list(allowed) and allowed != [] do
+    Enum.filter(tools, fn t -> tool_name(t) in allowed end)
+  end
+
+  def filter_for_role_allowlist(tools, _), do: tools
+
+  @doc """
   Restrict the tool list to coordinator-mode tools (delegation, messaging, and
   management) when `coordinator?` is true; otherwise return `tools` unchanged.
 
@@ -151,9 +168,8 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilter do
 
   Inert when the variable is unset or empty, which is every non-experimental
   run. It exists because there was no other way to vary the tool surface:
-  `state.allowed_tools` gates EXECUTION only (`subagent_tool_allowed?/2`), so
-  it leaves every schema in the request and measures nothing about what
-  advertising a tool costs. `:lite` is a SYSTEM-PROMPT variant and likewise
+  Role allowlists now also shrink the advertised set via
+  `filter_for_role_allowlist/2`. This env gate is the experimental override. `:lite` is a SYSTEM-PROMPT variant and likewise
   does not remove a tool from the array a native-tool provider receives.
 
   Applied once at session start, next to the coordinator and ask_user gates,

--- a/lib/optimal_system_agent/cli/doctor/inspection.ex
+++ b/lib/optimal_system_agent/cli/doctor/inspection.ex
@@ -29,10 +29,8 @@ defmodule OptimalSystemAgent.CLI.Doctor.Inspection do
   hot path, so it re-stats files rather than trusting a cache: a report that
   agrees with a stale cache instead of the disk would defeat its own purpose.
 
-  Where a gate is private (`Agent.Context`'s `user_known?/1`, the BOOTSTRAP.md
-  switch) the condition is re-evaluated here against the same file and the same
-  regex, and labelled as a mirror. That is a real duplication risk and it is
-  named rather than hidden — see `mirrors_private_gate?/0`.
+  Where a gate is private (`Agent.Context`'s `user_known?/1` used to be)
+  the condition is now delegated to that function rather than re-implemented.
 
   ## Reporting rules
 
@@ -45,15 +43,25 @@ defmodule OptimalSystemAgent.CLI.Doctor.Inspection do
       "not there". Those need opposite fixes and used to look identical.
   """
 
+  alias OptimalSystemAgent.Agent.Context
   alias OptimalSystemAgent.Settings
   alias OptimalSystemAgent.Tools.Registry.SkillLoader
 
   @app :optimal_system_agent
   @separator "────────────────────────────────────────────────────────────"
 
-  # Mirrors `Agent.Context`'s private `user_known?/1`. Kept adjacent to the
-  # comment that says so, so the coupling is visible at the point of use.
-  @user_known_re ~r/-\s*\*\*Name:\*\*\s*\S+/
+  @doc """
+  Kept so existing `osa doctor --config` tests still compile.
+
+  The BOOTSTRAP.md gate is no longer a private copy — `user_known_regex/0`
+  and `user_known?/1` now come from `Agent.Context`.
+  """
+  @spec mirrors_private_gate?() :: boolean()
+  def mirrors_private_gate?, do: false
+
+  @doc "The regex `Agent.Context.user_known?/1` uses to decide the BOOTSTRAP.md gate."
+  @spec user_known_regex() :: Regex.t()
+  def user_known_regex, do: Context.user_known_regex()
 
   @doc "Print the full inspection report."
   @spec run() :: :ok
@@ -125,20 +133,6 @@ defmodule OptimalSystemAgent.CLI.Doctor.Inspection do
         )
       ]
   end
-
-  @doc """
-  True while this module re-implements a gate that lives privately elsewhere.
-
-  Exists so a test can assert the duplication is still accurate rather than
-  letting it rot into a confidently-wrong report — the worst possible outcome
-  for a diagnostic. See `test/cli/doctor_inspection_test.exs`.
-  """
-  @spec mirrors_private_gate?() :: boolean()
-  def mirrors_private_gate?, do: true
-
-  @doc "The regex `Agent.Context.user_known?/1` uses to decide the BOOTSTRAP.md gate."
-  @spec user_known_regex() :: Regex.t()
-  def user_known_regex, do: @user_known_re
 
   # ── Section 1: static prompt tier ─────────────────────────────────────
 
@@ -418,7 +412,7 @@ defmodule OptimalSystemAgent.CLI.Doctor.Inspection do
     dir = bootstrap_dir()
     path = Path.join(dir, "BOOTSTRAP.md")
     user_md = Path.join(dir, "USER.md")
-    known? = user_known?(user_md)
+    known? = Context.user_known?(dir)
 
     cond do
       not File.exists?(path) ->
@@ -985,13 +979,6 @@ defmodule OptimalSystemAgent.CLI.Doctor.Inspection do
     case File.stat(path) do
       {:ok, %{size: s}} -> "#{s} bytes"
       _ -> "size unknown"
-    end
-  end
-
-  defp user_known?(user_md) do
-    case File.read(user_md) do
-      {:ok, content} -> Regex.match?(@user_known_re, content)
-      _ -> false
     end
   end
 

--- a/lib/optimal_system_agent/onboarding.ex
+++ b/lib/optimal_system_agent/onboarding.ex
@@ -2142,9 +2142,19 @@ defmodule OptimalSystemAgent.Onboarding do
       source = Path.join(prompts_dir, filename)
       dest = Path.join(osa_dir(), filename)
 
-      if File.exists?(source) and not File.exists?(dest) do
-        File.cp!(source, dest)
-        Logger.debug("[Onboarding] Seeded #{filename} → #{dest}")
+      cond do
+        filename == "BOOTSTRAP.md" and
+            OptimalSystemAgent.Agent.Context.user_known?(osa_dir()) ->
+          # First-meet file. Once USER.md has a name the ritual is done —
+          # copying it back is how a known user gets asked their name again.
+          :ok
+
+        File.exists?(source) and not File.exists?(dest) ->
+          File.cp!(source, dest)
+          Logger.debug("[Onboarding] Seeded #{filename} → #{dest}")
+
+        true ->
+          :ok
       end
     end)
 
@@ -2172,8 +2182,13 @@ defmodule OptimalSystemAgent.Onboarding do
       end
 
     # Check workspace files
+    # BOOTSTRAP.md is a first-meet ritual, not a required workspace file. Once
+    # the agent deletes it (or USER.md has a name), it must stay gone — reseeding
+    # it on every serve is how known users get asked their name again.
+    required_workspace = @workspace_templates -- ["BOOTSTRAP.md"]
+
     missing =
-      @workspace_templates
+      required_workspace
       |> Enum.reject(&File.exists?(Path.join(osa_dir(), &1)))
 
     checks =

--- a/priv/prompts/BOOTSTRAP.md
+++ b/priv/prompts/BOOTSTRAP.md
@@ -30,10 +30,16 @@ Have fun with it. Be genuine. This should feel like meeting a new colleague.
 
 ## After You Know Each Other
 
-After a few exchanges (not immediately), use file_write to save what you learned:
+After a few exchanges (not immediately), write what you learned. USER.md MUST keep this exact line — it is the completion signal that turns this ritual off:
 
+```
+- **Name:** TheirName
+```
+
+Do not invent a different heading or HTML comment. A free-form "they're called Roberto" note will not switch this off.
+
+- `~/.osa/USER.md` — start from the existing file; fill `- **Name:**` and `- **What to call them:**`, then add work / communication notes
 - `~/.osa/IDENTITY.md` — your name, vibe, style, emoji
-- `~/.osa/USER.md` — their name, what they work on, how they communicate
 
 Then mention that they can shape you — not just your personality, but how you work:
 

--- a/test/agent/context_test.exs
+++ b/test/agent/context_test.exs
@@ -430,4 +430,41 @@ defmodule OptimalSystemAgent.Agent.ContextTest do
         ""
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # First-meet ritual — USER.md name line is the only completion signal
+  # ---------------------------------------------------------------------------
+
+  describe "user_known?/1" do
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "osa-user-known-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+      %{dir: dir}
+    end
+
+    test "blank template is unknown", %{dir: dir} do
+      File.write!(Path.join(dir, "USER.md"), "- **Name:**\n")
+      refute Context.user_known?(dir)
+    end
+
+    test "missing USER.md is unknown", %{dir: dir} do
+      refute Context.user_known?(dir)
+    end
+
+    test "filled - **Name:** line is known", %{dir: dir} do
+      File.write!(Path.join(dir, "USER.md"), "- **Name:** Roberto\n")
+      assert Context.user_known?(dir)
+    end
+
+    test "free-form prose without the Name line is unknown", %{dir: dir} do
+      File.write!(Path.join(dir, "USER.md"), "They're called Roberto.\n")
+      refute Context.user_known?(dir)
+    end
+  end
 end

--- a/test/agent/loop/tool_filter_test.exs
+++ b/test/agent/loop/tool_filter_test.exs
@@ -159,6 +159,39 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilterTest do
     end
   end
 
+  # Role allowlists (explore/explorer tools_allowed) must shrink what the
+  # model SEES. Execution-only gating is how a read-only explorer still
+  # calls `delegate` and nests forever.
+  describe "filter_for_role_allowlist/2" do
+    defp advertised_tools do
+      ~w(file_read file_glob file_grep dir_list code_symbols shell_execute delegate tool_search)
+      |> Enum.map(&%{name: &1})
+    end
+
+    test "explore-style allowlist drops delegate and tool_search from the advertised set" do
+      allowed = ~w(file_read file_glob file_grep dir_list code_symbols shell_execute)
+
+      names =
+        advertised_tools()
+        |> ToolFilter.filter_for_role_allowlist(allowed)
+        |> Enum.map(& &1.name)
+
+      assert names == allowed
+      refute "delegate" in names
+      refute "tool_search" in names
+    end
+
+    test "nil allowlist (unrestricted / parent session) leaves the advertised set alone" do
+      tools = advertised_tools()
+      assert ToolFilter.filter_for_role_allowlist(tools, nil) == tools
+    end
+
+    test "empty allowlist is unrestricted, same as nil" do
+      tools = advertised_tools()
+      assert ToolFilter.filter_for_role_allowlist(tools, []) == tools
+    end
+  end
+
   defp session_effort_level do
     case :ets.whereis(:osa_settings) do
       :undefined ->

--- a/test/cli/doctor_inspection_test.exs
+++ b/test/cli/doctor_inspection_test.exs
@@ -186,8 +186,11 @@ defmodule OptimalSystemAgent.CLI.Doctor.InspectionTest do
       refute Regex.match?(re, "## Profile\n- Name: Ada\n")
     end
 
-    test "the mirror is declared, so its existence is discoverable" do
-      assert Inspection.mirrors_private_gate?()
+    test "the BOOTSTRAP.md gate is no longer a private copy" do
+      refute Inspection.mirrors_private_gate?()
+
+      assert Regex.source(Inspection.user_known_regex()) ==
+               Regex.source(OptimalSystemAgent.Agent.Context.user_known_regex())
     end
   end
 

--- a/test/optimal_system_agent/onboarding_setup_wizard_hotfix_test.exs
+++ b/test/optimal_system_agent/onboarding_setup_wizard_hotfix_test.exs
@@ -147,4 +147,45 @@ defmodule OptimalSystemAgent.OnboardingSetupWizardHotfixTest do
       assert recommended.id == "glm-5.2:cloud"
     end
   end
+
+  describe "seed_workspace/0 does not resurrect BOOTSTRAP.md for a known user" do
+    test "skips BOOTSTRAP.md when USER.md already has a Name line", %{osa_home: osa_home} do
+      File.write!(Path.join(osa_home, "USER.md"), "- **Name:** Roberto\n")
+      refute File.exists?(Path.join(osa_home, "BOOTSTRAP.md"))
+
+      Onboarding.seed_workspace()
+
+      refute File.exists?(Path.join(osa_home, "BOOTSTRAP.md")),
+             "known-user seed must not copy BOOTSTRAP.md back"
+    end
+
+    test "still seeds BOOTSTRAP.md on a true first run", %{osa_home: osa_home} do
+      File.rm(Path.join(osa_home, "USER.md"))
+      File.rm(Path.join(osa_home, "BOOTSTRAP.md"))
+
+      Onboarding.seed_workspace()
+
+      assert File.exists?(Path.join(osa_home, "BOOTSTRAP.md"))
+    end
+  end
+
+  describe "doctor_checks/0 does not treat a missing BOOTSTRAP.md as an error" do
+    test "a named USER.md without BOOTSTRAP.md is not a missing workspace file", %{
+      osa_home: osa_home
+    } do
+      File.write!(Path.join(osa_home, "USER.md"), "- **Name:** Roberto\n")
+      File.write!(Path.join(osa_home, "IDENTITY.md"), "- **Name:** OSA\n")
+      File.write!(Path.join(osa_home, "SOUL.md"), "ok\n")
+      File.write!(Path.join(osa_home, "HEARTBEAT.md"), "ok\n")
+      File.write!(Path.join(osa_home, ".env"), "OSA_DEFAULT_PROVIDER=ollama\n")
+      File.rm(Path.join(osa_home, "BOOTSTRAP.md"))
+
+      checks = Onboarding.doctor_checks()
+
+      missing =
+        Enum.find(checks, fn row -> match?({:error, "Missing workspace files", _}, row) end)
+
+      refute missing
+    end
+  end
 end


### PR DESCRIPTION
## Why

Two harness bugs that fire on a normal launch, not a first install.

**First-meet loop.** Every new session injected `BOOTSTRAP.md` unless `USER.md` matched `- **Name:** <nonempty>`. Memory did not count. Launch cwd did not count. The ritual never required that exact line, so agents wrote prose and the gate stayed open. `seed_workspace` (every `osa serve` / chat) copied `BOOTSTRAP.md` back if anyone deleted it. Doctor treated a missing bootstrap file as a broken workspace.

**Explorer nest.** `explore` / `explorer` declare six read-only tools. That list gated execution only (`subagent_tool_allowed?/2`). The advertised tool array stayed the full set, so a "read-only" explorer still saw `delegate`, spawned another explorer, and never STOPped. Observed this session: agent `6263` advertised 28 tools and spawned `6714`.

## What changed

- `Context.user_known?/1` is the single public gate (doctor and seed use it)
- Ritual text names the exact `- **Name:**` completion line
- `seed_workspace` will not resurrect `BOOTSTRAP.md` once the user is known
- Doctor no longer flags a missing `BOOTSTRAP.md` as a workspace error
- `ToolFilter.filter_for_role_allowlist/2` strips the advertised array to the role allowlist
- Mid-session coordinator / ask-user rebuilds keep that filter

Left out of this PR: untracked `lib/mix/tasks/probe.serve.ex` (not ours). Utility explorers are still silently promoted to specialist.

## Tests

```
mix test test/agent/context_test.exs \
        test/cli/doctor_inspection_test.exs \
        test/optimal_system_agent/onboarding_setup_wizard_hotfix_test.exs \
        test/agent/loop/tool_filter_test.exs \
        test/optimal_system_agent/agent/loop/tool_filter_depth_test.exs
```

Role-allowlist tests: red (`filter_for_role_allowlist/2` undefined, 13/3), then green after the source change (22/0 including depth tests).
