### PR TITLE
Fix Ollama Cloud route recovery

### DIFF
--- a/lib/optimal_system_agent/providers/ollama.ex
+++ b/lib/optimal_system_agent/providers/ollama.ex
@@ -28,6 +28,8 @@ defmodule OptimalSystemAgent.Providers.Ollama do
   # Minimum model size (in bytes) to enable tool calling — ~14B params ≈ 8GB on disk
   @tool_min_size 7_000_000_000
 
+  @local_url "http://localhost:11434"
+
   @impl true
   def name, do: :ollama
 
@@ -142,13 +144,58 @@ defmodule OptimalSystemAgent.Providers.Ollama do
     e -> {:error, Exception.message(e)}
   end
 
+  @doc false
+  @spec resolve_request_url(String.t(), String.t() | nil, [String.t()]) :: String.t()
+  def resolve_request_url(configured_url, model, local_model_names) do
+    if String.starts_with?(configured_url, "https://") and cloud_model?(model) and
+         model in local_model_names do
+      @local_url
+    else
+      configured_url
+    end
+  end
+
+  defp request_url(configured_url, model) do
+    if String.starts_with?(configured_url, "https://") and cloud_model?(model) do
+      local_url = Application.get_env(:optimal_system_agent, :ollama_local_url, @local_url)
+
+      # Hosted tags are not guaranteed to appear in /api/tags even when the
+      # signed daemon can serve them. /api/show is Ollama's authoritative
+      # per-model capability check and does not start a generation.
+      local_model_names =
+        case Req.post("#{local_url}/api/show",
+               json: %{model: model},
+               receive_timeout: 750,
+               retry: false
+             ) do
+          {:ok, %{status: 200}} -> [model]
+          _ -> []
+        end
+
+      case resolve_request_url(configured_url, model, local_model_names) do
+        @local_url ->
+          Logger.info("[Ollama] Routing hosted tag #{model} through the signed local daemon")
+
+          local_url
+
+        url ->
+          url
+      end
+    else
+      configured_url
+    end
+  rescue
+    _ -> configured_url
+  end
+
   @impl true
   def chat(messages, opts \\ []) do
-    url = Application.get_env(:optimal_system_agent, :ollama_url, "http://localhost:11434")
-
     model =
       Keyword.get(opts, :model) ||
         Application.get_env(:optimal_system_agent, :ollama_model, default_model())
+
+    configured_url = Application.get_env(:optimal_system_agent, :ollama_url, @local_url)
+    url = request_url(configured_url, model)
 
     with :ok <- context_floor_error(model, opts) do
       do_chat(url, model, messages, opts)
@@ -219,12 +266,13 @@ defmodule OptimalSystemAgent.Providers.Ollama do
     # the local ceiling only to non-cloud tags, so an Ollama Cloud model passes
     # this untouched.
     with :ok <- context_floor_error(model, opts) do
-      do_chat_stream(messages, callback, opts)
+      do_chat_stream(messages, callback, opts, model)
     end
   end
 
-  defp do_chat_stream(messages, callback, opts) do
-    url = Application.get_env(:optimal_system_agent, :ollama_url, "http://localhost:11434")
+  defp do_chat_stream(messages, callback, opts, model) do
+    configured_url = Application.get_env(:optimal_system_agent, :ollama_url, @local_url)
+    url = request_url(configured_url, model)
 
     # Ollama Cloud (HTTPS) — streaming via Erlang port + curl --no-buffer.
     # Req/Finch pool gets stuck after boot failures with HTTPS endpoints,
@@ -232,10 +280,6 @@ defmodule OptimalSystemAgent.Providers.Ollama do
     # NDJSON streaming. Each JSON line contains a token delta.
     if String.starts_with?(url, "https://") do
       Logger.info("[Ollama] Cloud URL detected — streaming via curl port")
-
-      model =
-        Keyword.get(opts, :model) ||
-          Application.get_env(:optimal_system_agent, :ollama_model, default_model())
 
       tools = Keyword.get(opts, :tools, [])
 

--- a/test/providers/ollama_test.exs
+++ b/test/providers/ollama_test.exs
@@ -5,6 +5,40 @@ defmodule OptimalSystemAgent.Providers.OllamaTest do
   alias OptimalSystemAgent.Providers.ThinkStreamParser
   alias OptimalSystemAgent.Utils.Text
 
+  describe "resolve_request_url/3" do
+    test "routes a cloud tag through the signed local daemon when it is available there" do
+      assert Ollama.resolve_request_url(
+               "https://ollama.com",
+               "glm-5.2:cloud",
+               ["glm-5.2:cloud", "llama3.2:3b"]
+             ) == "http://localhost:11434"
+    end
+
+    test "keeps direct cloud routing when the local daemon does not list the tag" do
+      assert Ollama.resolve_request_url(
+               "https://ollama.com",
+               "glm-5.2:cloud",
+               ["llama3.2:3b"]
+             ) == "https://ollama.com"
+    end
+
+    test "does not reroute local-weight models to a different daemon" do
+      assert Ollama.resolve_request_url(
+               "https://ollama.com",
+               "llama3.2:3b",
+               ["llama3.2:3b"]
+             ) == "https://ollama.com"
+    end
+
+    test "preserves an already-local configured URL" do
+      assert Ollama.resolve_request_url(
+               "http://ollama.internal:11434",
+               "glm-5.2:cloud",
+               ["glm-5.2:cloud"]
+             ) == "http://ollama.internal:11434"
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # model_supports_tools?/1
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the post-update 404 when an Ollama Cloud tag is selected while the configured direct HTTPS route cannot serve it.

The provider now checks the signed local daemon with `/api/show` and routes the hosted tag through it when available. Both streaming and non-streaming calls use the same decision. Direct HTTPS remains unchanged when the local daemon cannot serve the model.

Verification:
- 83 focused provider tests pass
- forced HTTPS non-streaming request reroutes locally and returns OK
- forced HTTPS streaming request reroutes locally and completes
- regression tests cover route selection and fallbacks