### PR TITLE
fix: guarantee SHELL for erlexec on boot

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,10 +1,10 @@
 import Config
 
-# ── Guarantee SHELL for the erlexec (:exec) port program ─────────────────
+# Guarantee SHELL for the erlexec (:exec) port program.
 # erlexec's native port hard-exits (status 4) at startup when SHELL is unset
 # or empty (erlexec c_src/exec.cpp: "SHELL environment variable not set!").
-# Non-login environments — CI, systemd units, minimal containers, test
-# runners — often don't export SHELL, which crashes the whole OpenComputers
+# Non-login environments such as CI, systemd units, minimal containers, and test
+# runners often don't export SHELL, which crashes the whole OpenComputers
 # subsystem on boot. runtime.exs runs before the app tree (and :exec) start,
 # so default it here to a real shell.
 if System.get_env("SHELL") in [nil, ""] do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,5 +1,16 @@
 import Config
 
+# ── Guarantee SHELL for the erlexec (:exec) port program ─────────────────
+# erlexec's native port hard-exits (status 4) at startup when SHELL is unset
+# or empty (erlexec c_src/exec.cpp: "SHELL environment variable not set!").
+# Non-login environments — CI, systemd units, minimal containers, test
+# runners — often don't export SHELL, which crashes the whole OpenComputers
+# subsystem on boot. runtime.exs runs before the app tree (and :exec) start,
+# so default it here to a real shell.
+if System.get_env("SHELL") in [nil, ""] do
+  System.put_env("SHELL", Enum.find(["/bin/bash", "/bin/sh"], &File.exists?/1) || "/bin/sh")
+end
+
 # ── User config dir resolved at RUNTIME, not compile time ────────────────
 # config/config.exs sets config_dir with Path.expand("~/.osa"), which is
 # evaluated during `mix release` on the build host (HOME=/home/runner on CI)


### PR DESCRIPTION
erlexec's native `:exec` port hard-exits (status 4) when `SHELL` is unset or empty (`erlexec c_src/exec.cpp`: "SHELL environment variable not set!"). Non-login environments (CI, systemd units, minimal containers, test runners) often don't export `SHELL`, crashing the whole OpenComputers subsystem on boot and blocking the test suite.

`config/runtime.exs` runs before the app tree (and `:exec`) start, so it defaults `SHELL` to a real shell when unset/empty. Verified: `env -u SHELL mix test` now boots (was crashing at `:exec_app.start` with `port_exited_with_status, 4`).

+11 lines, config/runtime.exs only.