### PR TITLE
Fix subagent skill and Ollama model selection

### DIFF
--- a/lib/optimal_system_agent/agent/loop/tool_executor.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_executor.ex
@@ -94,6 +94,10 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
       tool in @subagent_blocked_tools -> false
       # Per-agent denylist
       is_list(blocked) and tool in blocked -> false
+      # Skill discovery is part of every agent's task protocol. These read-only
+      # meta tools must survive role allowlists or a child can be instructed to
+      # select a skill while being structurally unable to inspect one.
+      tool in ["skill_view", "list_skills"] -> true
       # Per-agent allowlist (nil = all allowed)
       is_list(allowed) and allowed != [] -> tool in allowed
       # Default: allowed

--- a/lib/optimal_system_agent/agent/loop/tool_filter.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_filter.ex
@@ -203,11 +203,15 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilter do
   # same defect `Agent.FastPath` records as "the only stage in filter/1 that
   # logged NOTHING".
   defp report_role_filter(tools, kept, tier, allowed, blocked) do
+    allowlist_matches_task_tool? =
+      not (is_list(allowed) and allowed != []) or
+        Enum.any?(tools, fn tool -> tool_name(tool) in allowed end)
+
     cond do
       kept == tools ->
         tools
 
-      kept == [] and tools != [] ->
+      not allowlist_matches_task_tool? and tools != [] ->
         # A `tools_allowed` typo or a stale tool name intersects to nothing, and
         # a zero-length schema array is not something native-tool providers
         # degrade from gracefully. Drop the unsatisfiable ALLOWLIST, keep the

--- a/lib/optimal_system_agent/agent/tier.ex
+++ b/lib/optimal_system_agent/agent/tier.ex
@@ -211,9 +211,15 @@ defmodule OptimalSystemAgent.Agent.Tier do
   """
   @spec model_for(tier(), atom()) :: String.t()
   def model_for(tier, :ollama) do
-    case ollama_tier_model(tier) do
-      nil -> auto_model(:ollama)
-      model -> model
+    case configured_model(:ollama) do
+      model when is_binary(model) and model != "" ->
+        model
+
+      _ ->
+        case ollama_tier_model(tier) do
+          nil -> auto_model(:ollama)
+          model -> model
+        end
     end
   end
 
@@ -365,8 +371,7 @@ defmodule OptimalSystemAgent.Agent.Tier do
 
     case safe_list_ollama_models(url) do
       {:ok, models} when models != [] ->
-        sorted = Enum.sort_by(models, & &1.size, :desc)
-        mapping = assign_ollama_tiers(sorted)
+        mapping = assign_ollama_tiers(models)
         :persistent_term.put(:osa_ollama_tiers, mapping)
 
         Logger.info(
@@ -461,22 +466,31 @@ defmodule OptimalSystemAgent.Agent.Tier do
     end
   end
 
-  # Assign tiers from a size-sorted (descending) list of models.
+  # Assign tiers from chat-capable models, sorted by size descending.
   # User overrides take priority, then size-based assignment fills the rest.
   # With 1 model: all tiers use it.
   # With 2 models: elite=largest, specialist+utility=smallest.
   # With 3+: elite=largest, specialist=middle, utility=smallest.
-  defp assign_ollama_tiers([]), do: %{}
+  @doc false
+  @spec assign_ollama_tiers([map()]) :: map()
+  def assign_ollama_tiers(models) when is_list(models) do
+    models
+    |> Enum.filter(&agent_model?/1)
+    |> Enum.sort_by(& &1.size, :desc)
+    |> do_assign_ollama_tiers()
+  end
 
-  defp assign_ollama_tiers([only]) do
+  defp do_assign_ollama_tiers([]), do: %{}
+
+  defp do_assign_ollama_tiers([only]) do
     apply_overrides(%{elite: only.name, specialist: only.name, utility: only.name})
   end
 
-  defp assign_ollama_tiers([large, small]) do
+  defp do_assign_ollama_tiers([large, small]) do
     apply_overrides(%{elite: large.name, specialist: small.name, utility: small.name})
   end
 
-  defp assign_ollama_tiers([large | rest]) do
+  defp do_assign_ollama_tiers([large | rest]) do
     mid_idx = div(length(rest), 2)
     mid = Enum.at(rest, mid_idx)
     small = List.last(rest)
@@ -486,9 +500,19 @@ defmodule OptimalSystemAgent.Agent.Tier do
 
   # Merge user overrides on top of size-based assignments
   defp apply_overrides(mapping) do
-    overrides = get_tier_overrides()
+    overrides =
+      get_tier_overrides()
+      |> Enum.filter(fn {_tier, model} -> agent_model?(%{name: model}) end)
+      |> Map.new()
+
     Map.merge(mapping, overrides)
   end
+
+  defp agent_model?(%{name: name}) when is_binary(name) do
+    OptimalSystemAgent.Providers.Ollama.model_supports_tools?(name)
+  end
+
+  defp agent_model?(_), do: false
 
   # Safe wrapper that doesn't crash if Ollama module isn't loaded or unreachable
   defp safe_list_ollama_models(url) do

--- a/lib/optimal_system_agent/channels/http/api/tool_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/tool_routes.ex
@@ -21,6 +21,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
   import OptimalSystemAgent.Channels.HTTP.API.Shared
 
   alias OptimalSystemAgent.Tools.Registry, as: Tools
+  alias OptimalSystemAgent.Tools.Registry.SkillLoader
 
   plug(:match)
   plug(:dispatch)
@@ -570,7 +571,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
               name: name,
               description: Map.get(skill, :description, ""),
               triggers: Map.get(skill, :triggers, []),
-              has_instructions: Map.get(skill, :instructions, "") != ""
+              has_instructions: skill_has_instructions?(skill)
             }
           end)
 
@@ -583,6 +584,24 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
 
         conn |> put_resp_content_type("application/json") |> send_resp(200, body)
     end
+  end
+
+  defp skill_has_instructions?(skill) do
+    case Map.get(skill, :instructions) do
+      body when is_binary(body) and body != "" ->
+        true
+
+      _ ->
+        case Map.get(skill, :path) do
+          path when is_binary(path) ->
+            match?({:ok, body} when is_binary(body) and body != "", SkillLoader.load_body(path))
+
+          _ ->
+            false
+        end
+    end
+  rescue
+    _ -> false
   end
 
   # ── POST /respond (permissions) ────────────────────────────────────

--- a/lib/optimal_system_agent/tools/registry.ex
+++ b/lib/optimal_system_agent/tools/registry.ex
@@ -740,6 +740,10 @@ defmodule OptimalSystemAgent.Tools.Registry do
   """
   @spec active_skills_context() :: String.t() | nil
   def active_skills_context do
+    build_active_skills_context(nil)
+  end
+
+  defp build_active_skills_context(message) do
     skills = :persistent_term.get({__MODULE__, :skills}, %{})
 
     if map_size(skills) == 0 do
@@ -749,14 +753,16 @@ defmodule OptimalSystemAgent.Tools.Registry do
       # the model-facing listing until a matching file is touched this session.
       touched = touched_paths()
 
-      active =
+      surfaced =
         skills
         |> SkillLoader.list_for_model(touched)
         |> SkillLoader.reject_disabled()
 
-      if active == [] do
+      if surfaced == [] do
         nil
       else
+        active = rank_skills_for_message(surfaced, message)
+
         lines =
           Enum.map_join(active, "\n", fn skill ->
             description =
@@ -772,7 +778,9 @@ defmodule OptimalSystemAgent.Tools.Registry do
           "Before acting on any non-trivial task, scan this compact catalog. " <>
           "If a skill is relevant or partially relevant, say which skill you are using, " <>
           "call `skill_view` to load its full instructions, and follow them before using " <>
-          "other task tools. Never guess a skill body from its description. Do not create " <>
+          "other task tools. If no listed skill clearly fits, call `list_skills` to search " <>
+          "the full library before proceeding. This applies to parent agents and subagents. " <>
+          "Never guess a skill body from its description. Do not create " <>
           "a new skill unless the user asks or the completed workflow is genuinely reusable.\n\n" <>
           lines
       end
@@ -792,7 +800,30 @@ defmodule OptimalSystemAgent.Tools.Registry do
   def active_skills_context(nil), do: active_skills_context()
   def active_skills_context(""), do: active_skills_context()
 
-  def active_skills_context(message) when is_binary(message), do: active_skills_context()
+  def active_skills_context(message) when is_binary(message),
+    do: build_active_skills_context(message)
+
+  defp rank_skills_for_message(skills, message) when is_binary(message) and message != "" do
+    query = String.downcase(message)
+
+    skills
+    |> Enum.map(fn skill ->
+      searchable =
+        [skill.name, skill.description, Enum.join(List.wrap(skill.triggers), " ")]
+        |> Enum.join(" ")
+
+      trigger_bonus = if trigger_match?(skill, query), do: 2.0, else: 0.0
+      {skill, trigger_bonus + OptimalSystemAgent.Skills.Ranker.relevance(searchable, message)}
+    end)
+    |> Enum.filter(fn {_skill, score} -> score > 0.0 end)
+    |> Enum.sort_by(fn {_skill, score} -> score end, :desc)
+    |> Enum.take(12)
+    |> Enum.map(&elem(&1, 0))
+  rescue
+    _ -> Enum.take(skills, 12)
+  end
+
+  defp rank_skills_for_message(skills, _message), do: skills
 
   @doc """
   Match a message against all loaded skill trigger keywords.

--- a/test/agent/loop/tool_filter_test.exs
+++ b/test/agent/loop/tool_filter_test.exs
@@ -166,7 +166,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilterTest do
   # calls `delegate` and nests forever.
   describe "filter_for_role_allowlist/2" do
     defp advertised_tools do
-      ~w(file_read file_glob file_grep dir_list code_symbols shell_execute delegate tool_search)
+      ~w(file_read file_glob file_grep dir_list code_symbols shell_execute delegate tool_search skill_view list_skills)
       |> Enum.map(&%{name: &1})
     end
 
@@ -256,6 +256,25 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilterTest do
       assert "file_read" in advertised
     end
 
+    test "subagents retain skill discovery tools through a role allowlist" do
+      tools = advertised_tools()
+      role = %{allowed_tools: ~w(file_read), blocked_tools: []}
+
+      advertised =
+        tools
+        |> ToolFilter.filter_for_role_allowlist(Map.put(role, :permission_tier, :subagent))
+        |> Enum.map(& &1.name)
+
+      assert "skill_view" in advertised
+      assert "list_skills" in advertised
+      assert OptimalSystemAgent.Agent.Loop.ToolExecutor.subagent_tool_allowed?("skill_view", role)
+
+      assert OptimalSystemAgent.Agent.Loop.ToolExecutor.subagent_tool_allowed?(
+               "list_skills",
+               role
+             )
+    end
+
     # config/test.exs pins Logger to :warning, so an :info line is dropped
     # before capture. Raise the floor for the assertion, then put it back —
     # otherwise "does it report?" is untestable by construction.
@@ -279,7 +298,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolFilterTest do
         end)
 
       assert log =~ "role tool gate active"
-      assert log =~ "advertising 2 of 8 tools"
+      assert log =~ "advertising 2 of 10 tools"
     end
 
     test "an unrestricted role logs nothing — the gate is inert, not quiet" do

--- a/test/agent/tier_test.exs
+++ b/test/agent/tier_test.exs
@@ -1,7 +1,56 @@
 defmodule OptimalSystemAgent.Agent.TierTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Agent.Tier
+
+  describe "Ollama agent model selection" do
+    setup do
+      old_model = Application.get_env(:optimal_system_agent, :ollama_model)
+      old_tiers = :persistent_term.get(:osa_ollama_tiers, :missing)
+      old_overrides = :persistent_term.get(:osa_tier_overrides, :missing)
+
+      on_exit(fn ->
+        if old_model,
+          do: Application.put_env(:optimal_system_agent, :ollama_model, old_model),
+          else: Application.delete_env(:optimal_system_agent, :ollama_model)
+
+        restore_term(:osa_ollama_tiers, old_tiers)
+        restore_term(:osa_tier_overrides, old_overrides)
+      end)
+
+      :ok
+    end
+
+    test "the explicitly selected model beats stale automatic tier assignments" do
+      Application.put_env(:optimal_system_agent, :ollama_model, "glm-5.2:cloud")
+
+      :persistent_term.put(:osa_ollama_tiers, %{
+        elite: "llama3.2:3b",
+        specialist: "nomic-embed-text:latest",
+        utility: "qwen3-embedding:0.6b"
+      })
+
+      assert Tier.model_for(:specialist, :ollama) == "glm-5.2:cloud"
+    end
+
+    test "automatic tiers exclude embedding and undersized non-agent models" do
+      models = [
+        %{name: "llama3.2:3b", size: 2_019_393_189},
+        %{name: "qwen3-coder:480b-cloud", size: 382},
+        %{name: "qwen3-embedding:0.6b", size: 639_150_858},
+        %{name: "nomic-embed-text:latest", size: 274_302_450}
+      ]
+
+      assert Tier.assign_ollama_tiers(models) == %{
+               elite: "qwen3-coder:480b-cloud",
+               specialist: "qwen3-coder:480b-cloud",
+               utility: "qwen3-coder:480b-cloud"
+             }
+    end
+  end
+
+  defp restore_term(key, :missing), do: :persistent_term.erase(key)
+  defp restore_term(key, value), do: :persistent_term.put(key, value)
 
   # ── max_agents/1 ──────────────────────────────────────────────────
 

--- a/test/optimal_system_agent/skills/progressive_disclosure_test.exs
+++ b/test/optimal_system_agent/skills/progressive_disclosure_test.exs
@@ -68,6 +68,36 @@ defmodule OptimalSystemAgent.Skills.ProgressiveDisclosureTest do
     refute catalog =~ "Active Skill"
   end
 
+  test "message-aware catalog ranks relevant skills ahead of a large library" do
+    debugging = :persistent_term.get(@skills_key)["debugging"]
+
+    irrelevant =
+      for i <- 1..80, into: %{} do
+        name = "aaa-unrelated-#{String.pad_leading(Integer.to_string(i), 3, "0")}"
+
+        {name,
+         %{
+           debugging
+           | name: name,
+             description: "Prepare an unrelated weekly calendar summary"
+         }}
+      end
+
+    :persistent_term.put(@skills_key, Map.put(irrelevant, "debugging", debugging))
+
+    catalog = Registry.active_skills_context("diagnose a hard software bug")
+
+    assert catalog =~ "**debugging**"
+    assert catalog =~ "If no listed skill clearly fits, call `list_skills`"
+    assert length(String.split(catalog, "\n")) < 40
+  end
+
+  test "catalog tells every agent how to search when the shortlist has no match" do
+    catalog = Registry.active_skills_context("compose a baroque symphony")
+
+    assert catalog =~ "If no listed skill clearly fits, call `list_skills`"
+  end
+
   test "skill_view loads the selected body into the owning agent context" do
     assert {:ok, loaded} = SkillView.execute(%{"name" => "debugging"})
     assert loaded =~ "# Active Skill: debugging"


### PR DESCRIPTION
The live Forge session exposed two independent subagent failures.

Skill selection:
- the 105-skill catalog ignored the current task, sorted alphabetically, and was truncated before relevant entries reliably reached the model
- subagent role allowlists removed skill_view and list_skills, making children unable to follow the skill protocol

Ollama model selection:
- dynamic tiers included embedding-only and undersized models
- the Ollama-specific model resolver ignored the explicitly selected active model, allowing nomic-embed-text:latest to be dispatched as a specialist

This change ranks a bounded skill shortlist against the current task, preserves skill discovery for every subagent unless explicitly denied, and tells agents to search the full library when no shortlist entry fits. Ollama subagents now honor the explicitly selected model, and automatic tiers reject embedding and undersized non-agent models. The /skills/match instruction diagnostic is also corrected for progressively disclosed bodies.

Verification:
- red tests reproduced catalog burial, subagent skill-tool stripping, stale-tier override of the selected model, and embedding assignment
- 154 skill/context/registry/filter tests pass
- 144 tier/provider/orchestrator tests pass
- active-session checkpoint audit confirmed zero prior skill_view calls