### PR TITLE
test: make two host-dependent tests deterministic

### DIFF
--- a/test/agent/context/eviction_test.exs
+++ b/test/agent/context/eviction_test.exs
@@ -110,6 +110,15 @@ defmodule OptimalSystemAgent.Agent.Context.EvictionTest do
   end
 
   test "a session with room evicts nothing" do
+    # Isolate from the host's installed skills catalog: the recall block is
+    # hard-capped, so a large real catalog truncates (an eviction) regardless of
+    # window room, making this host-dependent. Empty the registry for a
+    # deterministic check; on_exit restores it.
+    skills_key = {OptimalSystemAgent.Tools.Registry, :skills}
+    prev_skills = :persistent_term.get(skills_key, %{})
+    :persistent_term.put(skills_key, %{})
+    on_exit(fn -> :persistent_term.put(skills_key, prev_skills) end)
+
     roomy = %{
       session_id: "evict-roomy-#{:erlang.unique_integer([:positive])}",
       channel: :cli,

--- a/test/channels/cli/cli_setup_test.exs
+++ b/test/channels/cli/cli_setup_test.exs
@@ -22,6 +22,11 @@ defmodule OptimalSystemAgent.CLI.SetupTest do
   setup do
     original = if File.exists?(@env_path), do: File.read!(@env_path), else: nil
 
+    # Start each test from a clean slate so write_config/* assertions don't
+    # accumulate onto the developer's real ~/.osa/.env (leaks provider keys and
+    # OSA_MODEL); on_exit restores the original below.
+    File.rm(@env_path)
+
     on_exit(fn ->
       case original do
         nil -> File.rm(@env_path)


### PR DESCRIPTION
Two tests pass on clean CI but fail on a developer machine with real config / installed skills:

- `cli_setup_test`: `setup` backed up + restored `~/.osa/.env` but never cleared it, so `write_config/*` accumulated onto the developer's real provider keys and `OSA_MODEL` (the `refute` cases then failed). Now starts each test from a clean slate; `on_exit` still restores the original.
- `eviction_test` "a session with room evicts nothing": reads the host's installed skills catalog via `active_skills_context`; the recall block is hard-capped at `memory_context_token_cap` (1200), so a large real catalog truncates (recorded as an eviction) regardless of window room. Now isolates the skills `persistent_term` to an empty map for a deterministic check.

Verified: the two files go 3 failures -> 0 on a skills/config-heavy machine (26 tests, 0 failures); unchanged on clean CI.