### PR TITLE
feat(runtime): make agent control durable

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,11 @@ type. The ones worth knowing:
 
 ```
 session    /new      /clear    /resume   /continue /session  /fork     /rename
-           /tag      /sessions /recap    /rewind   /undo     /retry    /export
+           /tag      /sessions /recap    /rewind   /undo     /retry    /export /save
 model      /model    /models   /reasoning /effort  /fast     /coordinator
 context    /context  /usage    /compact  /cost     /files    /memory
-work       /plan     /goal     /steer    /bg       /fg       /agents   /tasks
+work       /plan     /goal     /loop     /steer    /bg       /fg       /agents
+           /tasks
 project    /map      /init     /trust    /add-dir  /skills   /tools
 config     /setup    /config   /permissions /hooks /mcp      /sandbox  /channels
            /theme    /keybindings /verbose /a11y   /persona  /customize
@@ -288,6 +289,8 @@ Use the on-demand views for diagnosis instead of packing every metric into perma
 | `/context` | Current context occupancy and token breakdown |
 | `/cost` | Session token accounting and estimated spend |
 | `/usage` | Provider account quota and reported usage |
+| `/save` | A readable Markdown snapshot under `~/.osa/exports` |
+| `/loop 5m <prompt>` | Repeat a prompt through the durable session queue until `/loop stop` |
 | `/status` | Active provider, model, session, tools, and permission state |
 | `/reasoning` or `/effort` | Changing the speed-versus-depth tradeoff |
 

--- a/lib/optimal_system_agent/agent/background_notifier.ex
+++ b/lib/optimal_system_agent/agent/background_notifier.ex
@@ -10,8 +10,8 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
 
   This GenServer subscribes to a parent session's PubSub topic and, on each
   completion/failure, queues a `<task-notification>` via
-  `Agent.TaskNotifications.queue/2` and pokes the parent Loop
-  (`Loop.poke/1`): a BUSY loop folds the notification in at its next ReAct
+  `Agent.TaskNotifications.queue/2` and schedules one coalesced parent wake:
+  a BUSY loop folds the notification in at its next ReAct
   step boundary (beside the steer drain), an IDLE loop reacts with a
   synthetic turn — mirroring Claude Code's background completion resume.
 
@@ -23,7 +23,6 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
   use GenServer
   require Logger
 
-  alias OptimalSystemAgent.Agent.Loop
   alias OptimalSystemAgent.Agent.TaskNotifications
 
   # --- Client API ---
@@ -127,7 +126,7 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
       # Busy loop → ReactLoop drains this beside Steer at its next step
       # boundary; idle loop → the poke runs a synthetic turn so the agent
       # reacts unprompted (the old inject-only path was never acted on).
-      Loop.poke(state.parent_id)
+      TaskNotifications.poke_after_batch(state.parent_id)
     end
 
     {:noreply, state}
@@ -184,7 +183,7 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
         usage: usage
       })
 
-      Loop.poke(parent_id)
+      TaskNotifications.poke_after_batch(parent_id)
     end
   rescue
     e -> Logger.debug("[BackgroundNotifier] inject failed: #{Exception.message(e)}")
@@ -235,7 +234,7 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
       summary: summary
     })
 
-    Loop.poke(parent_id)
+    TaskNotifications.poke_after_batch(parent_id)
   rescue
     e -> Logger.debug("[BackgroundNotifier] inject_stall failed: #{Exception.message(e)}")
   end

--- a/lib/optimal_system_agent/agent/durable_inbox.ex
+++ b/lib/optimal_system_agent/agent/durable_inbox.ex
@@ -1,0 +1,178 @@
+defmodule OptimalSystemAgent.Agent.DurableInbox do
+  @moduledoc """
+  Durable FIFO lanes for facts that must cross a running-turn or restart seam.
+
+  ETS remains the low-latency live projection. The session sidecar is the
+  durable ledger. Consumers reserve entries in ETS, persist their incorporation,
+  then acknowledge the exact durable records. A crash before acknowledgement
+  therefore leaves the entries available to the replacement process.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.Agent.SessionPersistence
+
+  @type lane :: :steers | :task_notifications
+  @append_attempts 4
+  @retry_ms 10
+
+  @spec append(atom(), String.t(), lane(), map()) :: :ok | {:error, term()}
+  def append(table, session_id, lane, payload)
+      when is_atom(table) and is_binary(session_id) and is_map(payload) do
+    entry = %{
+      "id" => unique_id(),
+      "created_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "payload" => stringify(payload)
+    }
+
+    case append_durable(session_id, lane, entry, @append_attempts) do
+      :ok ->
+        seq = :erlang.unique_integer([:monotonic, :positive])
+        true = :ets.insert(table, {{session_id, seq}, entry})
+        :ok
+
+      {:error, reason} ->
+        Logger.error(
+          "[durable_inbox] append failed for #{session_id}/#{lane}: #{inspect(reason)}"
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp append_durable(session_id, lane, entry, attempts) do
+    case SessionPersistence.append_inbox(session_id, lane, entry) do
+      {:error, :contended} when attempts > 1 ->
+        Process.sleep(@retry_ms)
+        append_durable(session_id, lane, entry, attempts - 1)
+
+      outcome ->
+        outcome
+    end
+  end
+
+  @spec restore(atom(), String.t(), lane()) :: :ok
+  def restore(table, session_id, lane) do
+    if live_entries(table, session_id) == [] do
+      SessionPersistence.load_inbox(session_id, lane)
+      |> Enum.each(fn entry ->
+        seq = :erlang.unique_integer([:monotonic, :positive])
+        :ets.insert(table, {{session_id, seq}, entry})
+      end)
+    end
+
+    :ok
+  end
+
+  @spec drain(atom(), String.t(), lane()) :: [map()]
+  def drain(table, session_id, lane) do
+    case checkout(table, session_id, lane) do
+      :empty ->
+        []
+
+      {receipt, payloads} ->
+        :ok = acknowledge(table, session_id, lane, receipt)
+        payloads
+    end
+  end
+
+  @doc "Reserve current entries without deleting their durable records."
+  @spec checkout(atom(), String.t(), lane()) :: :empty | {[String.t()], [map()]}
+  def checkout(table, session_id, lane) do
+    restore(table, session_id, lane)
+
+    candidates =
+      table
+      |> live_entries(session_id)
+      |> Enum.reject(fn {_seq, entry} -> entry["claimed"] == true end)
+
+    rows =
+      Enum.filter(candidates, fn {seq, entry} ->
+        claimed = Map.put(entry, "claimed", true)
+
+        :ets.select_replace(table, [
+          {
+            {{session_id, seq}, :"$1"},
+            [{:==, :"$1", {:const, entry}}],
+            [{:const, {{session_id, seq}, claimed}}]
+          }
+        ]) == 1
+      end)
+
+    case rows do
+      [] ->
+        :empty
+
+      _ ->
+        ids = Enum.map(rows, fn {_seq, entry} -> entry["id"] end)
+
+        payloads =
+          Enum.map(rows, fn {_seq, entry} -> atomize_payload(entry["payload"] || %{}) end)
+
+        {ids, payloads}
+    end
+  end
+
+  @doc "Acknowledge reserved entries after the consumer has persisted incorporation."
+  @spec acknowledge(atom(), String.t(), lane(), [String.t()]) :: :ok | {:error, term()}
+  def acknowledge(table, session_id, lane, ids) do
+    case SessionPersistence.acknowledge_inbox(session_id, lane, ids) do
+      :ok ->
+        ids = MapSet.new(ids)
+
+        live_entries(table, session_id)
+        |> Enum.each(fn {seq, entry} ->
+          if MapSet.member?(ids, entry["id"]), do: :ets.delete(table, {session_id, seq})
+        end)
+
+        :ok
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  @doc "Release a live reservation after incorporation could not be persisted."
+  @spec release(atom(), String.t(), [String.t()]) :: :ok
+  def release(table, session_id, ids) do
+    ids = MapSet.new(ids)
+
+    live_entries(table, session_id)
+    |> Enum.each(fn {seq, entry} ->
+      if MapSet.member?(ids, entry["id"]) do
+        :ets.insert(table, {{session_id, seq}, Map.delete(entry, "claimed")})
+      end
+    end)
+
+    :ok
+  end
+
+  @spec count(atom(), String.t(), lane()) :: non_neg_integer()
+  def count(table, session_id, lane) do
+    restore(table, session_id, lane)
+    length(live_entries(table, session_id))
+  end
+
+  defp live_entries(table, session_id) do
+    match = [{{{session_id, :"$1"}, :"$2"}, [], [{{:"$1", :"$2"}}]}]
+    table |> :ets.select(match) |> Enum.sort_by(&elem(&1, 0))
+  end
+
+  defp unique_id do
+    :crypto.strong_rand_bytes(12) |> Base.url_encode64(padding: false)
+  end
+
+  defp stringify(map), do: Map.new(map, fn {key, value} -> {to_string(key), value} end)
+
+  defp atomize_payload(map) do
+    Map.new(map, fn {key, value} -> {safe_key(key), value} end)
+  end
+
+  defp safe_key(key) when is_atom(key), do: key
+
+  defp safe_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
+end

--- a/lib/optimal_system_agent/agent/loop.ex
+++ b/lib/optimal_system_agent/agent/loop.ex
@@ -1834,12 +1834,35 @@ defmodule OptimalSystemAgent.Agent.Loop do
   # which guarantees no double injection.
   @impl true
   def handle_cast({:steer, _text}, state) do
-    case Steer.drain(state.session_id) do
-      [] ->
+    case Steer.checkout(state.session_id) do
+      :empty ->
         {:noreply, state}
 
-      texts ->
-        {:noreply, %{state | messages: state.messages ++ Steer.to_messages(texts)}}
+      {receipt, texts} ->
+        if inbox_receipt_delivered?(state.messages, receipt) do
+          acknowledge_replayed(
+            receipt,
+            fn ->
+              Steer.acknowledge(state.session_id, receipt)
+            end,
+            fn -> Steer.release(state.session_id, receipt) end
+          )
+
+          {:noreply, state}
+        else
+          injected = mark_inbox_receipt(Steer.to_messages(texts), receipt)
+          messages = state.messages ++ injected
+
+          case persist_inbox_delivery(
+                 state,
+                 messages,
+                 fn -> Steer.acknowledge(state.session_id, receipt) end,
+                 fn -> Steer.release(state.session_id, receipt) end
+               ) do
+            :ok -> {:noreply, %{state | messages: messages}}
+            {:error, _reason} -> {:noreply, state}
+          end
+        end
     end
   end
 
@@ -1852,26 +1875,90 @@ defmodule OptimalSystemAgent.Agent.Loop do
   # iteration resets to 0 exactly like TurnPipeline does for a real turn.
   @impl true
   def handle_cast(:poke, %{status: :idle} = state) do
-    case TaskNotifications.drain(state.session_id) do
-      [] ->
+    case TaskNotifications.checkout(state.session_id) do
+      :empty ->
         {:noreply, state}
 
-      notifs ->
-        TaskNotifications.announce(state.session_id, notifs)
+      {receipt, notifs} ->
+        if inbox_receipt_delivered?(state.messages, receipt) do
+          acknowledge_replayed(
+            receipt,
+            fn ->
+              TaskNotifications.acknowledge(state.session_id, receipt)
+            end,
+            fn -> TaskNotifications.release(state.session_id, receipt) end
+          )
 
-        state = %{
-          state
-          | messages: state.messages ++ TaskNotifications.to_messages(notifs),
-            iteration: 0,
-            status: :processing,
-            current_input: "[background task notification]"
-        }
+          {:noreply, state}
+        else
+          TaskNotifications.announce(state.session_id, notifs)
+          injected = mark_inbox_receipt(TaskNotifications.to_messages(notifs), receipt)
 
-        # Same turn, same reasoning as handle_call({:process, _}) — see
-        # `during_turn/1`: this callback blocks in LLMClient exactly like a real
-        # turn does, so exit trapping must be off for its duration.
-        {:reply, _reply, state} = during_turn(fn -> run_and_reply(state) end)
-        {:noreply, state}
+          next_state = %{
+            state
+            | messages: state.messages ++ injected,
+              iteration: 0,
+              status: :processing,
+              current_input: "[background task notification]"
+          }
+
+          case persist_inbox_delivery(
+                 next_state,
+                 next_state.messages,
+                 fn -> TaskNotifications.acknowledge(state.session_id, receipt) end,
+                 fn -> TaskNotifications.release(state.session_id, receipt) end
+               ) do
+            :ok ->
+              # Same turn, same reasoning as handle_call({:process, _}) — see
+              # `during_turn/1`: this callback blocks in LLMClient exactly like a real
+              # turn does, so exit trapping must be off for its duration.
+              {:reply, _reply, final_state} = during_turn(fn -> run_and_reply(next_state) end)
+              {:noreply, final_state}
+
+            {:error, _reason} ->
+              {:noreply, state}
+          end
+        end
+    end
+  end
+
+  defp mark_inbox_receipt(messages, receipt) do
+    Enum.map(messages, &Map.put(&1, :durable_inbox_ids, receipt))
+  end
+
+  defp inbox_receipt_delivered?(messages, receipt) do
+    delivered =
+      messages
+      |> Enum.flat_map(&(&1[:durable_inbox_ids] || &1["durable_inbox_ids"] || []))
+      |> MapSet.new()
+
+    Enum.all?(receipt, &MapSet.member?(delivered, &1))
+  end
+
+  defp acknowledge_replayed(_receipt, acknowledge, release) do
+    case acknowledge.() do
+      :ok -> :ok
+      {:error, _reason} -> release.()
+    end
+  end
+
+  defp persist_inbox_delivery(state, messages, acknowledge, release) do
+    case SessionPersistence.save(state.session_id, messages, state.working_dir) do
+      :ok ->
+        case acknowledge.() do
+          :ok ->
+            :ok
+
+          {:error, reason} ->
+            release.()
+            Logger.error("[loop] durable inbox acknowledgement failed: #{inspect(reason)}")
+            :ok
+        end
+
+      {:error, reason} = error ->
+        release.()
+        Logger.error("[loop] durable inbox delivery failed: #{inspect(reason)}")
+        error
     end
   end
 

--- a/lib/optimal_system_agent/agent/loop/react_loop.ex
+++ b/lib/optimal_system_agent/agent/loop/react_loop.ex
@@ -2615,26 +2615,47 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
   # them to state.messages as system directives. Returns state unchanged when
   # nothing is queued (the common per-step case).
   defp inject_pending_steer(%{session_id: sid} = state) do
-    case OptimalSystemAgent.Agent.Loop.Steer.drain(sid) do
-      [] ->
+    case OptimalSystemAgent.Agent.Loop.Steer.checkout(sid) do
+      :empty ->
         state
 
-      texts ->
-        Logger.info(
-          "[loop] Mid-turn steer: folded #{length(texts)} directive(s) into session #{sid} at iteration #{state.iteration}"
-        )
+      {receipt, texts} ->
+        if inbox_receipt_delivered?(state.messages, receipt) do
+          acknowledge_replayed(
+            fn -> OptimalSystemAgent.Agent.Loop.Steer.acknowledge(sid, receipt) end,
+            fn -> OptimalSystemAgent.Agent.Loop.Steer.release(sid, receipt) end
+          )
 
-        Bus.emit(:system_event, %{
-          event: :steer_injected,
-          session_id: sid,
-          iteration: state.iteration,
-          count: length(texts)
-        })
-
-        %{
           state
-          | messages: state.messages ++ OptimalSystemAgent.Agent.Loop.Steer.to_messages(texts)
-        }
+        else
+          Logger.info(
+            "[loop] Mid-turn steer: folded #{length(texts)} directive(s) into session #{sid} at iteration #{state.iteration}"
+          )
+
+          Bus.emit(:system_event, %{
+            event: :steer_injected,
+            session_id: sid,
+            iteration: state.iteration,
+            count: length(texts)
+          })
+
+          injected =
+            texts
+            |> OptimalSystemAgent.Agent.Loop.Steer.to_messages()
+            |> mark_inbox_receipt(receipt)
+
+          next_state = %{
+            state
+            | messages: state.messages ++ injected
+          }
+
+          persist_inbox_delivery(
+            state,
+            next_state,
+            fn -> OptimalSystemAgent.Agent.Loop.Steer.acknowledge(sid, receipt) end,
+            fn -> OptimalSystemAgent.Agent.Loop.Steer.release(sid, receipt) end
+          )
+        end
     end
   end
 
@@ -2644,29 +2665,92 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
   # background completions on its very next LLM call. Announces the drain on
   # the session topic so the TUI shows why the agent pivots.
   defp inject_pending_task_notifications(%{session_id: sid} = state) do
-    case OptimalSystemAgent.Agent.TaskNotifications.drain(sid) do
-      [] ->
+    case OptimalSystemAgent.Agent.TaskNotifications.checkout(sid) do
+      :empty ->
         state
 
-      notifs ->
-        Logger.info(
-          "[loop] Task notifications: folded #{length(notifs)} into session #{sid} at iteration #{state.iteration}"
-        )
+      {receipt, notifs} ->
+        if inbox_receipt_delivered?(state.messages, receipt) do
+          acknowledge_replayed(
+            fn -> OptimalSystemAgent.Agent.TaskNotifications.acknowledge(sid, receipt) end,
+            fn -> OptimalSystemAgent.Agent.TaskNotifications.release(sid, receipt) end
+          )
 
-        Bus.emit(:system_event, %{
-          event: :task_notification_injected,
-          session_id: sid,
-          iteration: state.iteration,
-          count: length(notifs)
-        })
-
-        OptimalSystemAgent.Agent.TaskNotifications.announce(sid, notifs)
-
-        %{
           state
-          | messages:
-              state.messages ++ OptimalSystemAgent.Agent.TaskNotifications.to_messages(notifs)
-        }
+        else
+          Logger.info(
+            "[loop] Task notifications: folded #{length(notifs)} into session #{sid} at iteration #{state.iteration}"
+          )
+
+          Bus.emit(:system_event, %{
+            event: :task_notification_injected,
+            session_id: sid,
+            iteration: state.iteration,
+            count: length(notifs)
+          })
+
+          OptimalSystemAgent.Agent.TaskNotifications.announce(sid, notifs)
+
+          injected =
+            notifs
+            |> OptimalSystemAgent.Agent.TaskNotifications.to_messages()
+            |> mark_inbox_receipt(receipt)
+
+          next_state = %{
+            state
+            | messages: state.messages ++ injected
+          }
+
+          persist_inbox_delivery(
+            state,
+            next_state,
+            fn -> OptimalSystemAgent.Agent.TaskNotifications.acknowledge(sid, receipt) end,
+            fn -> OptimalSystemAgent.Agent.TaskNotifications.release(sid, receipt) end
+          )
+        end
+    end
+  end
+
+  defp mark_inbox_receipt(messages, receipt),
+    do: Enum.map(messages, &Map.put(&1, :durable_inbox_ids, receipt))
+
+  defp inbox_receipt_delivered?(messages, receipt) do
+    delivered =
+      messages
+      |> Enum.flat_map(&(&1[:durable_inbox_ids] || &1["durable_inbox_ids"] || []))
+      |> MapSet.new()
+
+    Enum.all?(receipt, &MapSet.member?(delivered, &1))
+  end
+
+  defp acknowledge_replayed(acknowledge, release) do
+    case acknowledge.() do
+      :ok -> :ok
+      {:error, _reason} -> release.()
+    end
+  end
+
+  defp persist_inbox_delivery(previous_state, next_state, acknowledge, release) do
+    case OptimalSystemAgent.Agent.SessionPersistence.save(
+           next_state.session_id,
+           next_state.messages,
+           next_state.working_dir
+         ) do
+      :ok ->
+        case acknowledge.() do
+          :ok ->
+            next_state
+
+          {:error, reason} ->
+            release.()
+            Logger.error("[loop] durable inbox acknowledgement failed: #{inspect(reason)}")
+            next_state
+        end
+
+      {:error, reason} ->
+        release.()
+        Logger.error("[loop] durable inbox delivery failed: #{inspect(reason)}")
+        previous_state
     end
   end
 

--- a/lib/optimal_system_agent/agent/loop/steer.ex
+++ b/lib/optimal_system_agent/agent/loop/steer.ex
@@ -20,11 +20,13 @@ defmodule OptimalSystemAgent.Agent.Loop.Steer do
   ## Storage
 
   Rows are `{{session_id, seq}, text}` in the `:osa_steer_queue` `:ordered_set`,
-  where `seq` is a strictly-increasing monotonic integer, so `drain/1` returns
-  the queued directives in FIFO order and removes them (each steer is injected
-  exactly once, no matter which entry point enqueued it).
+  where `seq` is a strictly-increasing monotonic integer. Production consumers
+  reserve directives in FIFO order and acknowledge them only after persisting
+  their incorporation into the session transcript.
   """
   require Logger
+
+  alias OptimalSystemAgent.Agent.DurableInbox
 
   @table :osa_steer_queue
 
@@ -34,11 +36,9 @@ defmodule OptimalSystemAgent.Agent.Loop.Steer do
   Concurrent-safe and non-blocking; returns `:ok` even if the table is missing
   (feature simply degrades to a no-op rather than crashing the caller).
   """
-  @spec queue(String.t(), String.t()) :: :ok
+  @spec queue(String.t(), String.t()) :: :ok | {:error, term()}
   def queue(session_id, text) when is_binary(session_id) and is_binary(text) do
-    seq = :erlang.unique_integer([:monotonic, :positive])
-    :ets.insert(@table, {{session_id, seq}, text})
-    :ok
+    DurableInbox.append(@table, session_id, :steers, %{text: text})
   rescue
     ArgumentError ->
       Logger.warning("[steer] queue table missing — steer dropped for #{session_id}")
@@ -51,21 +51,9 @@ defmodule OptimalSystemAgent.Agent.Loop.Steer do
   """
   @spec drain(String.t()) :: [String.t()]
   def drain(session_id) when is_binary(session_id) do
-    # Select {seq, text} for this session, then delete each row by its full key.
-    match = [{{{session_id, :"$1"}, :"$2"}, [], [{{:"$1", :"$2"}}]}]
-
-    case :ets.select(@table, match) do
-      [] ->
-        []
-
-      rows ->
-        rows
-        |> Enum.sort_by(fn {seq, _text} -> seq end)
-        |> Enum.map(fn {seq, text} ->
-          :ets.delete(@table, {session_id, seq})
-          text
-        end)
-    end
+    DurableInbox.drain(@table, session_id, :steers)
+    |> Enum.map(&(&1[:text] || &1["text"]))
+    |> Enum.filter(&is_binary/1)
   rescue
     ArgumentError -> []
   end
@@ -73,10 +61,30 @@ defmodule OptimalSystemAgent.Agent.Loop.Steer do
   @doc "Number of steer directives currently queued for `session_id`."
   @spec count(String.t()) :: non_neg_integer()
   def count(session_id) when is_binary(session_id) do
-    :ets.select_count(@table, [{{{session_id, :_}, :_}, [], [true]}])
+    DurableInbox.count(@table, session_id, :steers)
   rescue
     ArgumentError -> 0
   end
+
+  @doc false
+  def checkout(session_id) do
+    case DurableInbox.checkout(@table, session_id, :steers) do
+      :empty ->
+        :empty
+
+      {receipt, payloads} ->
+        texts = payloads |> Enum.map(&(&1[:text] || &1["text"])) |> Enum.filter(&is_binary/1)
+        {receipt, texts}
+    end
+  end
+
+  @doc false
+  def acknowledge(session_id, receipt) do
+    DurableInbox.acknowledge(@table, session_id, :steers, receipt)
+  end
+
+  @doc false
+  def release(session_id, receipt), do: DurableInbox.release(@table, session_id, receipt)
 
   @doc """
   Build the message list injected into the conversation for a set of steer

--- a/lib/optimal_system_agent/agent/loop_control.ex
+++ b/lib/optimal_system_agent/agent/loop_control.ex
@@ -1,0 +1,218 @@
+defmodule OptimalSystemAgent.Agent.LoopControl do
+  @moduledoc """
+  Persistent operator loops that periodically enqueue a prompt into one session.
+
+  A loop is explicit, visible, and cancellable. It never runs an agent directly:
+  each tick crosses the normal CLI message queue seam, so busy-session ordering,
+  reconnect persistence, permissions, and goal controls continue to apply.
+  """
+
+  use GenServer
+
+  alias OptimalSystemAgent.Agent.SessionPersistence
+  alias OptimalSystemAgent.Channels.CLI.MessageQueue
+
+  @lane :operator_loop
+  @minimum_interval_ms 5_000
+
+  def start_link(_opts), do: GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+
+  @spec start(String.t(), pos_integer(), String.t()) :: {:ok, map()} | {:error, term()}
+  def start(session_id, interval_ms, prompt)
+      when is_binary(session_id) and is_integer(interval_ms) and is_binary(prompt) do
+    GenServer.call(__MODULE__, {:start, session_id, interval_ms, prompt})
+  end
+
+  @spec stop(String.t()) :: :ok | {:error, term()}
+  def stop(session_id), do: GenServer.call(__MODULE__, {:stop, session_id})
+
+  @spec status(String.t()) :: map() | nil
+  def status(session_id), do: GenServer.call(__MODULE__, {:status, session_id})
+
+  @doc "Parse a duration such as 30s, 5m, or 2h."
+  @spec parse_interval(String.t()) :: {:ok, pos_integer()} | {:error, :invalid_interval}
+  def parse_interval(text) when is_binary(text) do
+    case Regex.run(~r/^(\d+)(s|m|h)$/i, String.trim(text)) do
+      [_, number, unit] ->
+        multiplier = %{"s" => 1_000, "m" => 60_000, "h" => 3_600_000}[String.downcase(unit)]
+        milliseconds = String.to_integer(number) * multiplier
+
+        if milliseconds >= @minimum_interval_ms,
+          do: {:ok, milliseconds},
+          else: {:error, :invalid_interval}
+
+      _ ->
+        {:error, :invalid_interval}
+    end
+  end
+
+  @impl true
+  def init(_) do
+    {:ok, restore_all()}
+  end
+
+  @impl true
+  def handle_call({:start, session_id, interval_ms, prompt}, _from, state) do
+    if interval_ms < @minimum_interval_ms or String.trim(prompt) == "" do
+      {:reply, {:error, :invalid_loop}, state}
+    else
+      entry = new_entry(interval_ms, prompt)
+
+      case persist(session_id, entry) do
+        :ok ->
+          state = cancel_timer(state, session_id)
+          {:reply, {:ok, public(entry)}, Map.put(state, session_id, arm(session_id, entry))}
+
+        {:error, reason} ->
+          {:reply, {:error, {:persistence_failed, reason}}, state}
+      end
+    end
+  end
+
+  def handle_call({:stop, session_id}, _from, state) do
+    case persist(session_id, nil) do
+      :ok ->
+        state = cancel_timer(state, session_id)
+        {:reply, :ok, Map.delete(state, session_id)}
+
+      {:error, reason} ->
+        {:reply, {:error, {:persistence_failed, reason}}, state}
+    end
+  end
+
+  def handle_call({:status, session_id}, _from, state) do
+    {:reply, state |> Map.get(session_id) |> public(), state}
+  end
+
+  @impl true
+  def handle_info({:tick, session_id}, state) do
+    case Map.get(state, session_id) do
+      nil ->
+        {:noreply, state}
+
+      entry ->
+        if queue_available?(session_id) do
+          attempted =
+            Map.merge(entry, %{
+              tick_count: entry.tick_count + 1,
+              last_tick_at: now_iso(),
+              last_tick_status: "dispatching"
+            })
+
+          case persist(session_id, attempted) do
+            :ok ->
+              status =
+                if dispatch(session_id, entry.prompt) == :ok, do: "accepted", else: "failed"
+
+              completed = %{attempted | last_tick_status: status}
+              _ = persist(session_id, completed)
+              {:noreply, Map.put(state, session_id, arm(session_id, completed))}
+
+            {:error, _reason} ->
+              {:noreply, Map.put(state, session_id, arm(session_id, entry))}
+          end
+        else
+          {:noreply, Map.put(state, session_id, arm(session_id, entry))}
+        end
+    end
+  end
+
+  defp queue_available?(session_id) do
+    Registry.lookup(OptimalSystemAgent.SessionRegistry, {:mq, session_id}) != []
+  end
+
+  defp dispatch(session_id, prompt) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, {:mq, session_id}) do
+      [{_pid, _}] ->
+        try do
+          _ = MessageQueue.submit(session_id, prompt, source: :operator_loop)
+          :ok
+        catch
+          :exit, reason -> {:error, {:queue_exit, reason}}
+        end
+
+      _ ->
+        {:error, :session_queue_unavailable}
+    end
+  end
+
+  defp restore_all do
+    SessionPersistence.list(limit: 1_000, include_cleared: true)
+    |> Enum.reduce(%{}, fn %{session_id: session_id}, acc ->
+      case SessionPersistence.load_inbox(session_id, @lane) do
+        [stored | _] ->
+          case restore_entry(stored) do
+            nil -> acc
+            entry -> Map.put(acc, session_id, maybe_arm_restored(session_id, entry))
+          end
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp restore_entry(stored) do
+    interval_ms = stored["interval_ms"]
+    prompt = stored["prompt"]
+
+    if is_integer(interval_ms) and interval_ms >= @minimum_interval_ms and is_binary(prompt) do
+      %{
+        interval_ms: interval_ms,
+        prompt: prompt,
+        tick_count: stored["tick_count"] || 0,
+        started_at: stored["started_at"] || now_iso(),
+        last_tick_at: stored["last_tick_at"],
+        last_tick_status: stored["last_tick_status"],
+        timer_ref: nil
+      }
+    end
+  end
+
+  defp new_entry(interval_ms, prompt) do
+    %{
+      interval_ms: interval_ms,
+      prompt: String.trim(prompt),
+      tick_count: 0,
+      started_at: now_iso(),
+      last_tick_at: nil,
+      last_tick_status: nil,
+      timer_ref: nil
+    }
+  end
+
+  defp arm(session_id, entry) do
+    %{entry | timer_ref: Process.send_after(self(), {:tick, session_id}, entry.interval_ms)}
+  end
+
+  # A crash while a tick is marked dispatching is ambiguous: the queue may
+  # already have accepted it. At-most-once recovery stops that loop and leaves
+  # it visible for an explicit operator restart instead of risking a duplicate.
+  defp maybe_arm_restored(_session_id, %{last_tick_status: "dispatching"} = entry), do: entry
+  defp maybe_arm_restored(session_id, entry), do: arm(session_id, entry)
+
+  defp cancel_timer(state, session_id) do
+    case Map.get(state, session_id) do
+      %{timer_ref: ref} when is_reference(ref) -> Process.cancel_timer(ref)
+      _ -> :ok
+    end
+
+    state
+  end
+
+  defp persist(session_id, nil), do: SessionPersistence.save_inbox(session_id, @lane, [])
+
+  defp persist(session_id, entry) do
+    SessionPersistence.save_inbox(session_id, @lane, [public(entry)])
+  end
+
+  defp public(nil), do: nil
+
+  defp public(entry) do
+    entry
+    |> Map.drop([:timer_ref])
+    |> Map.new(fn {key, value} -> {to_string(key), value} end)
+  end
+
+  defp now_iso, do: DateTime.utc_now() |> DateTime.to_iso8601()
+end

--- a/lib/optimal_system_agent/agent/session_persistence.ex
+++ b/lib/optimal_system_agent/agent/session_persistence.ex
@@ -624,6 +624,98 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
     _ -> []
   end
 
+  @doc "Persist a durable runtime inbox lane for a session."
+  @spec save_inbox(String.t(), atom() | String.t(), [map()]) :: :ok | {:error, term()}
+  def save_inbox(session_id, lane, entries) when is_list(entries) do
+    lane = to_string(lane)
+    sanitized = Enum.filter(entries, &is_map/1)
+
+    result =
+      RecordLock.with_lock_strict(meta_path(session_id), fn ->
+        existing = read_json(meta_path(session_id)) || %{}
+        inbox = Map.get(existing, "runtime_inbox", %{})
+        inbox = if is_map(inbox), do: inbox, else: %{}
+
+        write_json(
+          meta_path(session_id),
+          Map.put(existing, "runtime_inbox", Map.put(inbox, lane, sanitized))
+        )
+      end)
+
+    outcome =
+      case result do
+        {:ok, value} -> value
+        {:error, :contended} -> {:error, :contended}
+      end
+
+    unless File.exists?(session_path(session_id)) do
+      _ = update_metadata(session_id, %{})
+    end
+
+    outcome
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
+
+  @doc "Load one durable runtime inbox lane, returning an empty list when absent."
+  @spec load_inbox(String.t(), atom() | String.t()) :: [map()]
+  def load_inbox(session_id, lane) do
+    lane = to_string(lane)
+
+    case read_json(meta_path(session_id)) do
+      %{"runtime_inbox" => inbox} when is_map(inbox) ->
+        case Map.get(inbox, lane, []) do
+          entries when is_list(entries) -> Enum.filter(entries, &is_map/1)
+          _ -> []
+        end
+
+      _ ->
+        []
+    end
+  rescue
+    _ -> []
+  end
+
+  @doc "Atomically append one entry to a durable runtime inbox lane."
+  @spec append_inbox(String.t(), atom() | String.t(), map()) :: :ok | {:error, term()}
+  def append_inbox(session_id, lane, entry) when is_map(entry) do
+    mutate_inbox(session_id, lane, fn entries -> entries ++ [entry] end)
+  end
+
+  @doc "Atomically acknowledge runtime inbox entries by their durable ids."
+  @spec acknowledge_inbox(String.t(), atom() | String.t(), [String.t()]) ::
+          :ok | {:error, term()}
+  def acknowledge_inbox(session_id, lane, ids) when is_list(ids) do
+    ids = MapSet.new(ids)
+
+    mutate_inbox(
+      session_id,
+      lane,
+      &Enum.reject(&1, fn entry -> MapSet.member?(ids, entry["id"]) end)
+    )
+  end
+
+  defp mutate_inbox(session_id, lane, fun) do
+    File.mkdir_p!(sessions_dir())
+    lane = to_string(lane)
+
+    result =
+      RecordLock.with_lock_strict(meta_path(session_id), fn ->
+        existing = read_json(meta_path(session_id)) || %{}
+        inbox = if is_map(existing["runtime_inbox"]), do: existing["runtime_inbox"], else: %{}
+        entries = if is_list(inbox[lane]), do: inbox[lane], else: []
+        updated = Map.put(inbox, lane, fun.(entries))
+        write_json(meta_path(session_id), Map.put(existing, "runtime_inbox", updated))
+      end)
+
+    case result do
+      {:ok, outcome} -> outcome
+      {:error, :contended} -> {:error, :contended}
+    end
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
+
   @doc """
   Auto-save session state (called from hooks).
 

--- a/lib/optimal_system_agent/agent/session_persistence/record_lock.ex
+++ b/lib/optimal_system_agent/agent/session_persistence/record_lock.ex
@@ -66,6 +66,26 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence.RecordLock do
     end
   end
 
+  @doc "Run only while holding the lock, returning contention instead of writing unlocked."
+  @spec with_lock_strict(String.t(), (-> term())) :: {:ok, term()} | {:error, :contended}
+  def with_lock_strict(path, fun) when is_function(fun, 0) do
+    lock = lock_path(path)
+    _ = File.mkdir_p(Path.dirname(lock))
+
+    case acquire(lock, @max_tries) do
+      {:ok, fd} ->
+        try do
+          {:ok, fun.()}
+        after
+          :file.close(fd)
+          File.rm(lock)
+        end
+
+      :error ->
+        {:error, :contended}
+    end
+  end
+
   @doc "Lock sidecar path for a record path."
   @spec lock_path(String.t()) :: String.t()
   def lock_path(path), do: path <> ".lock"

--- a/lib/optimal_system_agent/agent/task_notifications.ex
+++ b/lib/optimal_system_agent/agent/task_notifications.ex
@@ -20,24 +20,26 @@ defmodule OptimalSystemAgent.Agent.TaskNotifications do
   Storage mirrors `Loop.Steer` — and for the same reason: the loop process is
   blocked in `handle_call` for the whole turn, so only ETS is visible mid-turn.
   Rows are `{{session_id, seq}, map}` in the `:osa_task_notifications`
-  `:ordered_set` (FIFO drain, destructive → exactly-once). The
+  `:ordered_set` (FIFO reserve, followed by durable acknowledgement). The
   `:osa_task_notified` set holds per-task check-and-set flags so a
   `bash_output` poll and the completion broadcast racing yield exactly ONE
   notification per task.
   """
   require Logger
 
+  alias OptimalSystemAgent.Agent.DurableInbox
+
   @table :osa_task_notifications
   @notified_table :osa_task_notified
+  @poke_table :osa_task_notification_pokes
+  @coalesce_ms 25
 
   @type notification :: map()
 
   @doc "Enqueue a task notification for `session_id`. Never raises."
-  @spec queue(String.t(), notification()) :: :ok
+  @spec queue(String.t(), notification()) :: :ok | {:error, term()}
   def queue(session_id, notification) when is_binary(session_id) and is_map(notification) do
-    seq = :erlang.unique_integer([:monotonic, :positive])
-    :ets.insert(@table, {{session_id, seq}, notification})
-    :ok
+    DurableInbox.append(@table, session_id, :task_notifications, notification)
   rescue
     ArgumentError ->
       Logger.warning("[task-notif] queue table missing — notification dropped for #{session_id}")
@@ -47,20 +49,7 @@ defmodule OptimalSystemAgent.Agent.TaskNotifications do
   @doc "Remove and return all queued notifications for `session_id`, oldest first."
   @spec drain(String.t()) :: [notification()]
   def drain(session_id) when is_binary(session_id) do
-    match = [{{{session_id, :"$1"}, :"$2"}, [], [{{:"$1", :"$2"}}]}]
-
-    case :ets.select(@table, match) do
-      [] ->
-        []
-
-      rows ->
-        rows
-        |> Enum.sort_by(fn {seq, _n} -> seq end)
-        |> Enum.map(fn {seq, notif} ->
-          :ets.delete(@table, {session_id, seq})
-          notif
-        end)
-    end
+    DurableInbox.drain(@table, session_id, :task_notifications)
   rescue
     ArgumentError -> []
   end
@@ -68,10 +57,21 @@ defmodule OptimalSystemAgent.Agent.TaskNotifications do
   @doc "Number of notifications currently queued for `session_id`."
   @spec count(String.t()) :: non_neg_integer()
   def count(session_id) when is_binary(session_id) do
-    :ets.select_count(@table, [{{{session_id, :_}, :_}, [], [true]}])
+    DurableInbox.count(@table, session_id, :task_notifications)
   rescue
     ArgumentError -> 0
   end
+
+  @doc false
+  def checkout(session_id),
+    do: DurableInbox.checkout(@table, session_id, :task_notifications)
+
+  @doc false
+  def acknowledge(session_id, receipt),
+    do: DurableInbox.acknowledge(@table, session_id, :task_notifications, receipt)
+
+  @doc false
+  def release(session_id, receipt), do: DurableInbox.release(@table, session_id, receipt)
 
   @doc "Whether any notifications are pending for `session_id`."
   @spec pending?(String.t()) :: boolean()
@@ -108,8 +108,8 @@ defmodule OptimalSystemAgent.Agent.TaskNotifications do
   dropped poke leaves it, and reports `:clear` rather than claiming a delivery
   it did not make.
 
-  It cannot spin. `drain/1` is destructive, so the synthetic turn this poke
-  starts empties the queue, and that turn's own `settle/1` finds it clear.
+  It cannot spin. A consumer claims live entries before starting the synthetic
+  turn, then acknowledges them after persisting their incorporation.
   """
   @spec settle(String.t() | nil) :: :unread | :clear
   def settle(session_id) when is_binary(session_id) do
@@ -130,6 +130,32 @@ defmodule OptimalSystemAgent.Agent.TaskNotifications do
   end
 
   def settle(_), do: :clear
+
+  @doc "Wake the loop after a short deduplicated completion-coalescing window."
+  @spec poke_after_batch(String.t()) :: :ok
+  def poke_after_batch(session_id) when is_binary(session_id) do
+    if :ets.insert_new(@poke_table, {session_id, true}) do
+      case Task.Supervisor.start_child(OptimalSystemAgent.TaskSupervisor, fn ->
+             Process.sleep(@coalesce_ms)
+             :ets.delete(@poke_table, session_id)
+             poker().poke(session_id)
+           end) do
+        {:ok, _pid} ->
+          :ok
+
+        {:error, reason} ->
+          :ets.delete(@poke_table, session_id)
+          Logger.warning("[task-notif] could not schedule coalesced poke: #{inspect(reason)}")
+          poker().poke(session_id)
+      end
+    end
+
+    :ok
+  rescue
+    ArgumentError ->
+      poker().poke(session_id)
+      :ok
+  end
 
   # Injected by the same convention `:background_manager` and `:subagent_roster`
   # already use. Also breaks what would otherwise be a compile-time cycle back
@@ -160,7 +186,10 @@ defmodule OptimalSystemAgent.Agent.TaskNotifications do
   """
   @spec to_messages([notification()]) :: [map()]
   def to_messages(notifications) when is_list(notifications) do
-    Enum.map(notifications, fn n -> %{role: "system", content: to_xml(n)} end)
+    case notifications do
+      [] -> []
+      list -> [%{role: "system", content: Enum.map_join(list, "\n\n", &to_xml/1)}]
+    end
   end
 
   # Element order is fixed by the CC `constants/xml.ts` contract. Declared once

--- a/lib/optimal_system_agent/application.ex
+++ b/lib/optimal_system_agent/application.ex
@@ -243,6 +243,10 @@ defmodule OptimalSystemAgent.Application do
     # the same reason as :osa_steer_queue. See Agent.TaskNotifications.
     :ets.new(:osa_task_notifications, [:named_table, :public, :ordered_set])
 
+    # One short-lived latch per session coalesces same-tick background
+    # completions before waking an idle loop.
+    :ets.new(:osa_task_notification_pokes, [:named_table, :public, :set])
+
     # WS6 — per-task "notified" check-and-set flags ({task_id, ts}) so a
     # bash_output poll and the completion broadcast race to exactly ONE
     # <task-notification> per task.

--- a/lib/optimal_system_agent/channels/cli.ex
+++ b/lib/optimal_system_agent/channels/cli.ex
@@ -229,7 +229,13 @@ defmodule OptimalSystemAgent.Channels.CLI do
           end)
 
         unless filtered do
-          MessageQueue.enqueue(session_id, input)
+          case MessageQueue.submit(session_id, input) do
+            %{status: :queued, position: position} ->
+              IO.puts("#{IO.ANSI.faint()}  Queued at position #{position}#{IO.ANSI.reset()}")
+
+            _accepted ->
+              :ok
+          end
         end
       end
 

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -50,11 +50,13 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     "fg" => {"Foreground a running agent/fleet node — switch the active session to it", :cmd_fg},
     "steer" => {"Inject a directive into the running turn (mid-turn steer)", :cmd_steer},
     "goal" => {"Anchor a goal the agent keeps working toward across turns", :cmd_goal},
+    "loop" => {"Repeat a prompt on an explicit interval until stopped", :cmd_loop},
     "sessions" => {"List recent sessions", :cmd_sessions},
     "tasks" => {"Show current tasks", :cmd_tasks},
     "plan" => {"Toggle plan mode", :cmd_plan},
     "doctor" => {"Run health check", :cmd_doctor},
     "export" => {"Export conversation as markdown", :cmd_export},
+    "save" => {"Save a readable snapshot of this session", :cmd_save},
     "version" => {"Show version and check for updates", :cmd_version},
     "release-notes" => {"Show what's new in this release", :cmd_release_notes},
     "coordinator" => {"Toggle coordinator mode (delegation only)", :cmd_coordinator},
@@ -1621,6 +1623,57 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     e ->
       IO.puts("  #{@yellow}error: #{Exception.message(e)}#{@reset}\n")
       session_id
+  end
+
+  def cmd_save(args, session_id), do: cmd_export(args, session_id)
+
+  def cmd_loop(args, session_id) do
+    alias OptimalSystemAgent.Agent.LoopControl
+
+    IO.puts("")
+
+    case String.split(String.trim(args), ~r/\s+/, parts: 2) do
+      [] ->
+        print_loop_status(LoopControl.status(session_id))
+
+      [verb] when verb in ["", "status", "show"] ->
+        print_loop_status(LoopControl.status(session_id))
+
+      [verb] when verb in ["stop", "off", "clear"] ->
+        :ok = LoopControl.stop(session_id)
+        IO.puts("  #{@green}✓#{@reset} Loop stopped")
+
+      [interval, prompt] ->
+        with {:ok, interval_ms} <- LoopControl.parse_interval(interval),
+             {:ok, loop} <- LoopControl.start(session_id, interval_ms, prompt) do
+          IO.puts("  #{@green}✓#{@reset} Loop active every #{interval}")
+          IO.puts("  #{@dim}#{loop["prompt"]}#{@reset}")
+          IO.puts("  #{@dim}/loop stop to cancel#{@reset}")
+        else
+          _ -> IO.puts("  #{@yellow}Usage: /loop <5s|5m|2h> <prompt> | stop | status#{@reset}")
+        end
+
+      _ ->
+        IO.puts("  #{@yellow}Usage: /loop <5s|5m|2h> <prompt> | stop | status#{@reset}")
+    end
+
+    IO.puts("")
+    session_id
+  rescue
+    error ->
+      IO.puts("  #{@yellow}error: #{Exception.message(error)}#{@reset}\n")
+      session_id
+  end
+
+  defp print_loop_status(nil) do
+    IO.puts("  #{@dim}No operator loop is active for this session.#{@reset}")
+  end
+
+  defp print_loop_status(loop) do
+    seconds = div(loop["interval_ms"], 1_000)
+    IO.puts("  #{@bold}Operator loop#{@reset} every #{seconds}s")
+    IO.puts("  #{loop["prompt"]}")
+    IO.puts("  #{@dim}ticks: #{loop["tick_count"]} · /loop stop to cancel#{@reset}")
   end
 
   def cmd_effort(args, session_id) do

--- a/lib/optimal_system_agent/channels/cli/message_queue.ex
+++ b/lib/optimal_system_agent/channels/cli/message_queue.ex
@@ -30,6 +30,13 @@ defmodule OptimalSystemAgent.Channels.CLI.MessageQueue do
             agent_busy: false,
             timer_ref: nil
 
+  @typedoc "Observable result of submitting user input to the session state machine."
+  @type submission :: %{
+          required(:status) => :accepted | :queued | :command,
+          required(:session_id) => String.t(),
+          optional(:position) => pos_integer()
+        }
+
   # ── Client API ───────────────────────────────────────────────────────
 
   def start_link(session_id) do
@@ -45,6 +52,17 @@ defmodule OptimalSystemAgent.Channels.CLI.MessageQueue do
     else
       GenServer.cast(via(session_id), {:enqueue, message, opts})
       session_id
+    end
+  end
+
+  @doc "Submit input and synchronously report whether it was accepted or queued."
+  @spec submit(String.t(), String.t(), keyword()) :: submission()
+  def submit(session_id, message, opts \\ []) do
+    if String.starts_with?(message, "/") do
+      Commands.dispatch(String.trim_leading(message, "/"), session_id)
+      %{status: :command, session_id: session_id}
+    else
+      GenServer.call(via(session_id), {:submit, message, opts})
     end
   end
 
@@ -88,22 +106,8 @@ defmodule OptimalSystemAgent.Channels.CLI.MessageQueue do
 
   @impl true
   def handle_cast({:enqueue, message, opts}, state) do
-    if state.agent_busy do
-      # Agent is working — queue for later (and mirror to disk for restart safety)
-      queued = state.queued ++ [{message, opts}]
-      persist_queue(state.session_id, queued)
-      {:noreply, %{state | queued: queued}}
-    else
-      # Cancel existing debounce timer
-      if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
-
-      # Add to pending batch
-      pending = state.pending ++ [{message, opts}]
-
-      # Start new debounce timer
-      ref = Process.send_after(self(), :flush, @debounce_ms)
-      {:noreply, %{state | pending: pending, timer_ref: ref}}
-    end
+    {_outcome, state} = accept(message, opts, state)
+    {:noreply, state}
   end
 
   @impl true
@@ -127,6 +131,11 @@ defmodule OptimalSystemAgent.Channels.CLI.MessageQueue do
     {:reply, state.queued != [] or state.pending != [], state}
   end
 
+  def handle_call({:submit, message, opts}, _from, state) do
+    {outcome, state} = accept(message, opts, state)
+    {:reply, outcome, state}
+  end
+
   @impl true
   def handle_info(:flush, state) do
     case state.pending do
@@ -144,6 +153,23 @@ defmodule OptimalSystemAgent.Channels.CLI.MessageQueue do
   end
 
   # ── Private ──────────────────────────────────────────────────────────
+
+  defp accept(message, opts, state) do
+    if state.agent_busy do
+      queued = state.queued ++ [{message, opts}]
+      persist_queue(state.session_id, queued)
+
+      {%{status: :queued, session_id: state.session_id, position: length(queued)},
+       %{state | queued: queued}}
+    else
+      if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+      pending = state.pending ++ [{message, opts}]
+      ref = Process.send_after(self(), :flush, @debounce_ms)
+
+      {%{status: :accepted, session_id: state.session_id},
+       %{state | pending: pending, timer_ref: ref}}
+    end
+  end
 
   defp dispatch_to_agent(message, opts, session_id) do
     Session.send_to_agent(message, session_id, opts)

--- a/lib/optimal_system_agent/supervisors/agent_services.ex
+++ b/lib/optimal_system_agent/supervisors/agent_services.ex
@@ -28,6 +28,7 @@ defmodule OptimalSystemAgent.Supervisors.AgentServices do
       OptimalSystemAgent.Agent.Hooks,
       OptimalSystemAgent.Agent.Scheduler,
       OptimalSystemAgent.Agent.Scheduler.HeartbeatExecutor,
+      OptimalSystemAgent.Agent.LoopControl,
       OptimalSystemAgent.Agent.Compactor,
       OptimalSystemAgent.Signal.Persistence,
       {DynamicSupervisor,

--- a/test/channels/cli/message_queue_persistence_test.exs
+++ b/test/channels/cli/message_queue_persistence_test.exs
@@ -78,5 +78,16 @@ defmodule OptimalSystemAgent.Channels.CLI.MessageQueuePersistenceTest do
 
       refute MessageQueue.has_queued?(id)
     end
+
+    test "submit reports accepted versus queued instead of making the UI guess", %{id: id} do
+      {:ok, pid} = MessageQueue.start_link(id)
+      on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+      assert %{status: :accepted, session_id: ^id} = MessageQueue.submit(id, "first")
+      :sys.replace_state(pid, &%{&1 | agent_busy: true})
+
+      assert %{status: :queued, session_id: ^id, position: 1} =
+               MessageQueue.submit(id, "second")
+    end
   end
 end

--- a/test/optimal_system_agent/agent/loop/steer_test.exs
+++ b/test/optimal_system_agent/agent/loop/steer_test.exs
@@ -55,6 +55,15 @@ defmodule OptimalSystemAgent.Agent.Loop.SteerTest do
       assert Steer.drain(other) == ["theirs"]
     end
 
+    test "a steer survives loss of the live ETS projection", %{session_id: sid} do
+      :ok = Steer.queue(sid, "survive restart")
+
+      :ets.match_delete(:osa_steer_queue, {{sid, :_}, :_})
+
+      assert Steer.drain(sid) == ["survive restart"]
+      assert Steer.drain(sid) == []
+    end
+
     test "to_messages/1 renders each steer as a labelled system directive" do
       [msg] = Steer.to_messages(["do X instead"])
 

--- a/test/optimal_system_agent/agent/loop_control_test.exs
+++ b/test/optimal_system_agent/agent/loop_control_test.exs
@@ -1,0 +1,65 @@
+defmodule OptimalSystemAgent.Agent.LoopControlTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Agent.LoopControl
+  alias OptimalSystemAgent.Agent.SessionPersistence
+
+  test "parses bounded operator intervals" do
+    assert {:ok, 5_000} = LoopControl.parse_interval("5s")
+    assert {:ok, 300_000} = LoopControl.parse_interval("5m")
+    assert {:ok, 7_200_000} = LoopControl.parse_interval("2h")
+    assert {:error, :invalid_interval} = LoopControl.parse_interval("1s")
+    assert {:error, :invalid_interval} = LoopControl.parse_interval("soon")
+  end
+
+  test "start, status, and stop expose explicit operator control" do
+    session_id = "loop-control-#{System.unique_integer([:positive])}"
+    on_exit(fn -> LoopControl.stop(session_id) end)
+
+    assert {:ok, %{"prompt" => "check the deployment"}} =
+             LoopControl.start(session_id, 5_000, "check the deployment")
+
+    assert %{"interval_ms" => 5_000, "tick_count" => 0} = LoopControl.status(session_id)
+    assert :ok = LoopControl.stop(session_id)
+    assert LoopControl.status(session_id) == nil
+  end
+
+  test "a tick is not counted when no live session queue accepts it" do
+    session_id = "missing-loop-#{System.unique_integer([:positive])}"
+
+    entry = %{
+      interval_ms: 60_000,
+      prompt: "check",
+      tick_count: 0,
+      started_at: DateTime.utc_now() |> DateTime.to_iso8601(),
+      last_tick_at: nil,
+      timer_ref: nil
+    }
+
+    assert {:noreply, %{^session_id => updated}} =
+             LoopControl.handle_info({:tick, session_id}, %{session_id => entry})
+
+    assert updated.tick_count == 0
+    assert updated.last_tick_at == nil
+    Process.cancel_timer(updated.timer_ref)
+  end
+
+  test "restart does not rearm an ambiguously dispatched tick" do
+    session_id = "dispatching-loop-#{System.unique_integer([:positive])}"
+
+    stored = %{
+      "interval_ms" => 60_000,
+      "prompt" => "check once",
+      "tick_count" => 1,
+      "started_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "last_tick_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "last_tick_status" => "dispatching"
+    }
+
+    assert :ok = SessionPersistence.save_inbox(session_id, :operator_loop, [stored])
+    on_exit(fn -> SessionPersistence.save_inbox(session_id, :operator_loop, []) end)
+
+    assert {:ok, restored} = LoopControl.init(%{})
+    assert %{timer_ref: nil, last_tick_status: "dispatching"} = restored[session_id]
+  end
+end

--- a/test/optimal_system_agent/agent/task_notifications_test.exs
+++ b/test/optimal_system_agent/agent/task_notifications_test.exs
@@ -3,6 +3,12 @@ defmodule OptimalSystemAgent.Agent.TaskNotificationsTest do
 
   alias OptimalSystemAgent.Agent.TaskNotifications, as: TN
 
+  defmodule TestPoker do
+    def poke(session_id) do
+      send(:persistent_term.get({__MODULE__, session_id}), {:poke, session_id})
+    end
+  end
+
   setup do
     # Tables are app-owned in production; create them here when the app
     # isn't started (they die with the test process, which is fine).
@@ -12,6 +18,10 @@ defmodule OptimalSystemAgent.Agent.TaskNotificationsTest do
 
     if :ets.whereis(:osa_task_notified) == :undefined do
       :ets.new(:osa_task_notified, [:named_table, :public, :set])
+    end
+
+    if :ets.whereis(:osa_task_notification_pokes) == :undefined do
+      :ets.new(:osa_task_notification_pokes, [:named_table, :public, :set])
     end
 
     {:ok, sid: "tn-test-" <> Integer.to_string(System.unique_integer([:positive]))}
@@ -33,6 +43,97 @@ defmodule OptimalSystemAgent.Agent.TaskNotificationsTest do
 
     assert [%{task_id: "mine"}] = TN.drain(sid)
     assert [%{task_id: "theirs"}] = TN.drain(sid <> "-other")
+  end
+
+  test "queued results survive loss of the live ETS projection", %{sid: sid} do
+    :ok = TN.queue(sid, %{task_id: "durable", status: :done})
+
+    :ets.match_delete(:osa_task_notifications, {{sid, :_}, :_})
+
+    assert [%{task_id: "durable"}] = TN.drain(sid)
+    assert TN.drain(sid) == []
+  end
+
+  test "checkout survives a consumer crash before acknowledgement", %{sid: sid} do
+    :ok = TN.queue(sid, %{task_id: "reserved", status: :done})
+
+    assert {receipt, [%{task_id: "reserved"}]} = TN.checkout(sid)
+
+    # A consumer incorporated nothing and died. Its ETS claim disappears, but
+    # the durable ledger still owns the fact, so the replacement can reserve it.
+    :ets.match_delete(:osa_task_notifications, {{sid, :_}, :_})
+    assert {restored_receipt, [%{task_id: "reserved"}]} = TN.checkout(sid)
+    assert restored_receipt == receipt
+
+    assert :ok = TN.acknowledge(sid, restored_receipt)
+    assert :empty = TN.checkout(sid)
+  end
+
+  test "simultaneous completions are coalesced into one context fragment" do
+    [message] =
+      TN.to_messages([
+        %{task_id: "one", status: :done},
+        %{task_id: "two", status: :done}
+      ])
+
+    assert message.content =~ "<task-id>one</task-id>"
+    assert message.content =~ "<task-id>two</task-id>"
+  end
+
+  test "completion pokes in one window are delivered once", %{sid: sid} do
+    key = {TestPoker, sid}
+    previous = Application.get_env(:optimal_system_agent, :notification_poker)
+    :persistent_term.put(key, self())
+    Application.put_env(:optimal_system_agent, :notification_poker, TestPoker)
+
+    on_exit(fn ->
+      :persistent_term.erase(key)
+
+      if previous do
+        Application.put_env(:optimal_system_agent, :notification_poker, previous)
+      else
+        Application.delete_env(:optimal_system_agent, :notification_poker)
+      end
+    end)
+
+    :ok = TN.poke_after_batch(sid)
+    :ok = TN.poke_after_batch(sid)
+    :ok = TN.poke_after_batch(sid)
+
+    assert_receive {:poke, ^sid}, 250
+    refute_receive {:poke, ^sid}, 75
+  end
+
+  test "concurrent producers cannot overwrite one another's durable entries", %{sid: sid} do
+    1..20
+    |> Task.async_stream(fn id -> TN.queue(sid, %{task_id: "task-#{id}"}) end,
+      max_concurrency: 20,
+      timeout: 5_000
+    )
+    |> Enum.each(fn result -> assert result == {:ok, :ok} end)
+
+    :ets.match_delete(:osa_task_notifications, {{sid, :_}, :_})
+
+    ids = sid |> TN.drain() |> Enum.map(& &1.task_id) |> MapSet.new()
+    assert ids == MapSet.new(Enum.map(1..20, &"task-#{&1}"))
+  end
+
+  test "concurrent checkouts cannot reserve the same entry twice", %{sid: sid} do
+    for id <- 1..20 do
+      :ok = TN.queue(sid, %{task_id: "claim-#{id}"})
+    end
+
+    results =
+      1..2
+      |> Task.async_stream(fn _ -> TN.checkout(sid) end, max_concurrency: 2)
+      |> Enum.flat_map(fn
+        {:ok, :empty} -> []
+        {:ok, {_receipt, notifications}} -> notifications
+      end)
+
+    ids = Enum.map(results, & &1.task_id)
+    assert length(ids) == 20
+    assert length(Enum.uniq(ids)) == 20
   end
 
   test "mark_notified is check-and-set: true exactly once" do


### PR DESCRIPTION
## Summary

- add durable steer and background-task inboxes with FIFO reservation, transcript receipt markers, restart replay deduplication, and bounded contention retries
- add explicit persistent `/loop` controls plus `/save` as an export alias
- expose accepted versus queued CLI submissions and queue position
- coalesce near-simultaneous background completions into one context injection and one wakeup
- tighten persistence failure handling so loop ticks, queue facts, and acknowledgements cannot silently report success or disappear

## Verification

- `mix compile`
- 48 focused runtime, persistence, queue, steer, notification, and concurrency tests pass
- `git diff --check`
- independent standards and spec reviews completed with blockers addressed

## Test-suite note

The full repository suite was attempted earlier on this checkout, but it currently has numerous unrelated environment and baseline failures, including temporary-directory permissions, platform path assumptions, persisted local secrets, and BSD `script` behavior. The focused tests covering this change are green.