### PR TITLE
Fix persistent goal controls and wrapped CLI input

### DIFF
--- a/lib/optimal_system_agent/agent/loop/goal_tracker.ex
+++ b/lib/optimal_system_agent/agent/loop/goal_tracker.ex
@@ -1259,6 +1259,8 @@ defmodule OptimalSystemAgent.Agent.Loop.GoalTracker do
         session_id: snap.session_id,
         status: snap.status,
         phase: snap.phase,
+        goal: snap.goal,
+        goal_id: snap.goal_id,
         pause_reason: snap.pause_reason,
         turn_count: snap.turn_count,
         verify_run_count: snap.verify_run_count

--- a/lib/optimal_system_agent/agent/session_persistence.ex
+++ b/lib/optimal_system_agent/agent/session_persistence.ex
@@ -30,6 +30,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
 
   alias OptimalSystemAgent.Agent.SessionPersistence.Jsonl
   alias OptimalSystemAgent.Agent.SessionPersistence.RecordLock
+  alias OptimalSystemAgent.Utils.Mojibake
   alias OptimalSystemAgent.ConfigFile
 
   # Runtime-resolved so a prebuilt release uses the END USER's home, not the CI
@@ -167,7 +168,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
             restored =
               messages
               |> Enum.filter(&is_map/1)
-              |> Enum.map(fn m -> Map.new(m, fn {k, v} -> {safe_key(k), v} end) end)
+              |> Enum.map(&restore_message/1)
 
             {:ok, restored}
 
@@ -206,7 +207,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
           session_id
           |> load_events()
           |> Enum.filter(&is_map/1)
-          |> Enum.map(fn m -> Map.new(m, fn {k, v} -> {safe_key(k), v} end) end)
+          |> Enum.map(&restore_message/1)
 
         # Recovery is a read that produces a record, so it must establish this
         # VM's write lineage exactly like the normal load path does. It did not,
@@ -935,7 +936,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
           )
         end
 
-        Enum.map(events, &Map.get(&1, "msg", &1))
+        Enum.map(events, &(Map.get(&1, "msg", &1) |> repair_message()))
 
       _ ->
         []
@@ -952,6 +953,24 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
   end
 
   # ── Private ──────────────────────────────────────────────────────────
+
+  defp restore_message(message) do
+    message
+    |> Map.new(fn {key, value} -> {safe_key(key), value} end)
+    |> repair_message()
+  end
+
+  defp repair_message(message) when is_map(message) do
+    Map.new(message, fn
+      {key, value} when key in [:content, "content"] and is_binary(value) ->
+        {key, Mojibake.repair(value)}
+
+      pair ->
+        pair
+    end)
+  end
+
+  defp repair_message(message), do: message
 
   defp session_path(session_id) do
     safe_id = Regex.replace(~r/[^a-zA-Z0-9_\-]/, session_id, "_")

--- a/lib/optimal_system_agent/channels/cli/line_editor.ex
+++ b/lib/optimal_system_agent/channels/cli/line_editor.ex
@@ -17,6 +17,8 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
   echo and terminal state tracking that conflicts with our own readline.
   """
 
+  alias OptimalSystemAgent.CLI.Width
+
   defstruct buffer: [],
             cursor: 0,
             history: [],
@@ -25,7 +27,7 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
             prompt: "",
             # fd for /dev/tty — used for BOTH raw byte reads AND writes
             tty: nil,
-            rendered_lines: 1
+            terminal_cols: 80
 
   @doc """
   Read a line of input with readline-style editing.
@@ -68,9 +70,11 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
           state = %__MODULE__{
             prompt: prompt,
             history: history,
-            tty: tty
+            tty: tty,
+            terminal_cols: terminal_columns()
           }
 
+          Process.put(:rendered_cursor_row, 0)
           tty_write(tty, prompt)
           result = input_loop(state)
           # Newline while still in raw mode (OPOST off → literal \r\n).
@@ -78,6 +82,7 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
           tty_write(tty, "\r\n")
           result
         after
+          Process.delete(:rendered_cursor_row)
           restore_stty(saved)
         end
 
@@ -94,9 +99,10 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
         text = Enum.join(state.buffer)
         # Move cursor to the last rendered line so the caller's \r\n lands below
         # all content rather than overwriting a middle line.
-        line_count = length(String.split(text, "\n"))
-        {cursor_line, _} = cursor_position(state.buffer, state.cursor)
-        lines_below = line_count - 1 - cursor_line
+        layout =
+          visual_layout(text, Width.visible(state.prompt), state.terminal_cols, state.cursor)
+
+        lines_below = layout.rendered_rows - 1 - layout.cursor_row
 
         if lines_below > 0 do
           tty_write(state.tty, "\e[#{lines_below}B")
@@ -309,15 +315,16 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
   defp redraw(state) do
     line = Enum.join(state.buffer)
     lines = String.split(line, "\n")
-    line_count = length(lines)
+    cols = terminal_columns(state.terminal_cols)
+    layout = visual_layout(line, Width.visible(state.prompt), cols, state.cursor)
 
-    # How many lines did we render last time? Use process dict since redraw
-    # is called for side-effects and does not return an updated state.
-    prev_rendered = Process.get(:rendered_lines, 1)
+    # Track the previous visual cursor row since redraw is side-effect-only and
+    # does not return an updated state.
+    prev_cursor_row = Process.get(:rendered_cursor_row, 0)
 
     # Move up to the first rendered line so we can overwrite everything.
-    if prev_rendered > 1 do
-      tty_write(state.tty, "\e[#{prev_rendered - 1}A")
+    if prev_cursor_row > 0 do
+      tty_write(state.tty, "\e[#{prev_cursor_row}A")
     end
 
     # Clear from here to end of screen.
@@ -332,33 +339,70 @@ defmodule OptimalSystemAgent.Channels.CLI.LineEditor do
     end
 
     # Position cursor on the correct line and column.
-    {cursor_line, cursor_col} = cursor_position(state.buffer, state.cursor)
-    lines_from_end = line_count - 1 - cursor_line
+    lines_from_end = layout.rendered_rows - 1 - layout.cursor_row
 
     if lines_from_end > 0 do
       tty_write(state.tty, "\e[#{lines_from_end}A")
     end
 
-    prefix_len = if cursor_line == 0, do: String.length(state.prompt), else: 2
     tty_write(state.tty, "\r")
 
-    if prefix_len + cursor_col > 0 do
-      tty_write(state.tty, "\e[#{prefix_len + cursor_col}C")
+    if layout.cursor_col > 0 do
+      tty_write(state.tty, "\e[#{layout.cursor_col}C")
     end
 
-    # Persist the rendered line count for the next redraw call.
-    Process.put(:rendered_lines, line_count)
+    Process.put(:rendered_cursor_row, layout.cursor_row)
   end
 
-  # Returns {line_number, column} of the cursor within a multi-line buffer.
-  # line_number is 0-based; column is the grapheme offset on that line.
-  defp cursor_position(buffer, cursor) do
-    chars_before = Enum.take(buffer, cursor)
-    text_before = Enum.join(chars_before)
-    lines_before = String.split(text_before, "\n")
-    line_num = length(lines_before) - 1
-    col = String.length(List.last(lines_before) || "")
-    {line_num, col}
+  @doc false
+  @spec visual_layout(String.t(), non_neg_integer(), pos_integer(), non_neg_integer()) :: map()
+  def visual_layout(text, prompt_width, terminal_cols, cursor)
+      when is_binary(text) and is_integer(prompt_width) and is_integer(terminal_cols) and
+             terminal_cols > 0 and is_integer(cursor) do
+    logical_lines = String.split(text, "\n")
+    before = text |> String.graphemes() |> Enum.take(max(cursor, 0)) |> Enum.join()
+    before_lines = String.split(before, "\n")
+    cursor_logical_line = length(before_lines) - 1
+    cursor_text = List.last(before_lines) || ""
+
+    rows_per_line =
+      logical_lines
+      |> Enum.with_index()
+      |> Enum.map(fn {logical, index} ->
+        prefix = if index == 0, do: prompt_width, else: 2
+        visual_rows(prefix + Width.visible(logical), terminal_cols)
+      end)
+
+    rows_before = rows_per_line |> Enum.take(cursor_logical_line) |> Enum.sum()
+    cursor_prefix = if cursor_logical_line == 0, do: prompt_width, else: 2
+    cursor_offset = cursor_prefix + Width.visible(cursor_text)
+    {cursor_wrap_row, cursor_col} = visual_cursor(cursor_offset, terminal_cols)
+
+    %{
+      rendered_rows: Enum.sum(rows_per_line),
+      cursor_row: rows_before + cursor_wrap_row,
+      cursor_col: cursor_col
+    }
+  end
+
+  defp visual_rows(width, cols), do: max(div(max(width, 1) - 1, cols) + 1, 1)
+
+  defp visual_cursor(0, _cols), do: {0, 0}
+
+  defp visual_cursor(offset, cols) do
+    case rem(offset, cols) do
+      0 -> {div(offset, cols) - 1, cols}
+      col -> {div(offset, cols), col}
+    end
+  end
+
+  defp terminal_columns(fallback \\ 80) do
+    case :io.columns() do
+      {:ok, cols} when is_integer(cols) and cols > 0 -> cols
+      _ -> fallback
+    end
+  rescue
+    _ -> fallback
   end
 
   # --- Tab Completion ---

--- a/lib/optimal_system_agent/channels/http/api/tool_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/tool_routes.ex
@@ -517,9 +517,11 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.ToolRoutes do
       # what the loop asks before it continues.
       active: GoalTracker.goal_loop?(session_id) and GoalTracker.continue?(session_id),
       status: snap && snap.status && to_string(snap.status),
+      phase: snap && snap.phase && to_string(snap.phase),
       goal: snap && snap.goal,
       goal_id: snap && snap.goal_id,
       turn_count: (snap && snap.turn_count) || 0,
+      verify_run_count: (snap && snap.verify_run_count) || 0,
       pause_reason: snap && snap.pause_reason && to_string(snap.pause_reason)
     }
 

--- a/lib/optimal_system_agent/events/tui_forwarder.ex
+++ b/lib/optimal_system_agent/events/tui_forwarder.ex
@@ -37,6 +37,7 @@ defmodule OptimalSystemAgent.Events.TuiForwarder do
     push_notification
     subscribe_pr_registered
     goal_verifier_round
+    goal_tracker_transition
     verification_gate_triggered
     announcement_continue
     announcement_continue_exhausted

--- a/lib/optimal_system_agent/providers/ollama.ex
+++ b/lib/optimal_system_agent/providers/ollama.ex
@@ -19,6 +19,7 @@ defmodule OptimalSystemAgent.Providers.Ollama do
 
   alias OptimalSystemAgent.Providers.ThinkStreamParser
   alias OptimalSystemAgent.Providers.ToolCallParsers
+  alias OptimalSystemAgent.Utils.Mojibake
   alias OptimalSystemAgent.Utils.Text
 
   # Models known to handle tool calling well (name prefix → min size in GB)
@@ -1326,6 +1327,8 @@ defmodule OptimalSystemAgent.Providers.Ollama do
   def process_ndjson_line(line, callback, acc) do
     case Jason.decode(line) do
       {:ok, %{"message" => %{"content" => text}}} when is_binary(text) and text != "" ->
+        text = Mojibake.repair(text)
+
         # Split inline <think>…</think> reasoning out before emitting so the
         # tags + reasoning never leak into the visible answer.
         case Map.get(acc, :think) do

--- a/lib/optimal_system_agent/store/session_transcript.ex
+++ b/lib/optimal_system_agent/store/session_transcript.ex
@@ -11,6 +11,7 @@ defmodule OptimalSystemAgent.Store.SessionTranscript do
   require Logger
 
   alias OptimalSystemAgent.Store.Repo
+  alias OptimalSystemAgent.Utils.Mojibake
 
   schema "session_transcripts" do
     field(:session_id, :string)
@@ -273,7 +274,7 @@ defmodule OptimalSystemAgent.Store.SessionTranscript do
   # ("[image]" placeholder per image block) so every turn survives
   # persistence. nil passes through so validate_required still catches
   # genuine caller bugs.
-  defp normalize_content(content) when is_binary(content), do: content
+  defp normalize_content(content) when is_binary(content), do: Mojibake.repair(content)
 
   defp normalize_content(content) when is_list(content) do
     content

--- a/lib/optimal_system_agent/utils/mojibake.ex
+++ b/lib/optimal_system_agent/utils/mojibake.ex
@@ -1,0 +1,62 @@
+defmodule OptimalSystemAgent.Utils.Mojibake do
+  @moduledoc """
+  Repairs the narrow, recognisable UTF-8-as-Latin-1 corruption produced by
+  older session imports.
+
+  The repair is deliberately conservative. It only accepts a decoding pass
+  when that pass reduces known mojibake markers, so ordinary non-ASCII text is
+  returned byte-for-byte unchanged.
+  """
+
+  @markers ["Ã", "Â", "â"]
+
+  @spec repair(String.t()) :: String.t()
+  def repair(text) when is_binary(text) do
+    text
+    |> String.to_charlist()
+    |> Enum.chunk_by(&(&1 <= 255))
+    |> Enum.map_join(fn codepoints ->
+      segment = List.to_string(codepoints)
+      if hd(codepoints) <= 255, do: repair_segment(segment, 3), else: segment
+    end)
+  end
+
+  defp repair_segment(text, 0), do: text
+
+  defp repair_segment(text, passes_left) do
+    before = marker_count(text)
+
+    with true <- before > 0,
+         {:ok, candidate} <- latin1_bytes_as_utf8(text),
+         true <- marker_count(candidate) < before do
+      repair_segment(candidate, passes_left - 1)
+    else
+      _ -> text
+    end
+  end
+
+  defp marker_count(text) do
+    Enum.reduce(@markers, 0, fn marker, total ->
+      total + length(:binary.matches(text, marker))
+    end)
+  end
+
+  defp latin1_bytes_as_utf8(text) do
+    bytes =
+      text
+      |> String.to_charlist()
+      |> Enum.reduce_while([], fn
+        codepoint, acc when codepoint <= 255 -> {:cont, [codepoint | acc]}
+        _codepoint, _acc -> {:halt, :not_latin1}
+      end)
+
+    case bytes do
+      :not_latin1 -> :error
+      reversed -> reversed |> Enum.reverse() |> :erlang.list_to_binary() |> valid_utf8()
+    end
+  end
+
+  defp valid_utf8(candidate) do
+    if String.valid?(candidate), do: {:ok, candidate}, else: :error
+  end
+end

--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -2110,6 +2110,11 @@ impl App {
         // Mirror the backend. `self.goal` is a CACHE of what the backend last
         // said, never an opinion of ours: `active` is `GoalTracker.goal_loop?/1
         // and continue?/1`, the same pair `ReactLoop` gates its own re-entry on.
+        self.goal_status = status
+            .goal
+            .as_ref()
+            .filter(|g| !g.trim().is_empty())
+            .map(|_| status.clone());
         self.goal = if status.active {
             status.goal.clone().filter(|g| !g.trim().is_empty())
         } else {
@@ -2184,15 +2189,11 @@ impl App {
         // The backend has authorized another turn. Only now does our own outer
         // bound get a say — it can stop early, never extend (see `goal_cycle`).
         if self.goal_cycle >= self.goal_max_cycles {
-            self.chat.add_system_message(
-                &format!(
-                    "Goal auto-continue reached its {}-turn cap while the backend still has the \
-                     goal active. Stopping here — the goal stays anchored, so sending any message \
-                     resumes work on it.",
-                    self.goal_max_cycles
-                ),
-                "warning",
-            );
+            self.pause_goal(&format!(
+                "Goal paused after the TUI's {}-turn safety cap. The goal stays anchored. \
+                 Use /goal resume to continue or /goal clear to forget it.",
+                self.goal_max_cycles
+            ));
             return false;
         }
 
@@ -2215,6 +2216,12 @@ impl App {
         }
         self.goal = None;
         self.goal_cycle = 0;
+        if let Some(snapshot) = self.goal_status.as_mut() {
+            snapshot.active = false;
+            snapshot.status = Some("paused".into());
+            snapshot.phase = Some("idle".into());
+            snapshot.pause_reason = Some("user".into());
+        }
         self.refresh_goal_status();
         self.chat.add_system_message(why, "info");
         self.goal_intent = Some(GoalIntent::Silent);
@@ -2223,14 +2230,7 @@ impl App {
 
     /// Sync the status-bar "goal N/max" indicator with the current state.
     fn refresh_goal_status(&mut self) {
-        if self.goal.is_some() {
-            self.status.set_goal_label(Some(format!(
-                "goal {}/{}",
-                self.goal_cycle, self.goal_max_cycles
-            )));
-        } else {
-            self.status.set_goal_label(None);
-        }
+        self.sync_goal_indicator();
     }
 
     /// Called at the end of each assistant turn. Asks the BACKEND whether the

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -176,6 +176,14 @@ impl App {
                 // coordinator on. The backend echoes a coordinator_mode event,
                 // which drives the chip; "status" reads without mutating.
                 self.spawn_backend_command("coordinator", "status");
+                // Goal state is also backend-authoritative and durable. Pull a
+                // snapshot on every (re)connect so a resumed TUI immediately
+                // restores the active, paused, or completed footer instead of
+                // waiting for the user to type `/goal status`.
+                if self.goal_intent.is_none() {
+                    self.goal_intent = Some(crate::app::handle_actions::GoalIntent::Silent);
+                    self.execute_backend_command_quiet("goal", "status");
+                }
             }
             BackendEvent::SseDisconnected { error } => {
                 match error.as_deref() {
@@ -2677,6 +2685,42 @@ impl App {
                     }
                 };
                 self.status.set_goal_verification(state);
+            }
+            BackendEvent::GoalTransition {
+                status,
+                phase,
+                goal,
+                goal_id,
+                pause_reason,
+                turn_count,
+                verify_run_count,
+                ..
+            } => {
+                let active = matches!(status.as_str(), "active" | "off_track");
+                let snapshot = crate::client::types::GoalStatus {
+                    active,
+                    status: Some(status),
+                    phase: Some(phase),
+                    goal: goal.clone(),
+                    goal_id,
+                    turn_count,
+                    verify_run_count,
+                    pause_reason,
+                };
+                self.goal_status = goal
+                    .as_ref()
+                    .filter(|g| !g.trim().is_empty())
+                    .map(|_| snapshot);
+                self.goal = if active {
+                    goal.filter(|g| !g.trim().is_empty())
+                } else {
+                    None
+                };
+                if !active {
+                    self.goal_cycle = 0;
+                }
+                self.sync_goal_indicator();
+                self.recompute_layout();
             }
 
             // === Context compaction: make a multi-minute blocking step visible ===

--- a/priv/rust/tui/src/app/mod.rs
+++ b/priv/rust/tui/src/app/mod.rs
@@ -12,12 +12,12 @@ mod handle_backend;
 mod handle_dialogs;
 pub mod key_normalize;
 mod keymap_dispatch;
+pub mod keys;
+pub mod layout;
 pub mod permission_queue;
 pub mod resume;
 pub mod self_update;
 pub mod settle_guard;
-pub mod keys;
-pub mod layout;
 pub mod state;
 pub mod stream_pace;
 pub mod stream_probe;
@@ -401,6 +401,10 @@ pub struct App {
     // own homework — while the backend's skeptic panel, stall detector and run
     // cap sat unused because `/goal` never reached them.
     pub goal: Option<String>,
+    /// Last authoritative backend snapshot. Kept after pursuit stops so the
+    /// footer can show paused, blocked, completed, or abandoned state instead
+    /// of disappearing precisely when the user needs the next command.
+    pub goal_status: Option<crate::client::types::GoalStatus>,
     /// Turns the TUI has auto-started toward the goal since it was anchored.
     ///
     /// This is the OUTER of three nested bounds, and the only one the TUI owns:
@@ -831,6 +835,7 @@ impl App {
 
             voice: VoiceState::new(),
             goal: None,
+            goal_status: None,
             goal_cycle: 0,
             goal_max_cycles,
             goal_intent: None,
@@ -1299,26 +1304,33 @@ impl App {
         }
     }
 
-    /// Reconcile the status-line active-goal indicator ("Working on: <goal> ·
-    /// 3m 40s") with the live goal state, once per frame. Stamps the goal-active
+    /// Reconcile the status-line goal indicator with the authoritative backend
+    /// snapshot once per frame. Stamps the goal-active
     /// Instant the first frame a goal is present so the elapsed counts from
     /// activation, and clears it the moment the goal clears so the timer resets
     /// (never leaks across goals). Overrides the plain "goal N/max" label that the
     /// `/goal` command path seeds, so the richer indicator is the single winner.
     pub(crate) fn sync_goal_indicator(&mut self) {
-        match self.goal.clone() {
-            Some(goal) => {
-                let since = *self.goal_activated_at.get_or_insert_with(Instant::now);
-                let elapsed = since.elapsed().as_secs();
-                self.status
-                    .set_goal_label(Some(compose_goal_label(&goal, elapsed)));
-            }
-            None => {
-                // Goal cleared: freeze/reset the timer and drop the chip.
-                if self.goal_activated_at.is_some() {
+        match self.goal_status.clone() {
+            Some(snapshot)
+                if snapshot
+                    .goal
+                    .as_deref()
+                    .is_some_and(|g| !g.trim().is_empty()) =>
+            {
+                let elapsed = if snapshot.active {
+                    let since = *self.goal_activated_at.get_or_insert_with(Instant::now);
+                    since.elapsed().as_secs()
+                } else {
                     self.goal_activated_at = None;
-                    self.status.set_goal_label(None);
-                }
+                    0
+                };
+                self.status
+                    .set_goal_label(Some(compose_goal_status_label(&snapshot, elapsed)));
+            }
+            _ => {
+                self.goal_activated_at = None;
+                self.status.set_goal_label(None);
             }
         }
     }
@@ -1384,6 +1396,26 @@ fn compose_goal_label(goal: &str, elapsed_secs: u64) -> String {
         shown,
         crate::components::status_bar::fmt_elapsed_compact(elapsed_secs)
     )
+}
+
+fn compose_goal_status_label(
+    snapshot: &crate::client::types::GoalStatus,
+    elapsed_secs: u64,
+) -> String {
+    let objective = snapshot.goal.as_deref().unwrap_or("").trim();
+    let shown = crate::util::fit_cols(objective, 36);
+    match snapshot.status.as_deref() {
+        Some("paused") => format!("Goal paused: {} · /goal resume", shown),
+        Some("blocked") => format!("Goal stalled: {} · /goal resume", shown),
+        Some("completed") => format!("Goal achieved: {} · /goal clear", shown),
+        Some("abandoned") => format!("Goal stopped: {} · /goal clear", shown),
+        _ if snapshot.active => format!(
+            "Pursuing: {} · {} · /goal pause",
+            shown,
+            crate::components::status_bar::fmt_elapsed_compact(elapsed_secs)
+        ),
+        _ => format!("Goal inactive: {} · /goal resume", shown),
+    }
 }
 
 pub(super) fn generate_session_id() -> String {
@@ -1535,7 +1567,8 @@ mod turn_active_tests {
 
 #[cfg(test)]
 mod goal_indicator_tests {
-    use super::compose_goal_label;
+    use super::{compose_goal_label, compose_goal_status_label};
+    use crate::client::types::GoalStatus;
 
     #[test]
     fn goal_label_shows_goal_and_nonzero_elapsed_once_activated() {
@@ -1562,6 +1595,47 @@ mod goal_indicator_tests {
         let label = compose_goal_label(&long, 5);
         assert!(label.contains('\u{2026}'), "long goal must be ellipsized");
         assert!(label.ends_with("\u{00b7} 5s"));
+    }
+
+    #[test]
+    fn active_goal_names_objective_elapsed_and_pause_control() {
+        let snapshot = GoalStatus {
+            active: true,
+            status: Some("active".into()),
+            goal: Some("ship the release".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            compose_goal_status_label(&snapshot, 220),
+            "Pursuing: ship the release · 3m 40s · /goal pause"
+        );
+    }
+
+    #[test]
+    fn paused_goal_remains_visible_with_resume_control() {
+        let snapshot = GoalStatus {
+            status: Some("paused".into()),
+            goal: Some("ship the release".into()),
+            pause_reason: Some("user".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            compose_goal_status_label(&snapshot, 0),
+            "Goal paused: ship the release · /goal resume"
+        );
+    }
+
+    #[test]
+    fn completed_goal_remains_visible_until_cleared() {
+        let snapshot = GoalStatus {
+            status: Some("completed".into()),
+            goal: Some("ship the release".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            compose_goal_status_label(&snapshot, 0),
+            "Goal achieved: ship the release · /goal clear"
+        );
     }
 }
 

--- a/priv/rust/tui/src/client/sse.rs
+++ b/priv/rust/tui/src/client/sse.rs
@@ -569,6 +569,7 @@ fn parse_sse_event(event_type: &str, data: &[u8]) -> Option<BackendEvent> {
         | "swarm_intelligence_converged"
         | "swarm_intelligence_completed"
         | "goal_verifier_round"
+        | "goal_tracker_transition"
         | "scratchpad_activity"
         | "hook_run"
         | "hook_blocked"
@@ -1529,6 +1530,42 @@ fn parse_system_event(data: &[u8]) -> Option<BackendEvent> {
             })
         }
 
+        "goal_tracker_transition" => {
+            #[derive(serde::Deserialize)]
+            struct Ev {
+                #[serde(default)]
+                action: String,
+                #[serde(default)]
+                status: String,
+                #[serde(default)]
+                phase: String,
+                #[serde(default)]
+                goal: Option<String>,
+                #[serde(default)]
+                goal_id: Option<String>,
+                #[serde(default)]
+                pause_reason: Option<String>,
+                #[serde(default)]
+                turn_count: u32,
+                #[serde(default)]
+                verify_run_count: u32,
+            }
+            let ev: Ev = match serde_json::from_slice(data) {
+                Ok(e) => e,
+                Err(e) => return Some(parse_warning("goal_tracker_transition", e)),
+            };
+            Some(BackendEvent::GoalTransition {
+                action: ev.action,
+                status: ev.status,
+                phase: ev.phase,
+                goal: ev.goal,
+                goal_id: ev.goal_id,
+                pause_reason: ev.pause_reason,
+                turn_count: ev.turn_count,
+                verify_run_count: ev.verify_run_count,
+            })
+        }
+
         "compaction_started" => {
             #[derive(serde::Deserialize)]
             struct Ev {
@@ -2189,6 +2226,26 @@ mod tests {
                 assert_eq!(verdict, "complete");
             }
             other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_authoritative_goal_tracker_transition() {
+        let data = br#"{"event":"goal_tracker_transition","action":"paused","status":"paused","phase":"idle","goal":"Ship the release","goal_id":"goal-1","pause_reason":"user","turn_count":3,"verify_run_count":1}"#;
+        match parse_sse_event("goal_tracker_transition", data) {
+            Some(BackendEvent::GoalTransition {
+                status,
+                goal,
+                pause_reason,
+                turn_count,
+                ..
+            }) => {
+                assert_eq!(status, "paused");
+                assert_eq!(goal.as_deref(), Some("Ship the release"));
+                assert_eq!(pause_reason.as_deref(), Some("user"));
+                assert_eq!(turn_count, 3);
+            }
+            other => panic!("expected goal transition, got {other:?}"),
         }
     }
 

--- a/priv/rust/tui/src/client/types.rs
+++ b/priv/rust/tui/src/client/types.rs
@@ -361,6 +361,8 @@ pub struct GoalStatus {
     /// session has no tracker entry yet.
     #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
+    pub phase: Option<String>,
     /// The anchored goal text, as the backend stored it.
     #[serde(default)]
     pub goal: Option<String>,
@@ -369,6 +371,8 @@ pub struct GoalStatus {
     /// Turns the backend has counted against this goal.
     #[serde(default)]
     pub turn_count: u32,
+    #[serde(default)]
+    pub verify_run_count: u32,
     /// Why a `paused` goal paused: `no_progress` | `run_cap` | `off_track` |
     /// `user`. Names the stop condition so an exhausted goal is distinguishable
     /// from a finished one.

--- a/priv/rust/tui/src/event/backend.rs
+++ b/priv/rust/tui/src/event/backend.rs
@@ -438,6 +438,18 @@ pub enum BackendEvent {
         total: u32,
         gaps: Vec<String>,
     },
+    /// Authoritative backend goal lifecycle transition. Unlike the verifier
+    /// chip, this persists in the footer for active and stopped states.
+    GoalTransition {
+        action: String,
+        status: String,
+        phase: String,
+        goal: Option<String>,
+        goal_id: Option<String>,
+        pause_reason: Option<String>,
+        turn_count: u32,
+        verify_run_count: u32,
+    },
     SwarmIntelligenceConverged {
         swarm_id: String,
         round: u32,

--- a/test/channels/cli/line_editor_wrap_test.exs
+++ b/test/channels/cli/line_editor_wrap_test.exs
@@ -1,0 +1,25 @@
+defmodule OptimalSystemAgent.Channels.CLI.LineEditorWrapTest do
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Channels.CLI.LineEditor
+
+  test "long logical lines are counted as terminal visual rows" do
+    text = String.duplicate("x", 170)
+
+    assert LineEditor.visual_layout(text, 4, 80, 170) == %{
+             rendered_rows: 3,
+             cursor_row: 2,
+             cursor_col: 14
+           }
+  end
+
+  test "explicit newlines and terminal wrapping compose" do
+    text = String.duplicate("a", 77) <> "\n" <> String.duplicate("界", 41)
+
+    assert LineEditor.visual_layout(text, 2, 80, String.length(text)) == %{
+             rendered_rows: 3,
+             cursor_row: 2,
+             cursor_col: 4
+           }
+  end
+end

--- a/test/optimal_system_agent/utils/mojibake_test.exs
+++ b/test/optimal_system_agent/utils/mojibake_test.exs
@@ -1,0 +1,27 @@
+defmodule OptimalSystemAgent.Utils.MojibakeTest do
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Utils.Mojibake
+
+  test "repairs doubly decoded punctuation" do
+    assert Mojibake.repair("frontend Ã¢ÂÂ 16 components") == "frontend — 16 components"
+  end
+
+  test "repairs common doubly decoded symbols" do
+    assert Mojibake.repair("done Ã¢ÂÂ") == "done ✅"
+    assert Mojibake.repair("next Ã¢ÂÂ step") == "next → step"
+  end
+
+  test "leaves valid Unicode and legitimate Latin text unchanged" do
+    text = "São Paulo — café ✅"
+    assert Mojibake.repair(text) == text
+  end
+
+  test "repairs contaminated spans without changing adjacent valid Unicode" do
+    assert Mojibake.repair("valid ✅ then Ã¢ÂÂ broken") == "valid ✅ then — broken"
+  end
+
+  test "repairs the single-pass form whose controls render as a lone a-circumflex" do
+    assert Mojibake.repair("paused â I spent time") == "paused — I spent time"
+  end
+end

--- a/test/pty/stub_backend.py
+++ b/test/pty/stub_backend.py
@@ -372,15 +372,8 @@ def gets_since(mark: int, path: str | None = None) -> list[str]:
 #: while the backend says the goal is active, instead of stopping when the
 #: model's last line happens to read `DONE`.
 _GOAL: dict = {
-    "output": "Goal anchored",
-    "goal": {
-        "active": True,
-        "status": "active",
-        "goal": "ship the parser",
-        "goal_id": "g-1",
-        "turn_count": 1,
-        "pause_reason": None,
-    },
+    "output": "No goal is active.",
+    "goal": None,
 }
 
 
@@ -401,6 +394,12 @@ def set_goal_state(active: bool, status: str, pause_reason: str | None = None,
 
 def reset_goal_state() -> None:
     set_goal_state(True, "active", output="Goal anchored")
+
+
+def clear_goal_state() -> None:
+    """Make reconnect goal sync report that this session has no goal."""
+    _GOAL["output"] = "No goal is active."
+    _GOAL["goal"] = None
 
 
 class _Handler(BaseHTTPRequestHandler):

--- a/test/pty/test_resize.py
+++ b/test/pty/test_resize.py
@@ -2772,7 +2772,14 @@ def test_goal_is_anchored_on_the_backend_not_graded_in_the_client(
             s.pump(SETTLE)
             s.write(b"\r")
 
-            body = _wait_post(s, mark, "/api/v1/commands/execute", '"goal"')
+            # Reconnect now performs a silent `/goal status` sync first. Wait
+            # for the criteria-bearing anchor, not merely the first goal POST.
+            body = _wait_post(
+                s,
+                mark,
+                "/api/v1/commands/execute",
+                "mix test passes",
+            )
             if body is None:
                 raise AssertionError(
                     "/goal never reached the backend. This is the shipped "

--- a/test/pty/test_resize.py
+++ b/test/pty/test_resize.py
@@ -35,6 +35,7 @@ from osa_pty import (  # noqa: E402
 from stub_backend import (  # noqa: E402
     CLEARED_SESSION_ID,
     StubBackend,
+    clear_goal_state,
     end_turn,
     get_mark,
     gets_since,
@@ -2843,6 +2844,35 @@ def test_goal_is_anchored_on_the_backend_not_graded_in_the_client(
         reset_goal_state()
 
 
+def test_reconnect_restores_a_paused_goal_footer(backend: StubBackend) -> None:
+    """A durable goal remains visible and controllable after reopening OSA."""
+    set_goal_state(
+        False,
+        "paused",
+        pause_reason="user",
+        goal="publish the release",
+        output="Goal paused",
+    )
+    try:
+        with PtySession(backend.base_url, cols=120, rows=30) as s:
+            s.boot()
+            s.pump(1.0)
+            screen = "\n".join(s.lines())
+            if "Goal paused: publish the release" not in screen:
+                raise AssertionError(
+                    "reopening the TUI did not restore the paused goal description "
+                    "in the footer.\n"
+                    f"--- rendered screen ---\n{s.dump()}"
+                )
+            if "/goal resume" not in screen:
+                raise AssertionError(
+                    "the paused goal footer did not expose its resume control.\n"
+                    f"--- rendered screen ---\n{s.dump()}"
+                )
+    finally:
+        clear_goal_state()
+
+
 def test_a_running_subagent_is_not_squeezed_off_screen_by_a_plan(
     backend: StubBackend,
 ) -> None:
@@ -2974,6 +3004,7 @@ TESTS = [
     test_a_turn_that_goes_silent_says_so_instead_of_spinning_forever,
     test_a_turn_that_answers_nothing_says_so_instead_of_vanishing,
     test_goal_is_anchored_on_the_backend_not_graded_in_the_client,
+    test_reconnect_restores_a_paused_goal_footer,
     test_a_running_subagent_is_not_squeezed_off_screen_by_a_plan,
 ]
 
@@ -2983,6 +3014,10 @@ def main() -> int:
     with StubBackend(STUB_PORT) as backend:
         for test in TESTS:
             name = test.__name__
+            # Every PTY session reconnects and asks for its durable goal
+            # snapshot. Tests that need a goal opt in explicitly so one test's
+            # tracker state cannot consume status-bar space in the next one.
+            clear_goal_state()
             sys.stdout.write(f"  {name} ... ")
             sys.stdout.flush()
             try:


### PR DESCRIPTION
## What changed

- repair mojibake while loading persisted session transcripts
- make the backend goal tracker authoritative in the TUI
- restore active, paused, and completed goal state after reconnect
- keep the goal description and pause, resume, or clear control visible in the footer
- pause the durable backend goal when the TUI safety cap or an interrupt stops continuation
- forward model-created goal lifecycle transitions to the TUI
- calculate legacy LineEditor redraw and cursor positions using terminal-width wrapping and Unicode display width
- add Rust, Elixir, and real PTY regressions for the lifecycle and rendering paths

## Validation

- 85 focused Elixir tests passed
- 1,482 of 1,489 Rust tests passed, with 1 ignored
- 6 unrelated environment-dependent Rust tests fail on this macOS machine because they assume Linux executable paths, terminal hyperlink capabilities, or a syntax-color environment
- real PTY goal continuation regression passed
- real PTY paused-goal reconnect footer regression passed
- LineEditor ASCII and CJK wrapping regressions passed

Fixes #112
