### PR TITLE
fix(tui): responsive status and Claude thinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ from the noise and does the work that counts. One command to install. Runs
 locally. Works with any model.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-v1.0.064-blue.svg)](#)
+[![Version](https://img.shields.io/badge/Version-v1.0.108-blue.svg)](#)
 [![Elixir](https://img.shields.io/badge/Elixir-1.17+-purple.svg)](https://elixir-lang.org)
 [![OTP](https://img.shields.io/badge/OTP-27+-green.svg)](https://www.erlang.org)
 [![Tools](https://img.shields.io/badge/Tools-82-blue.svg)](#built-in-tools)
@@ -48,7 +48,7 @@ setup wizard: pick a provider, paste a key or take the local Ollama default,
 done. After that, type `osa` from anywhere on disk.
 
 Prebuilt targets: **linux-x64**, **macOS arm64**, **windows-x64**. Pin a
-specific release with `OSA_VERSION=v1.0.064` (`$env:OSA_VERSION = "v1.0.064"` on
+specific release with `OSA_VERSION=v1.0.108` (`$env:OSA_VERSION = "v1.0.108"` on
 Windows). On any other platform (macOS Intel, Linux arm64) the installer stops
 and points you at the from-source script below.
 
@@ -272,6 +272,29 @@ system     /doctor   /status   /metrics  /version  /update   /release-notes
 Some commands are served by the engine and some by the TUI; the palette merges
 both, so everything above is reachable from the same prompt.
 
+### Reading model performance
+
+The permanent footer stays deliberately small so it remains stable while the terminal resizes.
+It shows the active model, current context occupancy, and a reasoning-effort chip only when the effort differs from the default `medium` tier.
+Running `/fast`, for example, makes `effort:fast` appear immediately.
+
+The activity row reports what matters during a turn: elapsed time, current output flow, thinking state, retries, stalls, and the interrupt control.
+It does not repeat the latest request's input-token count because that number is the full prompt sent to the model, not cumulative session usage, and duplicating it beside the context meter is misleading.
+
+Use the on-demand views for diagnosis instead of packing every metric into permanent chrome:
+
+| Command | Use it for |
+|---|---|
+| `/context` | Current context occupancy and token breakdown |
+| `/cost` | Session token accounting and estimated spend |
+| `/usage` | Provider account quota and reported usage |
+| `/status` | Active provider, model, session, tools, and permission state |
+| `/reasoning` or `/effort` | Changing the speed-versus-depth tradeoff |
+
+For quick conversational work, use `fast`.
+Keep `medium` for normal coding and tool use, move to `high` or `xhigh` for difficult multi-step reasoning, and reserve `ultra` for work that benefits from maximum reasoning or dynamic workflow fan-out.
+Model latency, cost, and answer quality are separate signals, so compare them on the same task rather than treating token count alone as performance.
+
 ### `/map` — see the whole repo, not just the checkout
 
 `/map` renders the structure of the workspace you are in: its components, the
@@ -391,7 +414,10 @@ you approve, with the plan itself written to a durable file so it survives a
 context reset or restart. For long autonomous runs, an independent read-only
 goal verifier periodically checks whether your actual *goal* was met (not
 just whether a file compiled) and a cross-turn goal tracker auto-pauses on a
-stall instead of spinning forever. **Esc Esc** also drives the unified
+stall instead of spinning forever. While a durable goal is active, the TUI gives
+it a dedicated footer row with its elapsed time and `/goal pause`, `/goal resume`,
+or `/goal stop` control, so the goal remains readable without widening the
+terminal. **Esc Esc** also drives the unified
 `/rewind`: jump back to any previous turn (code + conversation, or either
 alone), see a diff of what's about to change, and undo the rewind itself if
 you change your mind.
@@ -1124,25 +1150,17 @@ table was owned by whichever process created it, and being reached from transien
 processes meant the first one to exit destroyed every session's ledger. Fixed in
 this release. **Both benchmark arms predate the fix.**
 
-### Known break as of 1.0.102 — TUI resize
+### TUI resize status
 
-Resizing the terminal destroys the on-screen transcript. Outside a multiplexer
-OSA wipes the screen on resize and rebuilds; measured in real libvte, prose
-partially survives while **bordered tables and code fences are absent from the
-transcript entirely**. The wipe is deliberate — it prevents a worse defect where
-erasing on VTE scrolls content into history instead, depositing a stacked copy
-per drag step.
+The resize break documented in 1.0.102 is fixed.
+OSA now owns the visible transcript, reflows retained content at the new width, keeps live surfaces at stable measured heights, and redraws from state instead of relying on terminal scrollback behavior.
+Tables, code fences, the composer, thinking output, activity, goals, and status rows therefore resize as one layout rather than leaving stacked or duplicated frames behind.
 
-The fix is to own the scrollback and re-render the retained transcript at the new
-width. That is 1.0.103. Hyperlinks are **not** a cost of that change: OSA's
-renderer already lays lines out at true visible width and attaches escapes to the
-following cell, so an owned scrollback keeps OSC-8 intact.
+The status footer uses progressive disclosure at narrow widths.
+The context label survives first, its decorative meter shortens when necessary, and optional effort, MCP, and version chips render only when each complete chip fits.
+Active goals use their own row so their description and controls do not compete with model and context information.
 
-`test/pty/vte_content_reflow.py` is the instrument; it drives the release binary
-inside the library GNOME Terminal and Tilix use. It measures the wipe, not the
-terminal's reflow of already-committed rows, and it cannot see OSC-8 — stated
-because both existing test paths are structurally blind to reflow, which is how
-31 passing PTY tests coexisted with a broken screen.
+`test/pty/test_resize.py` exercises the release binary through a real pseudo-terminal, while `test/pty/vte_content_reflow.py` covers the libvte behavior used by GNOME Terminal and Tilix.
 
 ### Prefix cost as of 1.0.101
 

--- a/bin/version-bump
+++ b/bin/version-bump
@@ -106,6 +106,15 @@ fi
 
 echo "$NEW" > "$VERSION_FILE"
 
+# Keep the public install examples honest. The README advertises the latest
+# published release in both its badge and its pinned-install example, so a
+# release bump must update those references in the same tagged commit.
+README="$ROOT/README.md"
+if [ -f "$README" ]; then
+  awk -v old="v${CURRENT}" -v new="v${NEW}" \
+    '{gsub(old, new); print}' "$README" > "$README.tmp" && mv "$README.tmp" "$README"
+fi
+
 # Keep the Rust TUI crate version in lockstep — single source of truth.
 # Cargo/SemVer forbid leading zeros, so the crate version stays plain SemVer.
 CARGO_TOML="$ROOT/priv/rust/tui/Cargo.toml"
@@ -134,6 +143,7 @@ fi
 
 git add VERSION "$CARGO_TOML"
 [ -f "$CARGO_LOCK" ] && git add "$CARGO_LOCK"
+[ -f "$README" ] && git add "$README"
 git commit -m "bump: ${TAG}"
 git tag "$TAG"
 

--- a/lib/optimal_system_agent/agent/loop/llm_client.ex
+++ b/lib/optimal_system_agent/agent/loop/llm_client.ex
@@ -422,8 +422,11 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
       Task.async(fn ->
         res =
           case Providers.chat_stream(messages, callback, opts) do
-            {:ok, _} = success ->
-              success
+            :ok ->
+              # Callback-based streaming providers report the response through
+              # `callback` and return `:ok` when the stream closes normally.
+              # `Providers.chat_stream/3` documents exactly that contract.
+              :ok
 
             {:error, reason} = error ->
               # Try fallback chain on retryable errors

--- a/lib/optimal_system_agent/channels/http/api/agent_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/agent_routes.ex
@@ -10,6 +10,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AgentRoutes do
   """
   use Plug.Router
   import OptimalSystemAgent.Channels.HTTP.API.Shared
+  alias OptimalSystemAgent.Channels.HTTP.SessionAccess
   alias OptimalSystemAgent.Runtime.SessionManager
   require Logger
 
@@ -46,7 +47,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AgentRoutes do
     session_id = conn.params["session_id"]
     user_id = conn.assigns[:user_id]
 
-    case validate_session_owner(session_id, user_id) do
+    case SessionAccess.authorize(session_id, user_id) do
       :ok ->
         # Opening the session's event stream is how a client ANNOUNCES a session
         # id it holds. The TUI mints its own id locally at startup
@@ -84,34 +85,6 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AgentRoutes do
 
   match _ do
     json_error(conn, 404, "not_found", "Agent endpoint not found")
-  end
-
-  # ── Session Ownership Validation ────────────────────────────────────
-
-  defp validate_session_owner(session_id, user_id) do
-    case Registry.lookup(OptimalSystemAgent.SessionRegistry, session_id) do
-      [{_pid, owner}] ->
-        cond do
-          user_id == "anonymous" ->
-            :ok
-
-          owner == user_id ->
-            :ok
-
-          true ->
-            Logger.warning(
-              "[API] Session ownership mismatch: session=#{session_id} owner=#{inspect(owner)} requester=#{inspect(user_id)}"
-            )
-
-            {:error, :not_found}
-        end
-
-      _ ->
-        # Session not in registry yet (not started or stored-only).
-        # Allow any authenticated user to connect — they'll receive
-        # events once the session starts processing.
-        :ok
-    end
   end
 
   # ── SSE Loop ────────────────────────────────────────────────────────

--- a/lib/optimal_system_agent/channels/http/api/auth_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/auth_routes.ex
@@ -41,7 +41,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AuthRoutes do
     with :ok <- verify_login_secret(conn) do
       user_id =
         get_in(conn.body_params, ["user_id"]) ||
-          "tui_#{System.unique_integer([:positive])}"
+          default_user_id()
 
       token = Auth.generate_token(%{"user_id" => user_id})
       refresh = Auth.generate_refresh_token(%{"user_id" => user_id})
@@ -106,6 +106,17 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AuthRoutes do
   end
 
   # ── Helpers ──────────────────────────────────────────────────────────
+
+  # Local OSA is one user talking to one loopback-only daemon. A random id here
+  # made that same person become a different session owner after every fresh
+  # login, especially after an ephemeral JWT secret rotated on backend restart.
+  # Keep remote fallback behaviour isolated; authenticated deployments should
+  # continue sending an explicit account id.
+  defp default_user_id do
+    if Auth.loopback_only?(),
+      do: "local",
+      else: "tui_#{System.unique_integer([:positive])}"
+  end
 
   # Returns :ok when the request is allowed to proceed, {:error, :unauthorized}
   # when the secret check fails.

--- a/lib/optimal_system_agent/channels/http/api/session_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/session_routes.ex
@@ -20,6 +20,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.SessionRoutes do
   require Logger
 
   alias OptimalSystemAgent.Runtime.SessionManager
+  alias OptimalSystemAgent.Channels.HTTP.SessionAccess
   alias OptimalSystemAgent.SDK.Memory
 
   plug(:match)
@@ -525,27 +526,33 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.SessionRoutes do
     session_id = conn.params["id"]
     user_id = conn.assigns[:user_id] || "anonymous"
 
-    # Same announcement semantics as GET /stream/:session_id in AgentRoutes:
-    # subscribing records the client-held id so pre-first-turn, session-scoped
-    # writes (model switch) resolve instead of 404ing. No Loop is started here.
-    SessionManager.track_session(session_id, %{user_id: user_id, channel: :sse})
+    case SessionAccess.authorize(session_id, user_id) do
+      :ok ->
+        # Same announcement semantics as GET /stream/:session_id in AgentRoutes:
+        # subscribing records the client-held id so pre-first-turn, session-scoped
+        # writes (model switch) resolve instead of 404ing. No Loop is started here.
+        SessionManager.track_session(session_id, %{user_id: user_id, channel: :sse})
 
-    Phoenix.PubSub.subscribe(OptimalSystemAgent.PubSub, "osa:session:#{session_id}")
+        Phoenix.PubSub.subscribe(OptimalSystemAgent.PubSub, "osa:session:#{session_id}")
 
-    conn =
-      conn
-      |> put_resp_content_type("text/event-stream")
-      |> put_resp_header("cache-control", "no-cache")
-      |> put_resp_header("connection", "keep-alive")
-      |> put_resp_header("x-accel-buffering", "no")
-      |> send_chunked(200)
+        conn =
+          conn
+          |> put_resp_content_type("text/event-stream")
+          |> put_resp_header("cache-control", "no-cache")
+          |> put_resp_header("connection", "keep-alive")
+          |> put_resp_header("x-accel-buffering", "no")
+          |> send_chunked(200)
 
-    {:ok, conn} =
-      chunk(conn, "event: connected\ndata: {\"session_id\": \"#{session_id}\"}\n\n")
+        {:ok, conn} =
+          chunk(conn, "event: connected\ndata: {\"session_id\": \"#{session_id}\"}\n\n")
 
-    Logger.debug("[SSE] /sessions/#{session_id}/stream opened by #{user_id}")
+        Logger.debug("[SSE] /sessions/#{session_id}/stream opened by #{user_id}")
 
-    session_sse_loop(conn, session_id)
+        session_sse_loop(conn, session_id)
+
+      {:error, :not_found} ->
+        json_error(conn, 404, "not_found", "Session not found")
+    end
   end
 
   # ── DELETE /sessions/:id ───────────────────────────────────────────

--- a/lib/optimal_system_agent/channels/http/session_access.ex
+++ b/lib/optimal_system_agent/channels/http/session_access.ex
@@ -1,0 +1,53 @@
+defmodule OptimalSystemAgent.Channels.HTTP.SessionAccess do
+  @moduledoc """
+  Authorizes HTTP clients against the owner of a live agent session.
+
+  Older local TUI releases minted a new `tui_*` user id whenever the backend's
+  ephemeral JWT secret rotated. After a restart, the same person therefore
+  appeared to be a different owner and could not resume their own session.
+  Local OSA is a single-user, loopback-only service, so those legacy identities
+  are compatible with the stable `local` identity. Remote and multi-user
+  deployments still require an exact owner match.
+  """
+
+  alias OptimalSystemAgent.Channels.HTTP.Auth
+  require Logger
+
+  @spec authorize(String.t(), String.t() | nil) :: :ok | {:error, :not_found}
+  def authorize(session_id, requester) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, session_id) do
+      [{_pid, owner}] ->
+        case authorize_owner(owner, requester, Auth.loopback_only?()) do
+          :ok ->
+            :ok
+
+          {:error, :not_found} = error ->
+            Logger.warning(
+              "[API] Session ownership mismatch: session=#{session_id} " <>
+                "owner=#{inspect(owner)} requester=#{inspect(requester)}"
+            )
+
+            error
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
+  @spec authorize_owner(term(), term(), boolean()) :: :ok | {:error, :not_found}
+  def authorize_owner(owner, requester, loopback_only?) do
+    cond do
+      requester == "anonymous" -> :ok
+      owner == requester -> :ok
+      legacy_local_owner?(owner, requester, loopback_only?) -> :ok
+      true -> {:error, :not_found}
+    end
+  end
+
+  defp legacy_local_owner?(owner, "local", true) when is_binary(owner),
+    do: String.starts_with?(owner, "tui_")
+
+  defp legacy_local_owner?(_, _, _), do: false
+end

--- a/lib/optimal_system_agent/providers/anthropic.ex
+++ b/lib/optimal_system_agent/providers/anthropic.ex
@@ -1279,7 +1279,12 @@ defmodule OptimalSystemAgent.Providers.Anthropic do
   def maybe_add_thinking(body, nil), do: body
 
   def maybe_add_thinking(body, %{type: "adaptive"}) do
-    Map.put(body, :thinking, %{type: "adaptive"})
+    # Claude 5 still reasons when `display` is omitted, but Anthropic defaults
+    # current adaptive models to `omitted`: no readable `thinking_delta` events
+    # are streamed, so the TUI appears to skip thinking only for Claude. Ask
+    # for the provider's safe summarized view. This never exposes raw chain of
+    # thought; Anthropic generates the display summary separately.
+    Map.put(body, :thinking, %{type: "adaptive", display: "summarized"})
   end
 
   def maybe_add_thinking(body, %{type: "enabled", budget_tokens: budget}) do

--- a/priv/rust/tui/src/app/event_loop.rs
+++ b/priv/rust/tui/src/app/event_loop.rs
@@ -2446,6 +2446,7 @@ impl App {
             survey,
             popup: self.input.popup_desired_height(),
             input: self.input.desired_height(w),
+            status: self.status.desired_height(),
             // Keep one roster row alive while a subagent is. Not while the band
             // merely has rows to draw — a roster of finished agents is history,
             // and history loses to the plan like everything else on the ladder.

--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -704,6 +704,7 @@ impl App {
         // composer (CC PromptInputQueuedCommands), so no toast: the user can
         // see and verify exactly what they queued, and recall it with ↑/Esc.
         self.input.set_queued_items(self.message_queue.clone());
+        self.activity.set_queued(self.message_queue.len());
         self.recompute_layout();
     }
 
@@ -755,6 +756,7 @@ impl App {
         }
         let next = self.message_queue.remove(0);
         self.input.set_queued_items(self.message_queue.clone());
+        self.activity.set_queued(self.message_queue.len());
         self.recompute_layout();
         // Re-enter the normal submit path so queued commands / shell / prompts
         // all behave exactly as if freshly typed at an Idle prompt.

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -184,6 +184,12 @@ impl App {
                     self.goal_intent = Some(crate::app::handle_actions::GoalIntent::Silent);
                     self.execute_backend_command_quiet("goal", "status");
                 }
+                // A prompt retained across a transient disconnect or a stale
+                // resumed-session recovery may run only after a real stream is
+                // attached. The disconnect path lands Idle and marks the turn
+                // done, but deliberately keeps the queue intact; this is the
+                // reliable boundary that drains it.
+                self.maybe_dequeue_message();
             }
             BackendEvent::SseDisconnected { error } => {
                 match error.as_deref() {
@@ -232,6 +238,24 @@ impl App {
                         // reconnect, no error, just clear any stale banner.
                         debug!("SSE cancelled by client");
                         self.sse_reconnecting = false;
+                    }
+                    Some("session_not_found") => {
+                        // The backend is healthy but this resumed session no
+                        // longer exists. Retrying the same stream can never
+                        // work. Preserve queued input, retire any in-flight
+                        // turn, and create a fresh session. SessionCreated will
+                        // attach its SSE stream; SseConnected drains the queue.
+                        warn!("SSE session no longer exists; creating a replacement session");
+                        if self.turn_is_active() {
+                            self.end_active_turn_on_disconnect();
+                        }
+                        self.sse_reconnecting = false;
+                        self.toasts.push(
+                            "That session is no longer available. Starting a fresh session…"
+                                .into(),
+                            crate::components::toast::ToastLevel::Warning,
+                        );
+                        self.create_session();
                     }
                     Some("exhausted") => {
                         // Reconnect budget exhausted — honest terminal error.

--- a/priv/rust/tui/src/client/sse.rs
+++ b/priv/rust/tui/src/client/sse.rs
@@ -127,6 +127,17 @@ impl SseClient {
                     });
                     return;
                 }
+                Err(SseError::SessionNotFound) => {
+                    // A 404 is permanent for this session id. Retrying it with
+                    // network backoff only leaves the TUI stuck on
+                    // "Reconnecting…" for minutes. Hand recovery to the app,
+                    // which can create a replacement session and preserve any
+                    // queued prompt until that new stream is attached.
+                    let _ = self.send(BackendEvent::SseDisconnected {
+                        error: Some("session_not_found".to_string()),
+                    });
+                    return;
+                }
                 Err(SseError::Disconnected { err: e, connected }) => {
                     // D5: a drop that occurred AFTER the stream attached resets
                     // the budget (a recovered blip must not accumulate toward
@@ -206,6 +217,9 @@ impl SseClient {
         let status = resp.status();
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             return Err(SseError::AuthFailed);
+        }
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(SseError::SessionNotFound);
         }
         if !status.is_success() {
             return Err(SseError::Disconnected {
@@ -303,6 +317,7 @@ fn next_reconnect_attempt(attempt: u32, connected: bool) -> u32 {
 enum SseError {
     AuthFailed,
     Cancelled,
+    SessionNotFound,
     /// A network/stream failure. `connected` is true when the failure happened
     /// AFTER the stream body was successfully attached (a mid-stream drop), so
     /// the reconnect loop can reset its backoff budget for a recovered blip
@@ -2153,6 +2168,40 @@ mod tests {
             }
             other => panic!("expected a mid-stream Disconnected, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn a_missing_session_is_not_retried_as_a_network_failure() {
+        use tokio::io::AsyncWriteExt;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut buf).await;
+            sock.write_all(
+                b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        });
+
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let client = SseClient::with_cancel(
+            "missing-session".to_string(),
+            format!("http://{addr}"),
+            String::new(),
+            tx,
+            CancellationToken::new(),
+        );
+
+        let result = client.connect_once().await;
+        server.await.unwrap();
+        assert!(
+            matches!(result, Err(SseError::SessionNotFound)),
+            "a permanent 404 must trigger session recovery, not ten reconnects: {result:?}"
+        );
     }
 
     #[test]

--- a/priv/rust/tui/src/components/activity.rs
+++ b/priv/rust/tui/src/components/activity.rs
@@ -1747,11 +1747,9 @@ impl Component for Activity {
 
         // (The turn timer is already the leading part, bound to the interrupt hint.)
 
-        // Item 4 — input + cache breakdown, so the count reflects the true
-        // context-window number, not output-only.
-        if self.input_tokens > 0 {
-            parts.push(format!("\u{2191} {} in", format_count(self.input_tokens as usize)));
-        }
+        // Input tokens describe the full prompt sent on the latest request.
+        // The footer context meter and `/context` own that information. Showing
+        // it here as `↑ N in` duplicated the meter and looked cumulative.
         let cached = self.cache_read_tokens + self.cache_write_tokens;
         if cached > 0 {
             parts.push(format!("\u{26A1} {} cached", format_count(cached as usize)));
@@ -2190,6 +2188,19 @@ mod activity_tests {
     }
 
     #[test]
+    fn activity_row_does_not_duplicate_prompt_context_tokens() {
+        let mut act = Activity::new();
+        act.start();
+        act.verbosity = Verbosity::Verbose;
+        act.set_tokens(534_500, 3_000);
+        let text = render_activity_text(&act);
+        assert!(
+            !text.contains("534.5k in") && !text.contains("534,500 in"),
+            "request input belongs in the context view, not permanent activity chrome: {text:?}"
+        );
+    }
+
+    #[test]
     fn spinner_verb_is_stable_for_a_turn() {
         let mut act = Activity::new();
         act.start();
@@ -2322,9 +2333,9 @@ mod activity_tests {
     }
 
     #[test]
-    fn token_sum_includes_input_and_cache() {
-        // Item 4 — the true total sums input + output + reasoning + cache r/w,
-        // not output-only, and the input/cache figures surface on the row.
+    fn token_sum_includes_input_and_cache_without_duplicating_context() {
+        // The internal total still includes input + output + reasoning + cache
+        // r/w. Only the duplicate input display leaves the activity row.
         let mut act = Activity::new();
         act.start();
         act.set_tokens_detailed(1000, 200, 50, 4000, 100);
@@ -2336,7 +2347,7 @@ mod activity_tests {
             "true total must exceed output-only"
         );
         let text = render_activity_text(&act);
-        assert!(text.contains("in"), "input tokens must surface, got: {text:?}");
+        assert!(!text.contains("1.0k in"), "input context leaked onto the row: {text:?}");
         assert!(text.contains("cached"), "cache tokens must surface");
     }
 
@@ -2842,7 +2853,7 @@ mod activity_tests {
         assert!(wide.contains("queued"), "{wide}");
 
         // Narrower: the queue counter is gone, the stall notice is not.
-        let mid = render_activity_text_sized(&wedged, 92, 1);
+        let mid = render_activity_text_sized(&wedged, 80, 1);
         assert!(
             mid.contains("no response for"),
             "the stall notice was dropped before a queue counter: {mid}"

--- a/priv/rust/tui/src/components/status_bar.rs
+++ b/priv/rust/tui/src/components/status_bar.rs
@@ -558,6 +558,13 @@ impl StatusBar {
         self.goal_label = label;
     }
 
+    /// Two ordinary status rows, plus one dedicated goal row while a durable
+    /// goal exists. Keeping this measurement on the component makes the layout
+    /// reserve exactly what `draw` paints.
+    pub fn desired_height(&self) -> u16 {
+        if self.goal_label.is_some() { 3 } else { 2 }
+    }
+
     /// Set (or clear with None) the transient goal-verification indicator.
     pub fn set_goal_verification(&mut self, state: Option<GoalVerifyState>) {
         self.goal_verify = state;
@@ -997,17 +1004,29 @@ impl Component for StatusBar {
     fn draw(&self, frame: &mut Frame, area: Rect) {
         let theme = style::theme();
 
-        // Split into two rows: status line + permission/shell line.
+        // A goal owns its own row. It used to be appended to the already-dense
+        // primary status line, where normal terminal widths clipped the goal
+        // text and often left only a dangling `/` from `/goal pause`.
+        let row_constraints = if self.goal_label.is_some() {
+            vec![Constraint::Length(1), Constraint::Length(1), Constraint::Length(1)]
+        } else {
+            vec![Constraint::Length(1), Constraint::Length(1)]
+        };
         let rows = RLayout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(1), Constraint::Length(1)])
+            .constraints(row_constraints)
             .split(area);
         // Reserve a 1-column right gutter on both status rows so the right-most
         // segment (version chip / bg counter) never clips mid-glyph against the
         // terminal edge — parity with draw_context_hint's gutter (edd66d5).
         let row0 = Rect { width: rows[0].width.saturating_sub(1), ..rows[0] };
+        let goal_row = self.goal_label.as_ref().and_then(|_| rows.get(1)).map(|r| Rect {
+            width: r.width.saturating_sub(1),
+            ..*r
+        });
+        let permission_row_index = if self.goal_label.is_some() { 2 } else { 1 };
         let row1 = rows
-            .get(1)
+            .get(permission_row_index)
             .map(|r| Rect { width: r.width.saturating_sub(1), ..*r })
             .unwrap_or(row0);
         let area = row0; // special-case single-line indicators render into row 0
@@ -1227,15 +1246,6 @@ impl Component for StatusBar {
             ));
         }
 
-        // Active /goal auto-continue loop: "◎ goal N/max".
-        if let Some(ref goal_label) = self.goal_label {
-            spans.push(Span::styled(" \u{2502} ", theme.status_sep()));
-            spans.push(Span::styled(
-                format!("\u{25CE} {}", goal_label),
-                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
-            ));
-        }
-
         // Goal-verification indicator — the agent judging its own work. One
         // compact, understated chip tied to the goal line: dim for the common
         // verifying/on-track cases, warning for a gap, error for off-track.
@@ -1413,6 +1423,17 @@ impl Component for StatusBar {
             Paragraph::new(Line::from(spans)).style(theme.status_bar()),
             row0,
         );
+
+        if let (Some(goal_label), Some(goal_area)) = (self.goal_label.as_ref(), goal_row) {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    format!("\u{25CE} {}", goal_label),
+                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                )))
+                .style(theme.status_bar()),
+                goal_area,
+            );
+        }
 
         // ── Row 1: permission / shell / background line ─────────────────
         //   ⏵⏵ bypass permissions on · N shells · N bg
@@ -1868,8 +1889,12 @@ mod status_bar_tests {
 
     /// Flatten a fully-configured StatusBar's cells to one string.
     fn render_sb(sb: &StatusBar) -> String {
+        render_sb_at(sb, 120, 2)
+    }
+
+    fn render_sb_at(sb: &StatusBar, width: u16, height: u16) -> String {
         use ratatui::{backend::TestBackend, Terminal};
-        let mut term = Terminal::new(TestBackend::new(120, 2)).unwrap();
+        let mut term = Terminal::new(TestBackend::new(width, height)).unwrap();
         term.draw(|f| sb.draw(f, f.area())).unwrap();
         term.backend()
             .buffer()
@@ -1877,6 +1902,25 @@ mod status_bar_tests {
             .iter()
             .map(|c| c.symbol())
             .collect()
+    }
+
+    #[test]
+    fn narrow_goal_gets_an_aligned_dedicated_row_with_complete_controls() {
+        let mut sb = StatusBar::new();
+        sb.set_provider_info("anthropic", "claude-opus-5");
+        sb.set_cwd_path("/work/miosa");
+        sb.set_effort(Some("medium".into()));
+        sb.set_mcp(12);
+        sb.set_permission_mode(PermissionMode::BypassPermissions);
+        sb.set_goal_label(Some(
+            "Pursuing: Complete the MIOSA Forge product: m… · 3m 54s · /goal pause"
+                .into(),
+        ));
+
+        let text = render_sb_at(&sb, 100, 3);
+        assert!(text.contains("Pursuing: Complete the MIOSA Forge product"), "goal description was clipped: {text:?}");
+        assert!(text.contains("/goal pause"), "goal control was clipped: {text:?}");
+        assert!(text.contains("overdrive (full auto) on"), "permission row disappeared: {text:?}");
     }
 
     #[test]

--- a/priv/rust/tui/src/components/status_bar.rs
+++ b/priv/rust/tui/src/components/status_bar.rs
@@ -22,6 +22,20 @@ const TITLE_MIN_COLS: usize = 16;
 /// Upper bound so a long title cannot dominate row 0 on a wide terminal.
 const TITLE_MAX_COLS: usize = 32;
 
+fn spans_cols(spans: &[Span<'_>]) -> usize {
+    spans.iter().map(|span| cols(span.content.as_ref())).sum()
+}
+
+/// Append an optional status segment only when it fits in full. Ratatui clips
+/// overflowing lines cell-by-cell, which previously left fragments such as
+/// `effort:med` or `12 MC` after a resize. A chip is useful as a whole or it is
+/// omitted.
+fn push_segment_if_fits<'a>(spans: &mut Vec<Span<'a>>, segment: Vec<Span<'a>>, width: u16) {
+    if spans_cols(spans) + spans_cols(&segment) <= width as usize {
+        spans.extend(segment);
+    }
+}
+
 /// Tool-permission mode. OSA's Shift+Tab cycle is
 /// `ask → auto-edit → plan → overdrive (full auto)`. `Auto` is retained as a
 /// separate tier driven by the `/auto` command (the safety guardian) but is not
@@ -1200,7 +1214,11 @@ impl Component for StatusBar {
                 ));
             }
         } else {
-            let (bar_filled, bar_empty) = braille_bar(disp_ratio, 8);
+            // Keep the context label intact on narrow panes. The meter loses
+            // cells before its meaning is clipped, preserving `N% ctx` as the
+            // stable core while retaining the full 8-cell bar when space allows.
+            let bar_cells = if area.width < 50 { 4 } else { 8 };
+            let (bar_filled, bar_empty) = braille_bar(disp_ratio, bar_cells);
             if !bar_filled.is_empty() {
                 spans.push(Span::styled(bar_filled, Style::default().fg(ctx_color)));
             }
@@ -1317,11 +1335,14 @@ impl Component for StatusBar {
             }
         }
 
-        // Reasoning-effort chip (`effort:medium`). Faint for fast/medium; the
-        // heavier high/xhigh/ultra tiers get the accent color so a costly setting
-        // is visible at a glance. Omitted entirely when the backend didn't report.
-        if let Some(ref effort) = self.effort {
-            spans.push(Span::styled(" \u{2502} ", theme.status_sep()));
+        // Non-default reasoning-effort chip. Medium is the quiet default; fast
+        // and the heavier tiers remain visible so commands such as `/fast` have
+        // immediate, persistent confirmation.
+        if let Some(effort) = self
+            .effort
+            .as_ref()
+            .filter(|effort| effort.as_str() != "medium")
+        {
             let heavy = matches!(effort.as_str(), "high" | "xhigh" | "ultra");
             let style = if heavy {
                 Style::default()
@@ -1330,14 +1351,27 @@ impl Component for StatusBar {
             } else {
                 theme.faint()
             };
-            spans.push(Span::styled(format!("effort:{}", effort), style));
+            push_segment_if_fits(
+                &mut spans,
+                vec![
+                    Span::styled(" \u{2502} ", theme.status_sep()),
+                    Span::styled(format!("effort:{}", effort), style),
+                ],
+                row0.width,
+            );
         }
 
         // MCP chip (`3 MCP`). U-T26. Omitted when no servers.
         if let Some(mcp) = mcp_label(self.mcp_count) {
-            spans.push(Span::styled(" \u{2502} ", theme.status_sep()));
             let style = Style::default().fg(theme.colors.primary);
-            spans.push(Span::styled(mcp, style));
+            push_segment_if_fits(
+                &mut spans,
+                vec![
+                    Span::styled(" \u{2502} ", theme.status_sep()),
+                    Span::styled(mcp, style),
+                ],
+                row0.width,
+            );
         }
 
         // Hook chip (`hooks 54 ok, 19 failed`). Omitted until a hook has run.
@@ -1413,11 +1447,17 @@ impl Component for StatusBar {
 
         // Persistent OSA version chip (single build-time source — never stale).
         // Right-most element so it's the first to be clipped on narrow panes.
-        spans.push(Span::styled(" \u{2502} ", theme.status_sep()));
-        spans.push(Span::styled(
-            format!("v{}", crate::config::osa_version_display()),
-            theme.faint(),
-        ));
+        push_segment_if_fits(
+            &mut spans,
+            vec![
+                Span::styled(" \u{2502} ", theme.status_sep()),
+                Span::styled(
+                    format!("v{}", crate::config::osa_version_display()),
+                    theme.faint(),
+                ),
+            ],
+            row0.width,
+        );
 
         frame.render_widget(
             Paragraph::new(Line::from(spans)).style(theme.status_bar()),
@@ -1921,6 +1961,57 @@ mod status_bar_tests {
         assert!(text.contains("Pursuing: Complete the MIOSA Forge product"), "goal description was clipped: {text:?}");
         assert!(text.contains("/goal pause"), "goal control was clipped: {text:?}");
         assert!(text.contains("overdrive (full auto) on"), "permission row disappeared: {text:?}");
+    }
+
+    #[test]
+    fn default_effort_is_quiet_but_non_default_effort_is_visible() {
+        let mut sb = StatusBar::new();
+        sb.set_provider_info("anthropic", "claude-opus-5");
+        sb.set_context(0.17, 170_000, 1_000_000);
+
+        sb.set_effort(Some("medium".into()));
+        let default = render_sb_at(&sb, 100, 2);
+        assert!(
+            !default.contains("effort:medium"),
+            "the default effort is permanent footer noise: {default:?}"
+        );
+
+        sb.set_effort(Some("fast".into()));
+        let fast = render_sb_at(&sb, 100, 2);
+        assert!(
+            fast.contains("effort:fast"),
+            "a /fast change must be immediately visible: {fast:?}"
+        );
+    }
+
+    #[test]
+    fn narrow_status_rows_never_clip_optional_chips() {
+        let mut sb = StatusBar::new();
+        sb.set_provider_info("anthropic", "claude-opus-5");
+        sb.set_cwd_path("/work/miosa");
+        sb.set_context(0.17, 170_000, 1_000_000);
+        sb.set_effort(Some("fast".into()));
+        sb.set_mcp(12);
+
+        for width in [40u16, 60, 80, 100] {
+            let text = render_sb_at(&sb, width, 2);
+            assert!(
+                text.contains("ctx"),
+                "context disappeared at {width}: {text:?}"
+            );
+            if text.contains("effort:") {
+                assert!(
+                    text.contains("effort:fast"),
+                    "effort chip clipped at {width}: {text:?}"
+                );
+            }
+            if text.contains("12 M") {
+                assert!(
+                    text.contains("12 MCP"),
+                    "MCP chip clipped at {width}: {text:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/test/channels/http/auth_routes_test.exs
+++ b/test/channels/http/auth_routes_test.exs
@@ -72,14 +72,14 @@ defmodule OptimalSystemAgent.Channels.HTTP.AuthRoutesTest do
       assert body["expires_in"] == 900
     end
 
-    test "auto-generates user_id when not provided" do
+    test "uses the stable local identity when user_id is not provided" do
       conn = json_post("/login", %{})
 
       assert conn.status == 200
       body = decode_body(conn)
       assert is_binary(body["token"])
-      # token must be a valid JWT (3 segments)
-      assert length(String.split(body["token"], ".")) == 3
+      assert {:ok, claims} = Auth.verify_token(body["token"])
+      assert claims["user_id"] == "local"
     end
 
     test "returned token is verifiable" do

--- a/test/channels/http/session_access_test.exs
+++ b/test/channels/http/session_access_test.exs
@@ -1,0 +1,23 @@
+defmodule OptimalSystemAgent.Channels.HTTP.SessionAccessTest do
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Channels.HTTP.SessionAccess
+
+  test "stable local identity can reclaim a legacy random TUI owner on loopback" do
+    assert :ok == SessionAccess.authorize_owner("tui_1786981622480213000", "local", true)
+  end
+
+  test "legacy-owner compatibility never crosses a network boundary" do
+    assert {:error, :not_found} ==
+             SessionAccess.authorize_owner("tui_1786981622480213000", "local", false)
+  end
+
+  test "one explicit user cannot open another explicit user's session" do
+    assert {:error, :not_found} == SessionAccess.authorize_owner("alice", "bob", true)
+    assert {:error, :not_found} == SessionAccess.authorize_owner("alice", "bob", false)
+  end
+
+  test "the exact owner remains authorized" do
+    assert :ok == SessionAccess.authorize_owner("alice", "alice", false)
+  end
+end

--- a/test/providers/anthropic_effort_test.exs
+++ b/test/providers/anthropic_effort_test.exs
@@ -188,7 +188,9 @@ defmodule OptimalSystemAgent.Providers.AnthropicEffortTest do
 
       # ...and the thinking block is STILL the reason: it is identical in all
       # five. Depth rides entirely on output_config.
-      assert bodies |> Enum.map(& &1.thinking) |> Enum.uniq() == [%{type: "adaptive"}]
+      assert bodies |> Enum.map(& &1.thinking) |> Enum.uniq() == [
+               %{type: "adaptive", display: "summarized"}
+             ]
 
       assert Enum.map(bodies, & &1.output_config) == [
                %{effort: "low"},

--- a/test/providers/anthropic_test.exs
+++ b/test/providers/anthropic_test.exs
@@ -309,7 +309,7 @@ defmodule OptimalSystemAgent.Providers.AnthropicTest do
     test "adds adaptive thinking" do
       body = %{model: "test"}
       result = Anthropic.maybe_add_thinking(body, %{type: "adaptive"})
-      assert result.thinking == %{type: "adaptive"}
+      assert result.thinking == %{type: "adaptive", display: "summarized"}
     end
 
     test "adds enabled thinking with minimum 1024 budget" do

--- a/test/providers/anthropic_thinking_test.exs
+++ b/test/providers/anthropic_thinking_test.exs
@@ -17,7 +17,15 @@ defmodule OptimalSystemAgent.Providers.AnthropicThinkingTest do
       thinking = %{type: "adaptive"}
 
       result = Anthropic.maybe_add_thinking(body, thinking)
-      assert result.thinking == %{type: "adaptive"}
+      assert result.thinking == %{type: "adaptive", display: "summarized"}
+    end
+
+    test "requests a visible thinking summary for Claude 5" do
+      body = %{model: "claude-opus-5", max_tokens: 16_000}
+
+      result = Anthropic.maybe_add_thinking(body, %{type: "adaptive"})
+
+      assert result.thinking == %{type: "adaptive", display: "summarized"}
     end
 
     test "no-ops when thinking is nil" do

--- a/test/providers/effort_thinking_matrix_test.exs
+++ b/test/providers/effort_thinking_matrix_test.exs
@@ -81,7 +81,7 @@ defmodule OptimalSystemAgent.Providers.EffortThinkingMatrixTest do
         assert cfg == %{type: "adaptive"}
 
         body = Anthropic.maybe_add_thinking(%{model: @opus}, cfg)
-        assert body.thinking == %{type: "adaptive"}
+        assert body.thinking == %{type: "adaptive", display: "summarized"}
       end
     end
 
@@ -91,7 +91,7 @@ defmodule OptimalSystemAgent.Providers.EffortThinkingMatrixTest do
       assert cfg == %{type: "adaptive"}
 
       body = Anthropic.maybe_add_thinking(%{model: @opus}, cfg)
-      assert body.thinking == %{type: "adaptive"}
+      assert body.thinking == %{type: "adaptive", display: "summarized"}
     end
 
     test "opus at fast → no thinking block" do
@@ -108,7 +108,7 @@ defmodule OptimalSystemAgent.Providers.EffortThinkingMatrixTest do
         assert cfg == %{type: "adaptive"}
 
         body = Anthropic.maybe_add_thinking(%{model: @sonnet}, cfg)
-        assert body.thinking == %{type: "adaptive"}
+        assert body.thinking == %{type: "adaptive", display: "summarized"}
       end
     end
 

--- a/test/providers/google_system_hoist_test.exs
+++ b/test/providers/google_system_hoist_test.exs
@@ -191,7 +191,10 @@ defmodule OptimalSystemAgent.Providers.GoogleSystemHoistTest do
   # ── Dispatch-level: assert the real serialized wire body ───────────────────
   describe "chat/2 dispatch (stubbed HTTP)" do
     setup do
-      base = String.to_integer(System.get_env("OSA_HTTP_PORT") || "10331")
+      base =
+        String.to_integer(System.get_env("OSA_HTTP_PORT") || "10331") +
+          rem(System.unique_integer([:positive]), 10_000)
+
       test_pid = self()
       {server, port} = start_stub(base, test_pid, 0)
 
@@ -209,14 +212,14 @@ defmodule OptimalSystemAgent.Providers.GoogleSystemHoistTest do
           do: Application.put_env(:optimal_system_agent, :google_api_key, prev_key),
           else: Application.delete_env(:optimal_system_agent, :google_api_key)
 
-        Process.exit(server, :normal)
+        Supervisor.stop(server)
       end)
 
       :ok
     end
 
     test "the body actually sent keeps the steering nudge last, in contents" do
-      Google.chat(steering_history(), model: @model)
+      assert {:ok, _response} = Google.chat(steering_history(), model: @model)
 
       assert_receive {:captured_body, body}, 5_000
 
@@ -233,7 +236,7 @@ defmodule OptimalSystemAgent.Providers.GoogleSystemHoistTest do
     end
 
     test "auth still goes in the x-goog-api-key header, not a ?key= query param" do
-      Google.chat(steering_history(), model: @model)
+      assert {:ok, _response} = Google.chat(steering_history(), model: @model)
 
       assert_receive {:captured_request, req}, 5_000
 
@@ -243,7 +246,7 @@ defmodule OptimalSystemAgent.Providers.GoogleSystemHoistTest do
     end
 
     test "a request with no system message sends no systemInstruction at all" do
-      Google.chat([%{role: "user", content: "hi"}], model: @model)
+      assert {:ok, _response} = Google.chat([%{role: "user", content: "hi"}], model: @model)
 
       assert_receive {:captured_body, body}, 5_000
 
@@ -252,7 +255,11 @@ defmodule OptimalSystemAgent.Providers.GoogleSystemHoistTest do
     end
 
     test "thinking config is still emitted for Gemini 3.x (no regression)" do
-      Google.chat([%{role: "user", content: "hi"}], model: @model, reasoning_effort: "high")
+      assert {:ok, _response} =
+               Google.chat([%{role: "user", content: "hi"}],
+                 model: @model,
+                 reasoning_effort: "high"
+               )
 
       assert_receive {:captured_body, body}, 5_000
       assert body["generationConfig"]["thinkingLevel"] == "high"
@@ -280,6 +287,7 @@ defmodule OptimalSystemAgent.Providers.GoogleSystemHoistTest do
             startup_log: false
           )
 
+        Process.unlink(server)
         {server, port}
 
       {:error, _} ->

--- a/test/pty/stub_backend.py
+++ b/test/pty/stub_backend.py
@@ -259,6 +259,13 @@ _HEALTH_GATE.set()
 _TURN_GATE = threading.Event()
 _TURN_GATE.set()
 
+# Number of upcoming SSE attaches that should answer 404. This reproduces the
+# real stale-session failure without stopping the backend: /health remains
+# healthy while only the requested session stream is gone.
+_SSE_REJECT_LOCK = threading.Lock()
+_SSE_REJECT_COUNT = 0
+_SSE_REJECT_SESSION_ID: str | None = None
+
 #: Longest a gated request will ever be held, whatever the test forgets to do.
 GATE_CEILING = 30.0
 
@@ -283,6 +290,27 @@ def hold_turn() -> None:
 
 def release_turn() -> None:
     _TURN_GATE.set()
+
+
+def reject_next_sse(count: int = 1, session_id: str | None = None) -> None:
+    """Make the next matching `count` session streams answer HTTP 404."""
+    global _SSE_REJECT_COUNT, _SSE_REJECT_SESSION_ID
+    with _SSE_REJECT_LOCK:
+        _SSE_REJECT_COUNT = count
+        _SSE_REJECT_SESSION_ID = session_id
+
+
+def _should_reject_sse(path: str) -> bool:
+    global _SSE_REJECT_COUNT
+    with _SSE_REJECT_LOCK:
+        if _SSE_REJECT_COUNT <= 0:
+            return False
+        if _SSE_REJECT_SESSION_ID is not None and not path.endswith(
+            f"/{_SSE_REJECT_SESSION_ID}"
+        ):
+            return False
+        _SSE_REJECT_COUNT -= 1
+        return True
 
 
 # --- pushing events down the SSE stream --------------------------------------
@@ -477,6 +505,9 @@ class _Handler(BaseHTTPRequestHandler):
             _HEALTH_GATE.wait(GATE_CEILING)
             return self._json(_HEALTH)
         if path.startswith("/api/v1/stream/"):
+            GETS.append(path)
+            if _should_reject_sse(path):
+                return self._json({"error": "session not found"}, status=404)
             return self._sse()
         if path == "/api/v1/commands":
             return self._json({"commands": []})

--- a/test/pty/test_resize.py
+++ b/test/pty/test_resize.py
@@ -2861,7 +2861,7 @@ def test_reconnect_restores_a_paused_goal_footer(backend: StubBackend) -> None:
         output="Goal paused",
     )
     try:
-        with PtySession(backend.base_url, cols=120, rows=30) as s:
+        with PtySession(backend.base_url, cols=100, rows=30) as s:
             s.boot()
             s.pump(1.0)
             screen = "\n".join(s.lines())
@@ -2874,6 +2874,15 @@ def test_reconnect_restores_a_paused_goal_footer(backend: StubBackend) -> None:
             if "/goal resume" not in screen:
                 raise AssertionError(
                     "the paused goal footer did not expose its resume control.\n"
+                    f"--- rendered screen ---\n{s.dump()}"
+                )
+            rows = s.lines()
+            goal_row = next(i for i, row in enumerate(rows) if "Goal paused:" in row)
+            status_row = next(i for i, row in enumerate(rows) if "% ctx" in row)
+            if goal_row == status_row:
+                raise AssertionError(
+                    "the goal is still appended to the crowded primary status row "
+                    "instead of owning an aligned row underneath it.\n"
                     f"--- rendered screen ---\n{s.dump()}"
                 )
     finally:

--- a/test/pty/test_resize.py
+++ b/test/pty/test_resize.py
@@ -46,6 +46,7 @@ from stub_backend import (  # noqa: E402
     push_sse,
     release_health,
     release_turn,
+    reject_next_sse,
     reset_goal_state,
     set_claude_cli_state,
     set_goal_state,
@@ -1550,6 +1551,62 @@ def test_a_stale_backend_says_so_instead_of_relabelling_the_tui(
                 "no mismatch notice, so a stale daemon is still silent.\n"
                 f"--- rendered screen ---\n{s.dump()}"
             )
+
+
+def test_a_missing_session_recovers_without_a_reconnect_loop(
+    backend: StubBackend,
+) -> None:
+    """A healthy backend plus a missing session must create a replacement.
+
+    This is the exact production failure from the report: `/health` returned
+    healthy while `GET /api/v1/stream/<session>` returned 404. Treating that
+    permanent response as a network blip left the footer saying
+    `Reconnecting to backend...` while retrying the same impossible URL.
+
+    The first stream attach is rejected. A correct client creates one fresh
+    session, attaches its stream, and returns to a usable composer without any
+    backend restart or user input.
+    """
+    mark = post_mark()
+    get_start = get_mark()
+    reject_next_sse(session_id="pty-stub-session")
+    with PtySession(backend.base_url, cols=100, rows=30) as s:
+        s.boot()
+
+        waited = 0.0
+        session_posts = []
+        while waited < 5.0:
+            s.pump(0.1)
+            waited += 0.1
+            session_posts = posts_since(mark, "/api/v1/sessions")
+            streams = [
+                path
+                for path in gets_since(get_start)
+                if path.startswith("/api/v1/stream/")
+            ]
+            replacement_streams = [
+                path for path in streams if path.endswith("/pty-stub-session")
+            ]
+            if len(session_posts) >= 2 and len(replacement_streams) >= 2:
+                break
+
+        if len(session_posts) != 2:
+            raise AssertionError(
+                "a missing stream did not create exactly one replacement "
+                f"session; saw {len(session_posts)} session creates.\n"
+                f"--- rendered screen ---\n{s.dump()}"
+            )
+        if len(replacement_streams) != 2:
+            raise AssertionError(
+                "the replacement session did not attach exactly one fresh "
+                f"stream after the rejected one; saw {streams}.\n"
+                f"--- rendered screen ---\n{s.dump()}"
+            )
+        if "Reconnecting to backend" in "\n".join(s.lines()):
+            raise AssertionError(
+                "the TUI recovered but left the reconnect banner visible.\n"
+                f"--- rendered screen ---\n{s.dump()}"
+            )
         screen = s.dump()
         if "osa stop" in screen:
             raise AssertionError(
@@ -3005,6 +3062,7 @@ TESTS = [
     test_claude_code_is_installed_and_signed_in_without_leaving_osa,
     test_connecting_splash_does_not_trap_the_user,
     test_a_stale_backend_says_so_instead_of_relabelling_the_tui,
+    test_a_missing_session_recovers_without_a_reconnect_loop,
     test_a_draft_typed_while_connecting_survives_into_the_composer,
     test_a_slow_second_escape_still_interrupts,
     test_one_stray_escape_still_does_not_kill_a_turn,

--- a/test/pty/test_resize.py
+++ b/test/pty/test_resize.py
@@ -122,11 +122,12 @@ def assert_single_live_region_with_transcript(session: PtySession, context: str)
 
 def test_fast_updates_the_persistent_effort_chip(backend: StubBackend) -> None:
     """The backend can change effort after startup; the status bar must adopt
-    the command response instead of remaining frozen at the health snapshot."""
+    the command response instead of remaining frozen at the health snapshot.
+    The default medium tier stays quiet, while a non-default tier is explicit."""
     with PtySession(backend.base_url, cols=100, rows=30) as s:
         s.boot()
-        if "effort:medium" not in "\n".join(s.lines()):
-            raise AssertionError(f"startup effort was not medium:\n{s.dump()}")
+        if "effort:medium" in "\n".join(s.lines()):
+            raise AssertionError(f"default effort should stay quiet:\n{s.dump()}")
 
         s.write(b"/fast")
         s.pump(0.2)


### PR DESCRIPTION
## Summary

- Request summarized adaptive thinking from Anthropic so Claude reasoning appears in the provider-neutral thinking surface.
- Give active goals a dedicated footer row at normal widths.
- Keep context readable while resizing and render optional effort, MCP, and version chips only when they fit whole.
- Hide the default medium effort while keeping non-default changes such as /fast visible.
- Remove the duplicated latest-request input count from live activity chrome.

## Verification

- Rust status-bar suite: 41 passed
- Rust activity/thinking suite: 40 passed
- Rust layout contracts: 12 passed
- Anthropic/provider suite: 135 passed
- Focused real PTY /fast test passed
- Focused real PTY restored-goal test passed
- UI detail detector: no findings