### PR TITLE
feat(skills): preserve selected workflows across compaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -967,6 +967,11 @@ Skills are available immediately, no restart, no recompile. The Skills Registry
 hot-reloads on file change. Recurring behavior patterns (occurrence ≥ 5) are
 auto-promoted to skills by the SICA engine.
 
+OSA keeps the catalog compact and loads a full `SKILL.md` only after the agent selects it with `skill_view`.
+Selected skill names are checkpointed with the session and re-injected on every generation, so compaction or a backend restart cannot make a long-running agent forget the workflow it chose.
+When a selected skill body is no longer present in conversation context, OSA requires the agent to reload it with `skill_view` before taking another task action.
+Deleting the session removes that checkpoint.
+
 ---
 
 ## Project layout

--- a/lib/optimal_system_agent/agent/active_skills.ex
+++ b/lib/optimal_system_agent/agent/active_skills.ex
@@ -1,0 +1,158 @@
+defmodule OptimalSystemAgent.Agent.ActiveSkills do
+  @moduledoc """
+  Durable record of the skills selected by an agent for a session.
+
+  Skill bodies are loaded progressively and remain outside the permanent system
+  prompt. This store records only their names. The context builder rehydrates
+  those names on every generation, so compaction cannot make the agent forget
+  which operating instructions it deliberately selected.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.Agent.SessionPersistence.RecordLock
+  alias OptimalSystemAgent.ConfigFile
+  alias OptimalSystemAgent.System.AtomicFile
+  alias OptimalSystemAgent.Tools.Registry
+
+  @max_skills 12
+
+  @spec select(String.t(), String.t()) :: :ok | {:error, term()}
+  def select(session_id, skill_name)
+      when is_binary(session_id) and session_id != "" and is_binary(skill_name) and
+             skill_name != "" do
+    mutate(session_id, fn names ->
+      names
+      |> Enum.reject(&(&1 == skill_name))
+      |> Kernel.++([skill_name])
+      |> Enum.take(-@max_skills)
+    end)
+  end
+
+  @spec list(String.t()) :: [String.t()]
+  def list(session_id) when is_binary(session_id) do
+    case load(session_id) do
+      {:ok, names} -> names
+      {:error, _reason} -> []
+    end
+  end
+
+  @spec load(String.t()) :: {:ok, [String.t()]} | {:error, term()}
+  def load(session_id) when is_binary(session_id) do
+    case File.read(path(session_id)) do
+      {:ok, bytes} -> decode(bytes)
+      {:error, :enoent} -> {:ok, []}
+      {:error, reason} -> {:error, {:read_failed, reason}}
+    end
+  end
+
+  @spec clear(String.t()) :: :ok | {:error, term()}
+  def clear(session_id) when is_binary(session_id), do: File.rm(path(session_id)) |> absent_ok()
+
+  @spec exists?(String.t()) :: boolean()
+  def exists?(session_id) when is_binary(session_id), do: File.exists?(path(session_id))
+
+  @spec context_block(String.t(), [map()]) :: String.t() | nil
+  def context_block(session_id, messages \\ []) when is_binary(session_id) do
+    case load(session_id) do
+      {:ok, []} ->
+        nil
+
+      {:ok, names} ->
+        missing = Enum.reject(names, &body_present?(messages, &1))
+
+        reload =
+          case missing do
+            [] ->
+              "Their instruction bodies are present in the current conversation."
+
+            _ ->
+              calls = Enum.map_join(missing, ", ", &"`skill_view` for `#{&1}`")
+
+              "Their instruction bodies are absent, likely because of compaction or restart. " <>
+                "Before any further task action, reload #{calls}."
+          end
+
+        "## Selected Skills\n\n" <>
+          "These skills remain active for this task across compaction and restart. " <>
+          reload <> "\n\n" <> Enum.map_join(names, "\n", &"- **#{&1}**")
+
+      {:error, reason} ->
+        Logger.error("[active_skills] checkpoint unavailable: #{inspect(reason)}")
+
+        "## Selected Skills Checkpoint Error\n\n" <>
+          "OSA could not restore the selected-skill checkpoint (#{bounded(reason)}). " <>
+          "Do not continue the task until the skill is selected again with `skill_view`."
+    end
+  end
+
+  defp mutate(session_id, fun) do
+    record_path = path(session_id)
+
+    case RecordLock.with_lock_strict(record_path, fn ->
+           names =
+             case load(session_id) do
+               {:ok, loaded} ->
+                 loaded
+
+               {:error, reason} ->
+                 Logger.warning(
+                   "[active_skills] rebuilding unreadable checkpoint while selecting a skill: " <>
+                     inspect(reason)
+                 )
+
+                 []
+             end
+
+           AtomicFile.write(record_path, Jason.encode!(%{version: 1, skills: fun.(names)}))
+         end) do
+      {:ok, result} -> result
+      {:error, :contended} -> {:error, :contended}
+    end
+  end
+
+  defp decode(bytes) do
+    case Jason.decode(bytes) do
+      {:ok, %{"skills" => names}} when is_list(names) ->
+        {:ok,
+         names
+         |> Enum.filter(&(is_binary(&1) and &1 != ""))
+         |> Enum.uniq()
+         |> Enum.take(-@max_skills)}
+
+      {:ok, invalid} ->
+        {:error, {:invalid_structure, invalid}}
+
+      {:error, reason} ->
+        {:error, {:invalid_json, Exception.message(reason)}}
+    end
+  end
+
+  defp body_present?(messages, skill_name) do
+    with {:ok, body} <- Registry.load_skill_body(skill_name) do
+      expected = String.trim(body)
+
+      Enum.any?(messages, fn message ->
+        role = Map.get(message, :role) || Map.get(message, "role")
+        content = Map.get(message, :content) || Map.get(message, "content") || ""
+
+        role == "tool" and is_binary(content) and expected != "" and
+          String.contains?(content, expected)
+      end)
+    else
+      _ -> false
+    end
+  end
+
+  defp bounded(reason),
+    do: reason |> inspect(limit: 5, printable_limit: 120) |> String.slice(0, 160)
+
+  defp path(session_id) do
+    safe_id = Regex.replace(~r/[^a-zA-Z0-9_\-]/, session_id, "_")
+    Path.join([ConfigFile.config_dir(), "sessions", "#{safe_id}.skills"])
+  end
+
+  defp absent_ok(:ok), do: :ok
+  defp absent_ok({:error, :enoent}), do: :ok
+  defp absent_ok(error), do: error
+end

--- a/lib/optimal_system_agent/agent/context.ex
+++ b/lib/optimal_system_agent/agent/context.ex
@@ -450,7 +450,7 @@ defmodule OptimalSystemAgent.Agent.Context do
   # state. Everything else (memory, episodic, skills, learned skills) is RECALL
   # and competes within a bounded sub-budget capped to a fraction of the REAL
   # window. Labels owned by `WorldState.managed_labels/0` never reach this split.
-  @essential_labels ~w(task_brief runtime git_state task_state workflow)
+  @essential_labels ~w(task_brief active_skills runtime git_state task_state workflow)
 
   # `@dynamic_budget_floor` is declared with the other budget constants at the
   # top of the module — a module attribute read before its definition silently
@@ -771,6 +771,7 @@ defmodule OptimalSystemAgent.Agent.Context do
       {bootstrap_block(), 0, "bootstrap"},
       {personality_block(), 0, "personality"},
       {task_brief_block(state), 0, "task_brief"},
+      {active_skills_block(state), 0, "active_skills"},
       {tool_process_block(state), 1, "tool_process"},
       # Priority 0: tiny and load-bearing. It carries the session id, the channel
       # and the resolved model identity — the same resolver /health and the TUI
@@ -1530,6 +1531,24 @@ defmodule OptimalSystemAgent.Agent.Context do
     _ -> nil
   catch
     :exit, _ -> nil
+  end
+
+  defp active_skills_block(state) do
+    case Map.get(state, :session_id) do
+      session_id when is_binary(session_id) ->
+        OptimalSystemAgent.Agent.ActiveSkills.context_block(
+          session_id,
+          Map.get(state, :messages, [])
+        )
+
+      _ ->
+        nil
+    end
+  rescue
+    error ->
+      "## Selected Skills Checkpoint Error\n\n" <>
+        "OSA could not inspect the selected-skill checkpoint (#{Exception.message(error)}). " <>
+        "Do not continue the task until the skill is selected again with `skill_view`."
   end
 
   defp task_state_block(state) do

--- a/lib/optimal_system_agent/agent/session_persistence.ex
+++ b/lib/optimal_system_agent/agent/session_persistence.ex
@@ -370,16 +370,17 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
   """
   @spec exists?(String.t()) :: boolean()
   def exists?(session_id) when is_binary(session_id) do
-    Enum.any?(
-      [
-        session_path(session_id),
-        spend_path(session_id),
-        meta_path(session_id),
-        updates_path(session_id),
-        OptimalSystemAgent.Agent.Loop.GoalTracker.store_path(session_id)
-      ],
-      &File.exists?/1
-    )
+    OptimalSystemAgent.Agent.ActiveSkills.exists?(session_id) or
+      Enum.any?(
+        [
+          session_path(session_id),
+          spend_path(session_id),
+          meta_path(session_id),
+          updates_path(session_id),
+          OptimalSystemAgent.Agent.Loop.GoalTracker.store_path(session_id)
+        ],
+        &File.exists?/1
+      )
   rescue
     _ -> false
   end
@@ -397,6 +398,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
     _ = File.rm(meta_path(session_id))
     _ = File.rm(spend_path(session_id))
     _ = File.rm(pin_path(session_id))
+    _ = OptimalSystemAgent.Agent.ActiveSkills.clear(session_id)
     forget_rev(session_id)
     File.rm(path)
   end
@@ -452,6 +454,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistence do
                   _ = File.rm(RecordLock.lock_path(path))
                   _ = File.rm(meta_path(session_id))
                   _ = File.rm(spend_path(session_id))
+                  _ = OptimalSystemAgent.Agent.ActiveSkills.clear(session_id)
                   forget_rev(session_id)
                   File.rm(path) == :ok
                 end

--- a/lib/optimal_system_agent/tools/builtins/skill_view.ex
+++ b/lib/optimal_system_agent/tools/builtins/skill_view.ex
@@ -12,6 +12,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
 
   alias OptimalSystemAgent.Tools.Registry
   alias OptimalSystemAgent.Tools.Registry.{SkillLoader, SkillUsage}
+  alias OptimalSystemAgent.Agent.ActiveSkills
 
   @impl true
   def name, do: "skill_view"
@@ -52,20 +53,31 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
   @impl true
   def execute(%{"name" => name}) when is_binary(name) and name != "" do
     case Registry.get_skill(name) do
+      %{path: path} = skill when is_binary(path) -> preview(skill, path)
+      nil -> {:error, "Skill '#{name}' not found. Call list_skills to inspect the catalog."}
+      _ -> {:error, "Skill '#{name}' has no readable SKILL.md path."}
+    end
+  end
+
+  def execute(_), do: {:error, "skill_view preview requires a non-empty skill name"}
+
+  @impl true
+  def execute(%{"name" => name}, ctx) when is_binary(name) and name != "" do
+    case Registry.get_skill(name) do
       nil ->
         {:error, "Skill '#{name}' not found. Call list_skills to inspect the catalog."}
 
       %{path: path} = skill when is_binary(path) ->
-        load(skill, path)
+        load(skill, path, ctx)
 
       _skill ->
         {:error, "Skill '#{name}' has no readable SKILL.md path."}
     end
   end
 
-  def execute(_), do: {:error, "skill_view requires a non-empty skill name"}
+  def execute(_, _ctx), do: {:error, "skill_view requires a non-empty skill name"}
 
-  defp load(skill, path) do
+  defp load(skill, path, ctx) do
     cond do
       not SkillLoader.within_roots?(path) ->
         {:error, "Skill path is outside the configured skill roots."}
@@ -78,13 +90,48 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
           {:ok, body} ->
             SkillUsage.record_use(skill.name)
 
-            {:ok,
-             "# Active Skill: #{skill.name}\n\n" <>
-               "You selected this skill for the current task. Follow these instructions " <>
-               "before continuing.\n\n#{String.trim(body)}"}
+            case checkpoint_selection(ctx, skill.name) do
+              :ok ->
+                {:ok,
+                 "# Active Skill: #{skill.name}\n\n" <>
+                   "You selected this skill for the current task. Follow these instructions " <>
+                   "before continuing.\n\n#{String.trim(body)}"}
+
+              {:error, reason} ->
+                {:error,
+                 "Loaded '#{skill.name}' but could not checkpoint its selection: #{inspect(reason)}"}
+            end
 
           {:error, reason} ->
             {:error, "Could not load '#{skill.name}': #{inspect(reason)}"}
+        end
+    end
+  end
+
+  defp checkpoint_selection(%{session_id: session_id}, skill_name)
+       when is_binary(session_id) and session_id != "",
+       do: ActiveSkills.select(session_id, skill_name)
+
+  defp checkpoint_selection(_ctx, _skill_name), do: {:error, :missing_session_id}
+
+  defp preview(skill, path) do
+    cond do
+      not SkillLoader.within_roots?(path) ->
+        {:error, "Skill path is outside the configured skill roots."}
+
+      SkillLoader.disabled?(path) ->
+        {:error, "Skill '#{skill.name}' is disabled."}
+
+      true ->
+        case SkillLoader.load_body(path) do
+          {:ok, body} ->
+            {:ok,
+             "# Skill Preview: #{skill.name}\n\n" <>
+               "This direct preview has no owning session and did not activate the skill. " <>
+               "Runtime agents activate it through the session-aware tool path.\n\n#{String.trim(body)}"}
+
+          {:error, reason} ->
+            {:error, "Could not preview '#{skill.name}': #{inspect(reason)}"}
         end
     end
   end

--- a/test/agent/session_persistence_retention_test.exs
+++ b/test/agent/session_persistence_retention_test.exs
@@ -18,6 +18,7 @@ defmodule OptimalSystemAgent.Agent.SessionPersistenceRetentionTest do
   use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Agent.SessionPersistence
+  alias OptimalSystemAgent.Agent.ActiveSkills
   alias OptimalSystemAgent.Settings
 
   @two_years_ago 63_072_000
@@ -51,7 +52,14 @@ defmodule OptimalSystemAgent.Agent.SessionPersistenceRetentionTest do
     File.write!(path, Jason.encode!(%{session_id: id, messages: []}))
 
     old = System.system_time(:second) - @two_years_ago
-    {_, 0} = System.cmd("touch", ["-d", "@#{old}", path])
+
+    old_datetime =
+      old
+      |> DateTime.from_unix!()
+      |> DateTime.to_naive()
+      |> NaiveDateTime.to_erl()
+
+    File.touch!(path, old_datetime)
     path
   end
 
@@ -88,6 +96,16 @@ defmodule OptimalSystemAgent.Agent.SessionPersistenceRetentionTest do
 
       assert {:ok, 1} = SessionPersistence.purge_expired()
       refute File.exists?(path)
+    end
+
+    test "purging an ancient session removes its selected-skill checkpoint", %{dir: dir} do
+      _path = write_ancient_session(dir, "expired-with-skills")
+      assert :ok = ActiveSkills.select("expired-with-skills", "diagnosing-bugs")
+      assert ActiveSkills.exists?("expired-with-skills")
+      Settings.set_session("cleanupPeriodDays", 30)
+
+      assert {:ok, 1} = SessionPersistence.purge_expired()
+      refute ActiveSkills.exists?("expired-with-skills")
     end
 
     test "a fresh session survives a positive window", %{dir: dir} do

--- a/test/optimal_system_agent/agent/active_skills_test.exs
+++ b/test/optimal_system_agent/agent/active_skills_test.exs
@@ -1,0 +1,130 @@
+defmodule OptimalSystemAgent.Agent.ActiveSkillsTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias OptimalSystemAgent.Agent.ActiveSkills
+  alias OptimalSystemAgent.Agent.Context
+  alias OptimalSystemAgent.Agent.SessionPersistence
+
+  setup do
+    session_id = "active-skills-#{System.unique_integer([:positive])}"
+    on_exit(fn -> ActiveSkills.clear(session_id) end)
+    %{session_id: session_id}
+  end
+
+  test "selection survives outside the tool-result message and is re-injected", %{session_id: sid} do
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+    assert ActiveSkills.list(sid) == ["diagnosing-bugs"]
+
+    state = %{
+      session_id: sid,
+      messages: [%{role: "user", content: "continue after compaction"}],
+      working_dir: File.cwd!(),
+      channel: :cli,
+      provider: :ollama,
+      model: nil,
+      permission_tier: :full
+    }
+
+    %{messages: assembled} = Context.build(state)
+    rendered = inspect(assembled, limit: :infinity, printable_limit: :infinity)
+    assert rendered =~ "Selected Skills"
+    assert rendered =~ "diagnosing-bugs"
+    assert rendered =~ "Before any further task action"
+
+    assert {:ok, body} = OptimalSystemAgent.Tools.Registry.load_skill_body("diagnosing-bugs")
+    loaded_messages = [%{role: "tool", content: "# Active Skill: diagnosing-bugs\n\n#{body}"}]
+
+    block = ActiveSkills.context_block(sid, loaded_messages)
+    assert block =~ "instruction bodies are present"
+    refute block =~ "Before any further task action"
+  end
+
+  test "selection is ordered, deduplicated, and bounded", %{session_id: sid} do
+    for n <- 1..14, do: assert(:ok = ActiveSkills.select(sid, "skill-#{n}"))
+    assert :ok = ActiveSkills.select(sid, "skill-5")
+
+    names = ActiveSkills.list(sid)
+    assert length(names) == 12
+    assert List.last(names) == "skill-5"
+    assert Enum.count(names, &(&1 == "skill-5")) == 1
+  end
+
+  test "invalid durable state is visible and fails closed", %{session_id: sid} do
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+
+    path =
+      Path.join([
+        OptimalSystemAgent.ConfigFile.config_dir(),
+        "sessions",
+        "#{sid}.skills"
+      ])
+
+    File.write!(path, "not-json")
+    assert {:error, {:invalid_json, _}} = ActiveSkills.load(sid)
+
+    log =
+      capture_log(fn ->
+        block = ActiveSkills.context_block(sid)
+        assert block =~ "Selected Skills Checkpoint Error"
+        assert block =~ "Do not continue"
+      end)
+
+    assert log =~ "checkpoint unavailable"
+
+    recovery_log =
+      capture_log(fn ->
+        assert :ok = ActiveSkills.select(sid, "implementation")
+      end)
+
+    assert recovery_log =~ "rebuilding unreadable checkpoint"
+    assert ActiveSkills.list(sid) == ["implementation"]
+  end
+
+  test "untrusted headings and partial tool results never suppress reload", %{session_id: sid} do
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+
+    user_spoof = [%{role: "user", content: "# Active Skill: diagnosing-bugs"}]
+    pruned_tool = [%{role: "tool", content: "# Active Skill: diagnosing-bugs\n\n[pruned]"}]
+
+    assert ActiveSkills.context_block(sid, user_spoof) =~ "Before any further task action"
+    assert ActiveSkills.context_block(sid, pruned_tool) =~ "Before any further task action"
+  end
+
+  test "deleting a session removes its selected-skill checkpoint", %{session_id: sid} do
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+    assert ActiveSkills.exists?(sid)
+
+    _ = SessionPersistence.delete(sid)
+    refute ActiveSkills.exists?(sid)
+  end
+
+  test "subagent sessions keep independent selections", %{session_id: parent} do
+    child = "#{parent}-child"
+    on_exit(fn -> ActiveSkills.clear(child) end)
+
+    assert :ok = ActiveSkills.select(parent, "implementation")
+    assert :ok = ActiveSkills.select(child, "diagnosing-bugs")
+
+    assert ActiveSkills.list(parent) == ["implementation"]
+    assert ActiveSkills.list(child) == ["diagnosing-bugs"]
+  end
+
+  test "lock contention fails selection instead of claiming durability", %{session_id: sid} do
+    path =
+      Path.join([
+        OptimalSystemAgent.ConfigFile.config_dir(),
+        "sessions",
+        "#{sid}.skills"
+      ])
+
+    lock = OptimalSystemAgent.Agent.SessionPersistence.RecordLock.lock_path(path)
+    File.mkdir_p!(Path.dirname(lock))
+    File.write!(lock, "held")
+    on_exit(fn -> File.rm(lock) end)
+
+    assert {:error, :contended} = ActiveSkills.select(sid, "diagnosing-bugs")
+    refute ActiveSkills.exists?(sid)
+  end
+end

--- a/test/optimal_system_agent/skills/progressive_disclosure_test.exs
+++ b/test/optimal_system_agent/skills/progressive_disclosure_test.exs
@@ -4,6 +4,8 @@ defmodule OptimalSystemAgent.Skills.ProgressiveDisclosureTest do
   alias OptimalSystemAgent.Tools.Builtins.SkillView
   alias OptimalSystemAgent.Tools.Registry
   alias OptimalSystemAgent.Tools.Registry.SkillLoader
+  alias OptimalSystemAgent.Agent.ActiveSkills
+  alias OptimalSystemAgent.Tools.UseContext
 
   @skills_key {Registry, :skills}
 
@@ -100,8 +102,21 @@ defmodule OptimalSystemAgent.Skills.ProgressiveDisclosureTest do
 
   test "skill_view loads the selected body into the owning agent context" do
     assert {:ok, loaded} = SkillView.execute(%{"name" => "debugging"})
-    assert loaded =~ "# Active Skill: debugging"
+    assert loaded =~ "# Skill Preview: debugging"
+    assert loaded =~ "did not activate the skill"
     assert loaded =~ "REPRODUCE-FIRST-SENTINEL"
+  end
+
+  test "skill_view checkpoints the selection for its owning session" do
+    session_id = "skill-checkpoint-#{System.unique_integer([:positive])}"
+    on_exit(fn -> ActiveSkills.clear(session_id) end)
+
+    ctx = %UseContext{UseContext.empty() | session_id: session_id}
+    assert {:ok, loaded} = SkillView.execute(%{"name" => "debugging"}, ctx)
+    assert loaded =~ "REPRODUCE-FIRST-SENTINEL"
+
+    assert ActiveSkills.list(session_id) == ["debugging"]
+    assert ActiveSkills.exists?(session_id)
   end
 
   test "Codex user skills are a configured discovery root" do


### PR DESCRIPTION
## Summary

- Preserve explicitly selected skills across compaction and backend restart with a durable per-session checkpoint.
- Re-inject selected-skill control state on every generation and require `skill_view` reload whenever the exact current body is absent from a trusted tool result.
- Fail honestly on missing session identity, persistence contention, unreadable state, and corruption, while allowing an explicit skill selection to repair corrupt state.
- Keep parent and subagent skill state isolated by session, and remove sidecars during session deletion and retention purge.
- Make the retention fixture portable on macOS by replacing GNU-only `touch -d` with `File.touch!/2`.

## Why

OSA already had durable goals, bounded autonomous execution, fleet journals and recovery, provider guards, typed events, and responsive TUI goal controls.
The remaining Codex-derived gap was selected workflow state: `skill_view` returned the full body only as a tool-result message, so compaction could erase the fact that the agent had selected and was following that skill.

## Verification

- 451 focused runtime tests passed with 0 failures.
- Coverage includes compaction context assembly, mandatory body reload, corrupt-checkpoint recovery, lock contention, parent/subagent isolation, session deletion, retention purge, goals, autonomous limits, fleet recovery, and providers.
- Full suite ran 9,749 tests and exposed 79 pre-existing environment/order failures unrelated to this diff. The branch-specific and related suites are green.
- Standards review: clear.
- Spec review: clear.
- `git diff --check main...HEAD`: clean.
