### PR TITLE
feat: harden runtime intelligence and TUI visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -968,9 +968,18 @@ hot-reloads on file change. Recurring behavior patterns (occurrence ≥ 5) are
 auto-promoted to skills by the SICA engine.
 
 OSA keeps the catalog compact and loads a full `SKILL.md` only after the agent selects it with `skill_view`.
-Selected skill names are checkpointed with the session and re-injected on every generation, so compaction or a backend restart cannot make a long-running agent forget the workflow it chose.
+Before complex work, a metadata-only advisor ranks likely skills for the current request without loading the library's instruction bodies into context.
+Its short-lived cache is invalidated by metadata changes, and telemetry reports ranking time, cache hits, candidate counts, selected body size, and the bytes added back to context.
+Selected skill names, content hashes, and selection times are checkpointed with the session and re-injected on every generation, so compaction or a backend restart cannot make a long-running agent forget the workflow it chose or silently adopt changed instructions.
 When a selected skill body is no longer present in conversation context, OSA requires the agent to reload it with `skill_view` before taking another task action.
+The TUI shows active selections as `Using: diagnose` and restores that row when its session stream reconnects.
 Deleting the session removes that checkpoint.
+
+Long-running tools emit lightweight heartbeat frames so the TUI can distinguish useful work from a disconnected backend and surface a stalled-call recovery hint without killing legitimate builds.
+`GET /api/v1/sessions/:id/health` reports whether a session is live, healthy, degraded, recoverable, or missing, including transcript, durable-event, and selected-skill diagnostics plus the appropriate recovery action, and the TUI checks it after reconnecting.
+Provider reasoning state is normalized into a stable on/off signal for the TUI, while the configured effort tier remains visible separately.
+OpenRouter model identifiers reuse the matching vendor's native catalog context, tool-call, vision, and reasoning capability metadata, so routing decisions do not degrade merely because a model is addressed through the gateway.
+Fallback routing skips a provider when its selected model is authoritatively known to lack tools required by the active turn.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ and points you at the from-source script below.
 ✓ Warm background backend       ✓ Cross-session memory + learning
 ✓ Full chat TUI                 ✓ 82 built-in tools, deferred-loaded
 ✓ 27 providers + fallback       ✓ Nothing leaves your machine unless you say so
+✓ Proactive skill discovery     ✓ Durable goals, queues, and recovery
 ```
 
 <details>
@@ -130,7 +131,7 @@ you.
 you type a message
    │  HTTP POST → 127.0.0.1:9089
    ▼
-engine classifies the signal, builds context, picks a model tier
+engine classifies the signal, ranks relevant skills, builds context, picks a model tier
    │
    ▼
 ReAct loop:  think → call a tool → observe → repeat
@@ -142,7 +143,9 @@ tokens, tool results, and diffs stream back over SSE (live) into the TUI
 
 Everything the agent produces (reasoning, tool calls, file diffs, sub-agent
 activity) is streamed as it happens, so the TUI always mirrors the engine's
-real state. For the full pipeline (compaction, fallback chains, hooks,
+real state. Skill use, goal state, tool stalls, context occupancy, normalized
+reasoning state, and reconnect health remain visible without widening the
+terminal. For the full pipeline (compaction, fallback chains, hooks,
 guardrails) see [Architecture](#architecture) below.
 
 ---
@@ -276,8 +279,10 @@ both, so everything above is reachable from the same prompt.
 ### Reading model performance
 
 The permanent footer stays deliberately small so it remains stable while the terminal resizes.
-It shows the active model, current context occupancy, and a reasoning-effort chip only when the effort differs from the default `medium` tier.
+It shows the active model, current context occupancy, normalized reasoning state, and a reasoning-effort chip only when the effort differs from the default `medium` tier.
 Running `/fast`, for example, makes `effort:fast` appear immediately.
+Active skills use a separate `Using:` row, with a `+N` count when more selections are active than fit comfortably.
+That row is cleared and rebuilt from the attached session after reconnecting, so it never leaks labels from another conversation.
 
 The activity row reports what matters during a turn: elapsed time, current output flow, thinking state, retries, stalls, and the interrupt control.
 It does not repeat the latest request's input-token count because that number is the full prompt sent to the model, not cumulative session usage, and duplicating it beside the context meter is misleading.
@@ -409,6 +414,10 @@ Stop or interrupt any agent from the same view. Cancelling an agent cascades
 transitively to every sub-agent it spawned; a sibling can hand its context to
 another via peer-resume, and worktree work is snapshotted to a durable git ref
 before teardown so it stays inspectable even when discarded.
+Parent agents and sub-agents independently rank the compact skill catalog for
+their own task, then load only the selected `SKILL.md` body through `skill_view`.
+Each selection is checkpointed against that session, so one agent's workflow
+does not bleed into another agent's context.
 
 ### Plan mode, goal tracking, and rewind
 
@@ -700,7 +709,11 @@ same thing at launch. Retired model ids are tracked and rejected up front rather
 than 404-ing mid-turn.
 
 When a call rate-limits or fails, OSA walks a configurable fallback chain and
-reconnects mid-stream, the turn keeps going.
+reconnects mid-stream, so the turn keeps going.
+OpenRouter model identifiers inherit context, reasoning, vision, and tool-call
+capabilities from the matching vendor-scoped native catalog entry.
+When tools are required, fallback routing skips models authoritatively known not
+to support tool calls instead of sending a turn that cannot complete.
 
 ### Autonomous Task Orchestration
 
@@ -808,7 +821,7 @@ until needed, discoverable via `tool_search`):
 | **Agents** | `delegate`, `fleet`, `orchestrate`, `create_agent`, `list_agents`, `send_message`, `message_agent`, `team_create`, `team_delete`, `team_tasks`, `task_write`, `task_output`, `task_stop`, `task_wait`, `task_resume`, `spawn_conversation` |
 | **Multi-agent** | `mixture_of_agents`, `peer_review`, `peer_negotiate_task`, `peer_claim_region`, `cross_team_query` |
 | **Plan / worktree** | `enter_plan_mode`, `exit_plan_mode`, `enter_worktree`, `exit_worktree`, `rollback`, `verify_loop`, `start_speculative` |
-| **Skills** | `create_skill`, `save_skill`, `use_skill`, `find_skill`, `list_skills`, `skill_manager`, `use_tool` |
+| **Skills** | `skill_view`, `create_skill`, `save_skill`, `use_skill`, `find_skill`, `list_skills`, `skill_manager`, `use_tool` |
 | **Reporting** | `brief`, `progress_note`, `monitor`, `push_notification`, `send_user_file`, `subscribe_pr`, `remote_trigger` |
 | **Config / meta** | `config`, `cron`, `sleep`, `tool_search`, `budget_status`, `ask_user` |
 
@@ -831,7 +844,7 @@ one.
 | Long-term | SQLite + ETS | Relevance scoring: keyword match + signal weight + recency |
 | Episodic | ETS | Per-session event tracking, capped at 1000 events |
 | Vault | SQLite | Structured, typed memory with fact extraction and injection |
-| Skills | File system | Patterns with occurrence ≥ 5 auto-generate skill files (SICA) |
+| Skills | File system + session checkpoint | Patterns with occurrence ≥ 5 auto-generate skill files (SICA); active selections retain their name, body hash, and selection time |
 
 **SICA learning cycle:** See → Introspect → Capture → Adapt. OSA observes what
 works across sessions and converts recurring patterns into reusable skills
@@ -878,7 +891,7 @@ interact with any GUI application.
 
 | Channel | Notes |
 |---|---|
-| **Rust TUI** | Primary terminal UI: onboarding wizard, model picker, sessions, command palette, agent tree, `!` shell, `@` mentions with frecency ranking + ghost-text, LaTeX/table rendering, desktop notifications, and a fixed-height streaming viewport |
+| **Rust TUI** | Primary terminal UI: onboarding wizard, model picker, sessions, command palette, agent tree, skill and goal rows, normalized reasoning/effort state, tool-stall and recovery notices, `!` shell, `@` mentions with frecency ranking + ghost-text, LaTeX/table rendering, desktop notifications, and a fixed-height streaming viewport |
 | **Elixir CLI** | REPL: streaming, task display, diff view, Ctrl+R search, multi-line input |
 | **HTTP/SSE API** | Port 9089, JWT auth, 20+ route modules, real-time SSE streaming |
 | **Telegram** | Long-polling, typing indicators, markdown conversion |
@@ -933,6 +946,8 @@ with ultra effort"*).
 Higher effort means more visible thinking in the indicator; `ultra` additionally
 enables the fan-out dynamic-workflow orchestration described in
 [Agent Fleet & Dynamic Workflows](#agent-fleet--dynamic-workflows).
+The footer keeps effort and provider-normalized reasoning as separate signals,
+and refreshes both after `/reasoning`, `/effort`, `/fast`, or a model switch.
 
 ### Scheduler
 
@@ -1176,6 +1191,8 @@ Tables, code fences, the composer, thinking output, activity, goals, and status 
 The status footer uses progressive disclosure at narrow widths.
 The context label survives first, its decorative meter shortens when necessary, and optional effort, MCP, and version chips render only when each complete chip fits.
 Active goals use their own row so their description and controls do not compete with model and context information.
+Active skills also use their own row, collapse excess selections into `+N`, and replay from the current session after SSE reconnect.
+Tool heartbeats and session-health recovery notices appear in transient activity or notification surfaces rather than expanding the permanent footer.
 
 `test/pty/test_resize.py` exercises the release binary through a real pseudo-terminal, while `test/pty/vte_content_reflow.py` covers the libvte behavior used by GNOME Terminal and Tilix.
 

--- a/lib/optimal_system_agent/agent/active_skills.ex
+++ b/lib/optimal_system_agent/agent/active_skills.ex
@@ -3,9 +3,10 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
   Durable record of the skills selected by an agent for a session.
 
   Skill bodies are loaded progressively and remain outside the permanent system
-  prompt. This store records only their names. The context builder rehydrates
-  those names on every generation, so compaction cannot make the agent forget
-  which operating instructions it deliberately selected.
+  prompt. This store records their names plus a content hash and selection time.
+  The context builder rehydrates that identity on every generation, so
+  compaction cannot make the agent forget which operating instructions it
+  selected and a changed SKILL.md cannot silently replace the selected version.
   """
 
   require Logger
@@ -21,24 +22,35 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
   def select(session_id, skill_name)
       when is_binary(session_id) and session_id != "" and is_binary(skill_name) and
              skill_name != "" do
-    mutate(session_id, fn names ->
-      names
-      |> Enum.reject(&(&1 == skill_name))
-      |> Kernel.++([skill_name])
-      |> Enum.take(-@max_skills)
-    end)
+    with {:ok, snapshot} <- snapshot(skill_name) do
+      mutate(session_id, fn snapshots ->
+        snapshots
+        |> Enum.reject(&(&1.name == skill_name))
+        |> Kernel.++([snapshot])
+        |> Enum.take(-@max_skills)
+      end)
+    end
   end
 
   @spec list(String.t()) :: [String.t()]
   def list(session_id) when is_binary(session_id) do
-    case load(session_id) do
-      {:ok, names} -> names
+    case snapshots(session_id) do
+      {:ok, entries} -> Enum.map(entries, & &1.name)
       {:error, _reason} -> []
     end
   end
 
   @spec load(String.t()) :: {:ok, [String.t()]} | {:error, term()}
   def load(session_id) when is_binary(session_id) do
+    case snapshots(session_id) do
+      {:ok, entries} -> {:ok, Enum.map(entries, & &1.name)}
+      error -> error
+    end
+  end
+
+  @doc "Load the durable name/hash/version snapshots for a session."
+  @spec snapshots(String.t()) :: {:ok, [map()]} | {:error, term()}
+  def snapshots(session_id) when is_binary(session_id) do
     case File.read(path(session_id)) do
       {:ok, bytes} -> decode(bytes)
       {:error, :enoent} -> {:ok, []}
@@ -54,28 +66,46 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
 
   @spec context_block(String.t(), [map()]) :: String.t() | nil
   def context_block(session_id, messages \\ []) when is_binary(session_id) do
-    case load(session_id) do
+    case snapshots(session_id) do
       {:ok, []} ->
         nil
 
-      {:ok, names} ->
-        missing = Enum.reject(names, &body_present?(messages, &1))
+      {:ok, entries} ->
+        names = Enum.map(entries, & &1.name)
+        changed = Enum.filter(entries, &changed?/1)
+        missing = Enum.reject(entries, &body_present?(messages, &1.name))
 
         reload =
-          case missing do
-            [] ->
+          cond do
+            changed != [] ->
+              versions = Enum.map_join(changed, ", ", &"`#{&1.name}`")
+
+              "The installed body changed since selection for #{versions}. " <>
+                "Before any further task action, reload " <>
+                Enum.map_join(changed, ", ", &"`skill_view` for `#{&1.name}`") <> "."
+
+            missing == [] ->
               "Their instruction bodies are present in the current conversation."
 
-            _ ->
-              calls = Enum.map_join(missing, ", ", &"`skill_view` for `#{&1}`")
+            true ->
+              calls = Enum.map_join(missing, ", ", &"`skill_view` for `#{&1.name}`")
 
               "Their instruction bodies are absent, likely because of compaction or restart. " <>
                 "Before any further task action, reload #{calls}."
           end
 
-        "## Selected Skills\n\n" <>
-          "These skills remain active for this task across compaction and restart. " <>
-          reload <> "\n\n" <> Enum.map_join(names, "\n", &"- **#{&1}**")
+        block =
+          "## Selected Skills\n\n" <>
+            "These skills remain active for this task across compaction and restart. " <>
+            reload <> "\n\n" <> Enum.map_join(names, "\n", &"- **#{&1}**")
+
+        :telemetry.execute(
+          [:osa, :skills, :context],
+          %{count: length(entries), bytes: byte_size(block)},
+          %{session_id: session_id, reload_required: missing != [] or changed != []}
+        )
+
+        block
 
       {:error, reason} ->
         Logger.error("[active_skills] checkpoint unavailable: #{inspect(reason)}")
@@ -90,8 +120,8 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
     record_path = path(session_id)
 
     case RecordLock.with_lock_strict(record_path, fn ->
-           names =
-             case load(session_id) do
+           snapshots =
+             case snapshots(session_id) do
                {:ok, loaded} ->
                  loaded
 
@@ -104,7 +134,7 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
                  []
              end
 
-           AtomicFile.write(record_path, Jason.encode!(%{version: 1, skills: fun.(names)}))
+           AtomicFile.write(record_path, Jason.encode!(%{version: 2, skills: fun.(snapshots)}))
          end) do
       {:ok, result} -> result
       {:error, :contended} -> {:error, :contended}
@@ -113,11 +143,12 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
 
   defp decode(bytes) do
     case Jason.decode(bytes) do
-      {:ok, %{"skills" => names}} when is_list(names) ->
+      {:ok, %{"skills" => entries}} when is_list(entries) ->
         {:ok,
-         names
-         |> Enum.filter(&(is_binary(&1) and &1 != ""))
-         |> Enum.uniq()
+         entries
+         |> Enum.map(&decode_entry/1)
+         |> Enum.reject(&is_nil/1)
+         |> Enum.uniq_by(& &1.name)
          |> Enum.take(-@max_skills)}
 
       {:ok, invalid} ->
@@ -127,6 +158,42 @@ defmodule OptimalSystemAgent.Agent.ActiveSkills do
         {:error, {:invalid_json, Exception.message(reason)}}
     end
   end
+
+  defp decode_entry(name) when is_binary(name) and name != "",
+    do: %{name: name, hash: nil, selected_at: nil}
+
+  defp decode_entry(%{"name" => name} = entry) when is_binary(name) and name != "" do
+    %{name: name, hash: entry["hash"], selected_at: entry["selected_at"]}
+  end
+
+  defp decode_entry(_), do: nil
+
+  defp snapshot(skill_name) do
+    case Registry.load_skill_body(skill_name) do
+      {:ok, body} ->
+        {:ok,
+         %{
+           name: skill_name,
+           hash: body_hash(body),
+           selected_at: DateTime.utc_now() |> DateTime.to_iso8601()
+         }}
+
+      {:error, reason} ->
+        {:error, {:skill_body_unavailable, skill_name, reason}}
+    end
+  end
+
+  defp changed?(%{hash: nil}), do: false
+
+  defp changed?(%{name: name, hash: expected}) do
+    case Registry.load_skill_body(name) do
+      {:ok, body} -> body_hash(body) != expected
+      _ -> true
+    end
+  end
+
+  defp body_hash(body),
+    do: :crypto.hash(:sha256, String.trim(body)) |> Base.encode16(case: :lower)
 
   defp body_present?(messages, skill_name) do
     with {:ok, body} <- Registry.load_skill_body(skill_name) do

--- a/lib/optimal_system_agent/agent/loop/tool_executor.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_executor.ex
@@ -193,7 +193,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
         prefix_blocked(message)
 
       :allow ->
-        run_tool(tool_call, state)
+        run_with_heartbeat(tool_call, state)
 
       {:ask, request_id, summary} ->
         # DEFAULT 'ask' mode: park the executing process, emit a
@@ -206,10 +206,20 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
         # route (Codex funnels approval rejections through the same
         # RespondToModel channel).
         case await_permission(tool_call, state, request_id, summary) do
-          :allow -> run_tool(tool_call, state)
+          :allow -> run_with_heartbeat(tool_call, state)
           {:blocked, message} -> message
           {:steer, text} -> text
         end
+    end
+  end
+
+  defp run_with_heartbeat(tool_call, state) do
+    heartbeat = OptimalSystemAgent.Agent.Loop.ToolHeartbeat.start(tool_call, state)
+
+    try do
+      run_tool(tool_call, state)
+    after
+      OptimalSystemAgent.Agent.Loop.ToolHeartbeat.stop(heartbeat)
     end
   end
 

--- a/lib/optimal_system_agent/agent/loop/tool_heartbeat.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_heartbeat.ex
@@ -1,0 +1,93 @@
+defmodule OptimalSystemAgent.Agent.Loop.ToolHeartbeat do
+  @moduledoc """
+  Emits liveness frames for a running tool without changing its timeout policy.
+
+  Heartbeats let the TUI distinguish a long-running call from a dead backend.
+  The first frame at the stall threshold is marked `stalled`, but OSA does not
+  kill the tool because many builds and remote operations are legitimately long.
+  """
+
+  require Logger
+
+  @interval_ms 10_000
+  @stalled_ms 30_000
+
+  @spec start(map(), map()) :: pid()
+  def start(tool_call, state), do: start(tool_call, state, [])
+
+  @doc false
+  @spec start(map(), map(), keyword()) :: pid()
+  def start(tool_call, state, opts) do
+    owner = self()
+    started = System.monotonic_time(:millisecond)
+    interval_ms = Keyword.get(opts, :interval_ms, @interval_ms)
+    stalled_ms = Keyword.get(opts, :stalled_ms, @stalled_ms)
+
+    spawn(fn ->
+      ref = Process.monitor(owner)
+      loop(ref, owner, tool_call, state, started, false, interval_ms, stalled_ms)
+    end)
+  end
+
+  @spec stop(pid() | nil) :: :ok
+  def stop(pid) when is_pid(pid) do
+    send(pid, :stop)
+    :ok
+  end
+
+  def stop(_), do: :ok
+
+  defp loop(ref, owner, tool_call, state, started, stalled_sent, interval_ms, stalled_ms) do
+    receive do
+      :stop ->
+        Process.demonitor(ref, [:flush])
+        :ok
+
+      {:DOWN, ^ref, :process, ^owner, _reason} ->
+        :ok
+    after
+      interval_ms ->
+        elapsed_ms = System.monotonic_time(:millisecond) - started
+        stalled = elapsed_ms >= stalled_ms
+        emit(tool_call, state, elapsed_ms, stalled and not stalled_sent)
+
+        loop(
+          ref,
+          owner,
+          tool_call,
+          state,
+          started,
+          stalled_sent or stalled,
+          interval_ms,
+          stalled_ms
+        )
+    end
+  end
+
+  defp emit(tool_call, state, elapsed_ms, stalled) do
+    payload = %{
+      type: :tool_heartbeat,
+      name: tool_call.name,
+      tool_call_id: tool_call.id,
+      elapsed_ms: elapsed_ms,
+      stalled: stalled,
+      session_id: state.session_id
+    }
+
+    Phoenix.PubSub.broadcast(
+      OptimalSystemAgent.PubSub,
+      "osa:session:#{state.session_id}",
+      {:osa_event, payload}
+    )
+
+    :telemetry.execute(
+      [:osa, :tools, :heartbeat],
+      %{count: 1, elapsed_ms: elapsed_ms, stalled: if(stalled, do: 1, else: 0)},
+      %{tool: tool_call.name, session_id: state.session_id}
+    )
+  rescue
+    error ->
+      Logger.error("[tool_heartbeat] emit failed: #{Exception.message(error)}")
+      :ok
+  end
+end

--- a/lib/optimal_system_agent/agent/session_health.ex
+++ b/lib/optimal_system_agent/agent/session_health.ex
@@ -1,0 +1,94 @@
+defmodule OptimalSystemAgent.Agent.SessionHealth do
+  @moduledoc """
+  Read-only diagnostics for deciding whether a session is live, restorable, or degraded.
+
+  Every field is independently derived so one damaged sidecar does not hide the
+  rest of the recovery picture.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.Agent.{ActiveSkills, SessionPersistence}
+  alias OptimalSystemAgent.Runtime.SessionManager
+
+  @spec snapshot(String.t()) :: map()
+  def snapshot(session_id) when is_binary(session_id) do
+    live = SessionManager.session_exists?(session_id)
+    persistence = persistence_status(session_id)
+    skills = skills_status(session_id)
+    events = safe(fn -> SessionPersistence.event_count(session_id) end, 0)
+
+    status =
+      cond do
+        live and persistence.status in [:ok, :absent] and skills.status == :ok -> :healthy
+        live -> :degraded
+        persistence.restorable -> :recoverable
+        true -> :missing
+      end
+
+    %{
+      session_id: session_id,
+      status: status,
+      live: live,
+      persistence: persistence,
+      active_skills: skills,
+      durable_events: events,
+      recovery_action: recovery_action(status)
+    }
+  end
+
+  defp persistence_status(session_id) do
+    exists = SessionPersistence.exists?(session_id)
+
+    case SessionPersistence.load(session_id) do
+      {:ok, messages} ->
+        %{status: :ok, exists: exists, restorable: true, message_count: length(messages)}
+
+      {:error, reason} ->
+        if reason == :not_found do
+          %{status: :absent, exists: exists, restorable: false, message_count: 0}
+        else
+          %{status: :error, exists: exists, restorable: false, error: bounded(reason)}
+        end
+    end
+  rescue
+    error -> %{status: :error, exists: false, restorable: false, error: bounded(error)}
+  catch
+    :exit, reason -> %{status: :error, exists: false, restorable: false, error: bounded(reason)}
+  end
+
+  defp skills_status(session_id) do
+    case ActiveSkills.snapshots(session_id) do
+      {:ok, entries} ->
+        %{
+          status: :ok,
+          count: length(entries),
+          names: Enum.map(entries, & &1.name),
+          versioned: Enum.count(entries, &is_binary(&1.hash))
+        }
+
+      {:error, reason} ->
+        %{status: :error, count: 0, names: [], versioned: 0, error: bounded(reason)}
+    end
+  end
+
+  defp recovery_action(:healthy), do: "none"
+  defp recovery_action(:recoverable), do: "resume_session"
+  defp recovery_action(:degraded), do: "inspect_sidecars"
+  defp recovery_action(:missing), do: "start_new_session"
+
+  defp safe(fun, fallback) do
+    fun.()
+  rescue
+    error ->
+      Logger.error("[session_health] diagnostic failed: #{Exception.message(error)}")
+      fallback
+  catch
+    kind, reason ->
+      Logger.error("[session_health] diagnostic #{kind}: #{inspect(reason)}")
+      fallback
+  end
+
+  defp bounded(reason),
+    do: reason |> inspect(limit: 5, printable_limit: 160) |> String.slice(0, 200)
+end

--- a/lib/optimal_system_agent/channels/http.ex
+++ b/lib/optimal_system_agent/channels/http.ex
@@ -148,6 +148,18 @@ defmodule OptimalSystemAgent.Channels.HTTP do
         :exit, _ -> "medium"
       end
 
+    reasoning =
+      try do
+        OptimalSystemAgent.Observability.current_reasoning(%{
+          provider: provider_atom,
+          model: model_name
+        })
+      rescue
+        _ -> nil
+      catch
+        :exit, _ -> nil
+      end
+
     # Billing / budget snapshot. OSA has no subscription/plan concept in code,
     # so `subscription` is always nil — the only spend model is the local
     # Budget GenServer (daily/monthly USD spend + limits). Returns nil entirely
@@ -163,6 +175,7 @@ defmodule OptimalSystemAgent.Channels.HTTP do
         model: model_name,
         context_window: context_window,
         effort: effort,
+        reasoning: reasoning,
         # TUI presentation config from ~/.osa/config.toml [tui] (theme/verbosity).
         # This is the backend config surface the TUI reads at startup; the getters
         # fall back to the documented defaults ("dark" / "normal") when unset.

--- a/lib/optimal_system_agent/channels/http/api/agent_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/agent_routes.ex
@@ -10,6 +10,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AgentRoutes do
   """
   use Plug.Router
   import OptimalSystemAgent.Channels.HTTP.API.Shared
+  alias OptimalSystemAgent.Agent.ActiveSkills
   alias OptimalSystemAgent.Channels.HTTP.SessionAccess
   alias OptimalSystemAgent.Runtime.SessionManager
   require Logger
@@ -76,11 +77,19 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AgentRoutes do
         {:ok, conn} =
           chunk(conn, "event: connected\ndata: {\"session_id\": \"#{session_id}\"}\n\n")
 
+        replay_active_skills(session_id)
+
         sse_loop(conn, session_id)
 
       {:error, :not_found} ->
         json_error(conn, 404, "not_found", "Session not found")
     end
+  end
+
+  defp replay_active_skills(session_id) do
+    Enum.each(ActiveSkills.list(session_id), fn skill ->
+      send(self(), {:osa_event, %{type: :skill_selected, skill: skill}})
+    end)
   end
 
   match _ do

--- a/lib/optimal_system_agent/channels/http/api/session_routes.ex
+++ b/lib/optimal_system_agent/channels/http/api/session_routes.ex
@@ -345,6 +345,11 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.SessionRoutes do
 
   # ── GET /sessions/:id ──────────────────────────────────────────────
 
+  get "/:id/health" do
+    session_id = conn.params["id"]
+    json(conn, 200, OptimalSystemAgent.Agent.SessionHealth.snapshot(session_id))
+  end
+
   get "/:id" do
     session_id = conn.params["id"]
 
@@ -546,6 +551,8 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.SessionRoutes do
         {:ok, conn} =
           chunk(conn, "event: connected\ndata: {\"session_id\": \"#{session_id}\"}\n\n")
 
+        replay_active_skills(session_id)
+
         Logger.debug("[SSE] /sessions/#{session_id}/stream opened by #{user_id}")
 
         session_sse_loop(conn, session_id)
@@ -553,6 +560,12 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.SessionRoutes do
       {:error, :not_found} ->
         json_error(conn, 404, "not_found", "Session not found")
     end
+  end
+
+  defp replay_active_skills(session_id) do
+    Enum.each(OptimalSystemAgent.Agent.ActiveSkills.list(session_id), fn skill ->
+      send(self(), {:osa_event, %{type: :skill_selected, skill: skill}})
+    end)
   end
 
   # ── DELETE /sessions/:id ───────────────────────────────────────────

--- a/lib/optimal_system_agent/protocol/tui_schema.ex
+++ b/lib/optimal_system_agent/protocol/tui_schema.ex
@@ -82,6 +82,11 @@ defmodule OptimalSystemAgent.Protocol.TUISchema do
             doc:
               "Current reasoning effort: \"fast\" | \"medium\" | \"high\" | \"xhigh\" | \"ultra\".\n`Option` + `default` keep older backends (which omit it) decodable."
           ),
+          f("reasoning", {:option, :string},
+            default: true,
+            doc:
+              "Provider-normalized effective reasoning state, including the rule that selected it.\nExamples: `on:catalog:high`, `off:model_unsupported`, `on:config`."
+          ),
           f("billing", {:option, {:struct, "HealthBilling"}},
             default: true,
             doc:

--- a/lib/optimal_system_agent/providers/fallback_chain.ex
+++ b/lib/optimal_system_agent/providers/fallback_chain.ex
@@ -16,7 +16,7 @@ defmodule OptimalSystemAgent.Providers.FallbackChain do
   require Logger
 
   alias OptimalSystemAgent.Providers.Registry, as: Providers
-  alias OptimalSystemAgent.Providers.{ErrorCatalog, Resilience, RetryClassifier}
+  alias OptimalSystemAgent.Providers.{ErrorCatalog, ModelLimits, Resilience, RetryClassifier}
   alias OptimalSystemAgent.Events.Bus
 
   @default_chain [:anthropic, :openai, :groq, :ollama]
@@ -218,7 +218,18 @@ defmodule OptimalSystemAgent.Providers.FallbackChain do
   defp try_providers([provider | rest], messages, opts, errors) do
     opts_with_provider = Keyword.put(hop_opts(opts, errors), :provider, provider)
 
-    case Providers.chat(messages, opts_with_provider) do
+    result =
+      if capability_compatible?(provider, opts_with_provider) do
+        Providers.chat(messages, opts_with_provider)
+      else
+        :capability_mismatch
+      end
+
+    case result do
+      :capability_mismatch ->
+        Logger.warning("[fallback] #{provider} skipped: selected model lacks required tools")
+        try_providers(rest, messages, opts, errors ++ [{provider, :capability_mismatch}])
+
       {:ok, result} ->
         if errors != [] do
           Logger.info("[fallback] Succeeded with #{provider} after #{length(errors)} failure(s)")
@@ -249,15 +260,33 @@ defmodule OptimalSystemAgent.Providers.FallbackChain do
   defp try_stream_providers([provider | rest], messages, callback, opts, errors) do
     opts_with_provider = Keyword.put(hop_opts(opts, errors), :provider, provider)
 
-    case Providers.chat_stream(messages, callback, opts_with_provider) do
-      {:ok, result} ->
+    result =
+      if capability_compatible?(provider, opts_with_provider) do
+        Providers.chat_stream(messages, callback, opts_with_provider)
+      else
+        :capability_mismatch
+      end
+
+    case result do
+      :capability_mismatch ->
+        Logger.warning("[fallback] #{provider} skipped: selected model lacks required tools")
+
+        try_stream_providers(
+          rest,
+          messages,
+          callback,
+          opts,
+          errors ++ [{provider, :capability_mismatch}]
+        )
+
+      :ok ->
         if errors != [] do
           Logger.info(
             "[fallback] Stream succeeded with #{provider} after #{length(errors)} failure(s)"
           )
         end
 
-        {:ok, result, provider}
+        {:ok, :stream_started, provider}
 
       {:error, reason} ->
         if retryable_error?(reason) do
@@ -280,6 +309,24 @@ defmodule OptimalSystemAgent.Providers.FallbackChain do
         opts,
         errors ++ [{provider, Exception.message(e)}]
       )
+  end
+
+  @doc false
+  def capability_compatible?(provider, opts) do
+    tools_required? = Keyword.get(opts, :tools, []) != []
+
+    if tools_required? do
+      model =
+        Keyword.get(opts, :model) ||
+          case Providers.provider_info(provider) do
+            {:ok, info} -> info.default_model
+            _ -> nil
+          end
+
+      not (is_binary(model) and ModelLimits.tool_call(provider, model) == false)
+    else
+      true
+    end
   end
 
   @doc """

--- a/lib/optimal_system_agent/providers/model_limits.ex
+++ b/lib/optimal_system_agent/providers/model_limits.ex
@@ -173,7 +173,22 @@ defmodule OptimalSystemAgent.Providers.ModelLimits do
   defp find_model(provider, model) do
     safe(fn -> Catalog.model(to_string(provider), model) end) ||
       safe(fn -> Catalog.find(model) end) ||
+      safe(fn -> find_gateway_model(model) end) ||
       safe(fn -> Catalog.find(strip_tag(model)) end)
+  end
+
+  # OpenRouter names models as `vendor/model`. models.dev stores the native
+  # model id under that vendor, so an exact gateway id lookup often misses even
+  # though the capability is known. Preserve both halves and perform a scoped
+  # vendor lookup so equal native ids from different vendors cannot collide.
+  defp find_gateway_model(model) do
+    case String.split(model, "/", parts: 2) do
+      [vendor, native_id] when vendor != "" and native_id != "" ->
+        Catalog.model(vendor, native_id)
+
+      _ ->
+        nil
+    end
   end
 
   defp strip_tag(model) do

--- a/lib/optimal_system_agent/skills/advisor.ex
+++ b/lib/optimal_system_agent/skills/advisor.ex
@@ -1,0 +1,133 @@
+defmodule OptimalSystemAgent.Skills.Advisor do
+  @moduledoc """
+  Bounded, cached skill recommendations for the current task.
+
+  The advisor ranks metadata only. It never loads a SKILL.md body into model
+  context. The model still activates a recommendation explicitly through
+  `skill_view`, preserving progressive disclosure as the library grows.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.Skills.Ranker
+
+  @table :osa_skill_advisor_cache
+  @ttl_ms 5 * 60 * 1_000
+
+  @spec recommend([map()], String.t(), keyword()) :: [map()]
+  def recommend(skills, query, opts \\ [])
+
+  def recommend(skills, query, opts) when is_list(skills) and is_binary(query) do
+    limit = Keyword.get(opts, :limit, 5)
+    started = System.monotonic_time(:microsecond)
+    ensure_table()
+    sweep_expired()
+    key = cache_key(skills, query, limit)
+
+    {recommendations, cache_hit} =
+      case :ets.lookup(@table, key) do
+        [{^key, inserted_at, cached}] when is_integer(inserted_at) ->
+          if System.monotonic_time(:millisecond) - inserted_at <= @ttl_ms do
+            {cached, true}
+          else
+            :ets.delete(@table, key)
+            {rank(skills, query, limit), false}
+          end
+
+        _ ->
+          {rank(skills, query, limit), false}
+      end
+
+    unless cache_hit do
+      :ets.insert(@table, {key, System.monotonic_time(:millisecond), recommendations})
+    end
+
+    :telemetry.execute(
+      [:osa, :skills, :recommend],
+      %{
+        duration_us: System.monotonic_time(:microsecond) - started,
+        candidates: length(skills),
+        recommendations: length(recommendations),
+        cache_hit: if(cache_hit, do: 1, else: 0)
+      },
+      %{query_bytes: byte_size(query)}
+    )
+
+    recommendations
+  rescue
+    error ->
+      Logger.error("[skills.advisor] recommendation failed: #{Exception.message(error)}")
+      []
+  end
+
+  def recommend(_skills, _query, _opts), do: []
+
+  @spec clear_cache() :: :ok
+  def clear_cache do
+    if :ets.whereis(@table) != :undefined, do: :ets.delete_all_objects(@table)
+    :ok
+  end
+
+  defp rank(skills, query, limit) do
+    skills
+    |> Enum.map(fn skill ->
+      text =
+        [
+          value(skill, :name),
+          value(skill, :description),
+          value(skill, :triggers) |> List.wrap() |> Enum.join(" ")
+        ]
+        |> Enum.join(" ")
+
+      score = Ranker.relevance(text, query) + trigger_bonus(skill, query)
+      %{skill: skill, score: score, confidence: confidence(score)}
+    end)
+    |> Enum.filter(&(&1.score > 0.0))
+    |> Enum.sort_by(& &1.score, :desc)
+    |> Enum.take(limit)
+  end
+
+  defp trigger_bonus(skill, query) do
+    lower = String.downcase(query)
+
+    skill
+    |> value(:triggers)
+    |> List.wrap()
+    |> Enum.any?(fn trigger ->
+      trigger = trigger |> to_string() |> String.downcase()
+      trigger not in ["", "*"] and String.contains?(lower, trigger)
+    end)
+    |> if(do: 3.0, else: 0.0)
+  end
+
+  defp confidence(score) when score >= 5.0, do: :high
+  defp confidence(score) when score >= 2.0, do: :medium
+  defp confidence(_score), do: :low
+
+  defp cache_key(skills, query, limit) do
+    fingerprint =
+      Enum.map(skills, fn skill ->
+        {value(skill, :name), value(skill, :description), value(skill, :triggers)}
+      end)
+
+    :erlang.phash2({fingerprint, String.downcase(String.trim(query)), limit})
+  end
+
+  defp value(skill, key) when is_map(skill),
+    do: Map.get(skill, key) || Map.get(skill, to_string(key))
+
+  defp ensure_table do
+    if :ets.whereis(@table) == :undefined do
+      try do
+        :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+      rescue
+        ArgumentError -> @table
+      end
+    end
+  end
+
+  defp sweep_expired do
+    cutoff = System.monotonic_time(:millisecond) - @ttl_ms
+    :ets.select_delete(@table, [{{:_, :"$1", :_}, [{:<, :"$1", cutoff}], [true]}])
+  end
+end

--- a/lib/optimal_system_agent/tools/builtins/skill_view.ex
+++ b/lib/optimal_system_agent/tools/builtins/skill_view.ex
@@ -13,6 +13,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
   alias OptimalSystemAgent.Tools.Registry
   alias OptimalSystemAgent.Tools.Registry.{SkillLoader, SkillUsage}
   alias OptimalSystemAgent.Agent.ActiveSkills
+  alias OptimalSystemAgent.Events.Bus
 
   @impl true
   def name, do: "skill_view"
@@ -78,6 +79,10 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
   def execute(_, _ctx), do: {:error, "skill_view requires a non-empty skill name"}
 
   defp load(skill, path, ctx) do
+    started = System.monotonic_time(:microsecond)
+    session_id = Map.get(ctx, :session_id)
+    reload? = is_binary(session_id) and skill.name in ActiveSkills.list(session_id)
+
     cond do
       not SkillLoader.within_roots?(path) ->
         {:error, "Skill path is outside the configured skill roots."}
@@ -92,12 +97,36 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
 
             case checkpoint_selection(ctx, skill.name) do
               :ok ->
+                emit_selected(ctx, skill.name)
+
+                :telemetry.execute(
+                  [:osa, :skills, :selected],
+                  %{
+                    count: 1,
+                    body_bytes: byte_size(body),
+                    duration_us: System.monotonic_time(:microsecond) - started,
+                    persistence_failed: 0
+                  },
+                  %{skill: skill.name, session_id: session_id, reload: reload?}
+                )
+
                 {:ok,
                  "# Active Skill: #{skill.name}\n\n" <>
                    "You selected this skill for the current task. Follow these instructions " <>
                    "before continuing.\n\n#{String.trim(body)}"}
 
               {:error, reason} ->
+                :telemetry.execute(
+                  [:osa, :skills, :selected],
+                  %{
+                    count: 0,
+                    body_bytes: byte_size(body),
+                    duration_us: System.monotonic_time(:microsecond) - started,
+                    persistence_failed: 1
+                  },
+                  %{skill: skill.name, session_id: session_id, reload: reload?}
+                )
+
                 {:error,
                  "Loaded '#{skill.name}' but could not checkpoint its selection: #{inspect(reason)}"}
             end
@@ -113,6 +142,24 @@ defmodule OptimalSystemAgent.Tools.Builtins.SkillView do
        do: ActiveSkills.select(session_id, skill_name)
 
   defp checkpoint_selection(_ctx, _skill_name), do: {:error, :missing_session_id}
+
+  defp emit_selected(%{session_id: session_id}, skill_name)
+       when is_binary(session_id) and session_id != "" do
+    payload = %{type: :skill_selected, skill: skill_name, session_id: session_id}
+    Bus.emit(:skill_selected, payload)
+
+    Phoenix.PubSub.broadcast(
+      OptimalSystemAgent.PubSub,
+      "osa:session:#{session_id}",
+      {:osa_event, payload}
+    )
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp emit_selected(_ctx, _skill_name), do: :ok
 
   defp preview(skill, path) do
     cond do

--- a/lib/optimal_system_agent/tools/registry.ex
+++ b/lib/optimal_system_agent/tools/registry.ex
@@ -764,18 +764,21 @@ defmodule OptimalSystemAgent.Tools.Registry do
         active = rank_skills_for_message(surfaced, message)
 
         lines =
-          Enum.map_join(active, "\n", fn skill ->
+          active
+          |> Enum.with_index()
+          |> Enum.map_join("\n", fn {skill, index} ->
             description =
               skill.description
               |> to_string()
               |> String.replace(~r/\s+/, " ")
               |> String.slice(0, 120)
 
-            "- **#{skill.name}**: #{description}"
+            recommendation = if index < 3 and is_binary(message), do: " (recommended)", else: ""
+            "- **#{skill.name}**#{recommendation}: #{description}"
           end)
 
         "## Skills (mandatory)\n\n" <>
-          "Before acting on any non-trivial task, scan this compact catalog. " <>
+          "Before acting on any non-trivial task, scan this compact, task-ranked catalog. " <>
           "If a skill is relevant or partially relevant, say which skill you are using, " <>
           "call `skill_view` to load its full instructions, and follow them before using " <>
           "other task tools. If no listed skill clearly fits, call `list_skills` to search " <>
@@ -804,21 +807,10 @@ defmodule OptimalSystemAgent.Tools.Registry do
     do: build_active_skills_context(message)
 
   defp rank_skills_for_message(skills, message) when is_binary(message) and message != "" do
-    query = String.downcase(message)
+    recommendations =
+      OptimalSystemAgent.Skills.Advisor.recommend(skills, message, limit: 12)
 
-    skills
-    |> Enum.map(fn skill ->
-      searchable =
-        [skill.name, skill.description, Enum.join(List.wrap(skill.triggers), " ")]
-        |> Enum.join(" ")
-
-      trigger_bonus = if trigger_match?(skill, query), do: 2.0, else: 0.0
-      {skill, trigger_bonus + OptimalSystemAgent.Skills.Ranker.relevance(searchable, message)}
-    end)
-    |> Enum.filter(fn {_skill, score} -> score > 0.0 end)
-    |> Enum.sort_by(fn {_skill, score} -> score end, :desc)
-    |> Enum.take(12)
-    |> Enum.map(&elem(&1, 0))
+    Enum.map(recommendations, & &1.skill)
   rescue
     _ -> Enum.take(skills, 12)
   end

--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -79,6 +79,7 @@ impl App {
                 // spend/limits. Both are Option — a field the backend didn't
                 // send simply leaves its chip off (no "effort:" / "$" shown).
                 self.status.set_effort(health.effort.clone());
+                self.status.set_reasoning(health.reasoning.clone());
                 self.status.set_billing(health.billing.clone());
 
                 // Update-available signal (Codex parity: understated, no
@@ -1245,6 +1246,19 @@ impl App {
                 Err(e) => BackendEvent::HealthResult(Err(e.to_string())),
             };
             let _ = tx.send(Event::Backend(event));
+        });
+    }
+
+    pub fn check_session_health(&self) {
+        let client = self.client.clone();
+        let tx = self.event_tx.clone();
+        let session_id = self.session_id.clone();
+        tokio::spawn(async move {
+            let result = client
+                .get_session_health(&session_id)
+                .await
+                .map_err(|error| error.to_string());
+            let _ = tx.send(Event::Backend(BackendEvent::SessionHealthResult(result)));
         });
     }
 

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -143,12 +143,33 @@ impl App {
             BackendEvent::HealthResult(result) => {
                 self.handle_health_result(result);
             }
+            BackendEvent::SessionHealthResult(Ok(health)) => {
+                let status = health
+                    .get("status")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("");
+                let action = health
+                    .get("recovery_action")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or("inspect_session");
+                if matches!(status, "degraded" | "recoverable") {
+                    self.toasts.push(
+                        format!("Session {} - {}", status, action.replace('_', " ")),
+                        crate::components::toast::ToastLevel::Warning,
+                    );
+                }
+            }
+            BackendEvent::SessionHealthResult(Err(error)) => {
+                debug!("session health check failed: {}", error);
+            }
             BackendEvent::LoginResult(result) => {
                 self.handle_login_result(result);
             }
             BackendEvent::SseConnected { session_id } => {
                 info!("SSE connected: {}", session_id);
                 self.sse_reconnecting = false;
+                self.status.clear_active_skills();
+                self.check_session_health();
                 self.sidebar.set_session(&self.session_id);
                 // Load commands and tools after SSE connection
                 self.load_commands();
@@ -754,6 +775,26 @@ impl App {
                     self.chat.finalize_tool(&name, tool_call_id.as_deref());
                 }
                 debug!("Tool result: {} (success={})", name, success);
+            }
+            BackendEvent::SkillSelected { skill } => {
+                self.status.add_active_skill(skill);
+            }
+            BackendEvent::ToolHeartbeat {
+                name,
+                elapsed_ms,
+                stalled,
+                ..
+            } => {
+                if stalled {
+                    self.toasts.push(
+                        format!(
+                            "{} has been running for {}s. It is still connected; press Esc to interrupt.",
+                            name,
+                            elapsed_ms / 1_000
+                        ),
+                        crate::components::toast::ToastLevel::Warning,
+                    );
+                }
             }
             BackendEvent::LlmRequest {
                 iteration,
@@ -1372,6 +1413,7 @@ impl App {
                     if let Some(effort) = resp.effort.clone() {
                         self.status.set_effort(Some(effort));
                     }
+                    self.check_health();
                     self.toasts.push(
                         format!("Model: {}/{}", resp.provider, resp.model),
                         crate::components::toast::ToastLevel::Info,

--- a/priv/rust/tui/src/app/handle_dialogs.rs
+++ b/priv/rust/tui/src/app/handle_dialogs.rs
@@ -835,6 +835,11 @@ impl App {
         // Reflect the new effort on the status line immediately — the backend
         // /health value was only a startup snapshot, and this is a live change.
         self.status.set_effort(Some(level.to_string()));
+        self.status.set_reasoning(Some(if level == "off" {
+            "off".to_string()
+        } else {
+            format!("on:{}", level)
+        }));
         self.toasts.push(
             format!("Reasoning: {}", level),
             crate::components::toast::ToastLevel::Info,

--- a/priv/rust/tui/src/client/generated.rs
+++ b/priv/rust/tui/src/client/generated.rs
@@ -29,6 +29,10 @@ pub struct HealthResponse {
     /// `Option` + `default` keep older backends (which omit it) decodable.
     #[serde(default)]
     pub effort: Option<String>,
+    /// Provider-normalized effective reasoning state, including the rule that selected it.
+    /// Examples: `on:catalog:high`, `off:model_unsupported`, `on:config`.
+    #[serde(default)]
+    pub reasoning: Option<String>,
     /// Spend/limit snapshot from the backend Budget. `null` when Budget is
     /// unavailable; individual limits are `null` when uncapped.
     #[serde(default)]

--- a/priv/rust/tui/src/client/http.rs
+++ b/priv/rust/tui/src/client/http.rs
@@ -357,6 +357,14 @@ impl ApiClient {
         Ok(resp.json().await?)
     }
 
+    /// GET /api/v1/sessions/:id/health
+    pub async fn get_session_health(&self, id: &str) -> Result<serde_json::Value> {
+        let resp = self
+            .get(&format!("/api/v1/sessions/{}/health", id))
+            .await?;
+        Ok(resp.json().await?)
+    }
+
     /// GET /api/v1/sessions/:id/context — token-usage breakdown for the session.
     pub async fn get_context(&self, id: &str) -> Result<ContextStats> {
         let resp = self

--- a/priv/rust/tui/src/client/sse.rs
+++ b/priv/rust/tui/src/client/sse.rs
@@ -438,6 +438,41 @@ fn parse_sse_event(event_type: &str, data: &[u8]) -> Option<BackendEvent> {
             }
         }
 
+        "skill_selected" => {
+            #[derive(serde::Deserialize)]
+            struct Ev {
+                skill: String,
+            }
+            let ev: Ev = match serde_json::from_slice(data) {
+                Ok(e) => e,
+                Err(e) => return Some(parse_warning("skill_selected", e)),
+            };
+            Some(BackendEvent::SkillSelected { skill: ev.skill })
+        }
+
+        "tool_heartbeat" => {
+            #[derive(serde::Deserialize)]
+            struct Ev {
+                name: String,
+                #[serde(default)]
+                elapsed_ms: u64,
+                #[serde(default)]
+                stalled: bool,
+                #[serde(default)]
+                tool_call_id: Option<String>,
+            }
+            let ev: Ev = match serde_json::from_slice(data) {
+                Ok(e) => e,
+                Err(e) => return Some(parse_warning("tool_heartbeat", e)),
+            };
+            Some(BackendEvent::ToolHeartbeat {
+                name: ev.name,
+                elapsed_ms: ev.elapsed_ms,
+                stalled: ev.stalled,
+                tool_call_id: ev.tool_call_id,
+            })
+        }
+
         "command_output_delta" => {
             #[derive(serde::Deserialize)]
             struct Ev {
@@ -2231,6 +2266,32 @@ mod tests {
                 delay_ms: 4000,
                 reason,
             }) => assert_eq!(reason, "timeout"),
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parses_skill_selection_and_tool_heartbeat() {
+        match parse_sse_event("skill_selected", br#"{"skill":"diagnosing-bugs"}"#) {
+            Some(BackendEvent::SkillSelected { skill }) => {
+                assert_eq!(skill, "diagnosing-bugs");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+
+        let heartbeat = br#"{"name":"shell_execute","elapsed_ms":31000,"stalled":true,"tool_call_id":"call-7"}"#;
+        match parse_sse_event("tool_heartbeat", heartbeat) {
+            Some(BackendEvent::ToolHeartbeat {
+                name,
+                elapsed_ms,
+                stalled,
+                tool_call_id,
+            }) => {
+                assert_eq!(name, "shell_execute");
+                assert_eq!(elapsed_ms, 31_000);
+                assert!(stalled);
+                assert_eq!(tool_call_id.as_deref(), Some("call-7"));
+            }
             other => panic!("unexpected: {:?}", other),
         }
     }

--- a/priv/rust/tui/src/components/status_bar.rs
+++ b/priv/rust/tui/src/components/status_bar.rs
@@ -406,12 +406,17 @@ pub struct StatusBar {
     session_title: Option<String>,
     /// "goal N/max" indicator when a /goal auto-continue loop is active.
     goal_label: Option<String>,
+    /// Skills explicitly activated for this session, shown on their own row so
+    /// narrow terminals never hide the workflow the agent is following.
+    active_skills: Vec<String>,
     /// Transient goal-verification indicator, rendered next to the goal line.
     /// None ⇒ no verifier round this turn ⇒ chip omitted.
     goal_verify: Option<GoalVerifyState>,
     /// Reasoning effort ("fast"|"medium"|"high"|"xhigh"|"ultra") from `/health.effort`.
     /// None ⇒ backend didn't report it ⇒ the chip is omitted.
     effort: Option<String>,
+    /// Provider-normalized effective reasoning state from `/health.reasoning`.
+    reasoning: Option<String>,
     /// Billing snapshot from `/health.billing`. None ⇒ omit the spend chip.
     billing: Option<crate::client::types::HealthBilling>,
     /// WS12 — % of usable context left before auto-compact (backend
@@ -488,8 +493,10 @@ impl StatusBar {
             cwd_basename,
             session_title: None,
             goal_label: None,
+            active_skills: Vec::new(),
             goal_verify: None,
             effort: None,
+            reasoning: None,
             billing: None,
             percent_left: None,
             context_low: false,
@@ -562,6 +569,10 @@ impl StatusBar {
         self.effort.clone()
     }
 
+    pub fn set_reasoning(&mut self, reasoning: Option<String>) {
+        self.reasoning = reasoning.filter(|s| !s.trim().is_empty());
+    }
+
     /// Set (or clear with None) the billing spend/limit chip.
     pub fn set_billing(&mut self, billing: Option<crate::client::types::HealthBilling>) {
         self.billing = billing;
@@ -572,11 +583,25 @@ impl StatusBar {
         self.goal_label = label;
     }
 
+    pub fn add_active_skill(&mut self, skill: String) {
+        let skill = crate::render::sanitize::scrub_untrusted_line(&skill);
+        let skill = skill.trim();
+        if skill.is_empty() {
+            return;
+        }
+        self.active_skills.retain(|existing| existing != skill);
+        self.active_skills.push(skill.to_string());
+    }
+
+    pub fn clear_active_skills(&mut self) {
+        self.active_skills.clear();
+    }
+
     /// Two ordinary status rows, plus one dedicated goal row while a durable
     /// goal exists. Keeping this measurement on the component makes the layout
     /// reserve exactly what `draw` paints.
     pub fn desired_height(&self) -> u16 {
-        if self.goal_label.is_some() { 3 } else { 2 }
+        2 + u16::from(self.goal_label.is_some()) + u16::from(!self.active_skills.is_empty())
     }
 
     /// Set (or clear with None) the transient goal-verification indicator.
@@ -1021,11 +1046,14 @@ impl Component for StatusBar {
         // A goal owns its own row. It used to be appended to the already-dense
         // primary status line, where normal terminal widths clipped the goal
         // text and often left only a dangling `/` from `/goal pause`.
-        let row_constraints = if self.goal_label.is_some() {
-            vec![Constraint::Length(1), Constraint::Length(1), Constraint::Length(1)]
-        } else {
-            vec![Constraint::Length(1), Constraint::Length(1)]
-        };
+        let mut row_constraints = vec![Constraint::Length(1)];
+        if self.goal_label.is_some() {
+            row_constraints.push(Constraint::Length(1));
+        }
+        if !self.active_skills.is_empty() {
+            row_constraints.push(Constraint::Length(1));
+        }
+        row_constraints.push(Constraint::Length(1));
         let rows = RLayout::default()
             .direction(Direction::Vertical)
             .constraints(row_constraints)
@@ -1038,7 +1066,12 @@ impl Component for StatusBar {
             width: r.width.saturating_sub(1),
             ..*r
         });
-        let permission_row_index = if self.goal_label.is_some() { 2 } else { 1 };
+        let skill_row_index = 1 + usize::from(self.goal_label.is_some());
+        let skill_row = (!self.active_skills.is_empty()).then(|| Rect {
+            width: rows[skill_row_index].width.saturating_sub(1),
+            ..rows[skill_row_index]
+        });
+        let permission_row_index = rows.len().saturating_sub(1);
         let row1 = rows
             .get(permission_row_index)
             .map(|r| Rect { width: r.width.saturating_sub(1), ..*r })
@@ -1361,6 +1394,18 @@ impl Component for StatusBar {
             );
         }
 
+        if let Some(reasoning) = self.reasoning.as_ref() {
+            let state = if reasoning.starts_with("on:") { "think:on" } else { "think:off" };
+            push_segment_if_fits(
+                &mut spans,
+                vec![
+                    Span::styled(" \u{2502} ", theme.status_sep()),
+                    Span::styled(state, theme.faint()),
+                ],
+                row0.width,
+            );
+        }
+
         // MCP chip (`3 MCP`). U-T26. Omitted when no servers.
         if let Some(mcp) = mcp_label(self.mcp_count) {
             let style = Style::default().fg(theme.colors.primary);
@@ -1472,6 +1517,24 @@ impl Component for StatusBar {
                 )))
                 .style(theme.status_bar()),
                 goal_area,
+            );
+        }
+
+        if let Some(skill_area) = skill_row {
+            let visible = self.active_skills.iter().take(3).cloned().collect::<Vec<_>>();
+            let hidden = self.active_skills.len().saturating_sub(visible.len());
+            let label = if hidden == 0 {
+                visible.join(", ")
+            } else {
+                format!("{} +{}", visible.join(", "), hidden)
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    format!("Using: {}", label),
+                    Style::default().fg(Color::Cyan),
+                )))
+                .style(theme.status_bar()),
+                skill_area,
             );
         }
 
@@ -1982,6 +2045,30 @@ mod status_bar_tests {
             fast.contains("effort:fast"),
             "a /fast change must be immediately visible: {fast:?}"
         );
+    }
+
+    #[test]
+    fn active_skill_uses_a_dedicated_row_at_narrow_width() {
+        let mut sb = StatusBar::new();
+        sb.set_provider_info("openrouter", "anthropic/claude-opus-5");
+        sb.set_permission_mode(PermissionMode::BypassPermissions);
+        sb.add_active_skill("diagnosing-bugs".into());
+
+        assert_eq!(sb.desired_height(), 3);
+        let text = render_sb_at(&sb, 42, 3);
+        assert!(text.contains("Using: diagnosing-bugs"), "skill row missing: {text:?}");
+        assert!(text.contains("overdrive"), "permission row missing: {text:?}");
+
+        for skill in ["review", "tdd", "security-auditor"] {
+            sb.add_active_skill(skill.into());
+        }
+        let overflow = render_sb_at(&sb, 60, 3);
+        assert!(overflow.contains("+1"), "hidden skill count missing: {overflow:?}");
+
+        sb.clear_active_skills();
+        assert_eq!(sb.desired_height(), 2);
+        let cleared = render_sb_at(&sb, 60, 2);
+        assert!(!cleared.contains("Using:"), "skills leaked across sessions: {cleared:?}");
     }
 
     #[test]

--- a/priv/rust/tui/src/event/backend.rs
+++ b/priv/rust/tui/src/event/backend.rs
@@ -85,6 +85,15 @@ pub enum BackendEvent {
         success: bool,
         tool_call_id: Option<String>,
     },
+    SkillSelected {
+        skill: String,
+    },
+    ToolHeartbeat {
+        name: String,
+        elapsed_ms: u64,
+        stalled: bool,
+        tool_call_id: Option<String>,
+    },
 
     /// Live stdout/stderr from a still-running foreground shell command
     /// (`command_output_delta`). Emitted at most ~4/sec while the command runs
@@ -575,6 +584,7 @@ pub enum BackendEvent {
 
     // === HTTP Response Results ===
     HealthResult(Result<HealthResponse, String>),
+    SessionHealthResult(Result<serde_json::Value, String>),
     LoginResult(Result<LoginResponse, String>),
     OrchestrateResult(Result<OrchestrateResponse, String>),
     CommandsLoaded(Result<Vec<CommandEntry>, String>),

--- a/test/optimal_system_agent/agent/active_skills_test.exs
+++ b/test/optimal_system_agent/agent/active_skills_test.exs
@@ -41,14 +41,68 @@ defmodule OptimalSystemAgent.Agent.ActiveSkillsTest do
     refute block =~ "Before any further task action"
   end
 
-  test "selection is ordered, deduplicated, and bounded", %{session_id: sid} do
-    for n <- 1..14, do: assert(:ok = ActiveSkills.select(sid, "skill-#{n}"))
-    assert :ok = ActiveSkills.select(sid, "skill-5")
+  test "context injection reports its bounded context cost", %{session_id: sid} do
+    ref = make_ref()
+    parent = self()
 
-    names = ActiveSkills.list(sid)
-    assert length(names) == 12
-    assert List.last(names) == "skill-5"
-    assert Enum.count(names, &(&1 == "skill-5")) == 1
+    :telemetry.attach(
+      "active-skills-context-#{inspect(ref)}",
+      [:osa, :skills, :context],
+      fn event, measurements, metadata, _ ->
+        send(parent, {ref, event, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach("active-skills-context-#{inspect(ref)}") end)
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+    assert is_binary(ActiveSkills.context_block(sid, []))
+
+    assert_receive {^ref, [:osa, :skills, :context], %{count: 1, bytes: bytes}, metadata}
+    assert bytes > 0
+    assert metadata.session_id == sid
+    assert metadata.reload_required
+  end
+
+  test "selection persists a body hash and requires reload after the body changes", %{
+    session_id: sid
+  } do
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+    assert {:ok, [%{name: "diagnosing-bugs", hash: hash}]} = ActiveSkills.snapshots(sid)
+    assert is_binary(hash) and byte_size(hash) == 64
+
+    skill = OptimalSystemAgent.Tools.Registry.get_skill("diagnosing-bugs")
+    original = File.read!(skill.path)
+    on_exit(fn -> File.write!(skill.path, original) end)
+    File.write!(skill.path, original <> "\ntemporary version change\n")
+
+    assert ActiveSkills.context_block(sid, []) =~ "installed body changed since selection"
+  end
+
+  test "selection is ordered, deduplicated, and bounded", %{session_id: sid} do
+    names =
+      OptimalSystemAgent.Tools.Registry.list_skills()
+      |> Enum.map(&(&1[:name] || &1["name"]))
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+      |> Enum.take(14)
+
+    assert length(names) == 14
+    for name <- names, do: assert(:ok = ActiveSkills.select(sid, name))
+    repeated = Enum.at(names, 4)
+    assert :ok = ActiveSkills.select(sid, repeated)
+
+    selected = ActiveSkills.list(sid)
+    assert length(selected) == 12
+    assert List.last(selected) == repeated
+    assert Enum.count(selected, &(&1 == repeated)) == 1
+  end
+
+  test "selection refuses a versionless checkpoint", %{session_id: sid} do
+    assert {:error, {:skill_body_unavailable, "missing-skill", :not_found}} =
+             ActiveSkills.select(sid, "missing-skill")
+
+    refute ActiveSkills.exists?(sid)
   end
 
   test "invalid durable state is visible and fails closed", %{session_id: sid} do

--- a/test/optimal_system_agent/agent/loop/tool_heartbeat_test.exs
+++ b/test/optimal_system_agent/agent/loop/tool_heartbeat_test.exs
@@ -1,0 +1,23 @@
+defmodule OptimalSystemAgent.Agent.Loop.ToolHeartbeatTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Agent.Loop.ToolHeartbeat
+
+  test "emits periodic liveness and marks the stall threshold only once" do
+    session_id = "heartbeat-#{System.unique_integer([:positive])}"
+    Phoenix.PubSub.subscribe(OptimalSystemAgent.PubSub, "osa:session:#{session_id}")
+
+    pid =
+      ToolHeartbeat.start(
+        %{name: "slow_tool", id: "call-1"},
+        %{session_id: session_id},
+        interval_ms: 5,
+        stalled_ms: 10
+      )
+
+    assert_receive {:osa_event, %{type: :tool_heartbeat, stalled: false}}, 100
+    assert_receive {:osa_event, %{type: :tool_heartbeat, stalled: true}}, 100
+    assert_receive {:osa_event, %{type: :tool_heartbeat, stalled: false}}, 100
+    assert :ok = ToolHeartbeat.stop(pid)
+  end
+end

--- a/test/optimal_system_agent/agent/session_health_test.exs
+++ b/test/optimal_system_agent/agent/session_health_test.exs
@@ -1,0 +1,29 @@
+defmodule OptimalSystemAgent.Agent.SessionHealthTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Agent.{ActiveSkills, SessionHealth, SessionPersistence}
+
+  setup do
+    session_id = "session-health-#{System.unique_integer([:positive])}"
+    on_exit(fn -> SessionPersistence.delete(session_id) end)
+    %{session_id: session_id}
+  end
+
+  test "distinguishes a missing session from a durable recoverable session", %{session_id: sid} do
+    assert %{status: :missing, recovery_action: "start_new_session"} =
+             SessionHealth.snapshot(sid)
+
+    assert :ok =
+             SessionPersistence.save(sid, [%{role: "user", content: "recover me"}], File.cwd!())
+
+    assert :ok = ActiveSkills.select(sid, "diagnosing-bugs")
+
+    assert %{
+             status: :recoverable,
+             live: false,
+             recovery_action: "resume_session",
+             persistence: %{status: :ok, restorable: true, message_count: 1},
+             active_skills: %{status: :ok, count: 1, names: ["diagnosing-bugs"], versioned: 1}
+           } = SessionHealth.snapshot(sid)
+  end
+end

--- a/test/optimal_system_agent/channels/http/health_update_test.exs
+++ b/test/optimal_system_agent/channels/http/health_update_test.exs
@@ -37,6 +37,7 @@ defmodule OptimalSystemAgent.Channels.HTTP.HealthUpdateTest do
     assert update["available"] == false
     assert Map.has_key?(update, "current_version")
     assert Map.get(update, "latest_version") == nil
+    assert Map.has_key?(body, "reasoning")
   end
 
   test "surfaces a stubbed newer version as available:true with current + latest" do

--- a/test/optimal_system_agent/skills/advisor_test.exs
+++ b/test/optimal_system_agent/skills/advisor_test.exs
@@ -1,0 +1,48 @@
+defmodule OptimalSystemAgent.Skills.AdvisorTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Skills.Advisor
+
+  setup do
+    Advisor.clear_cache()
+    :ok
+  end
+
+  test "ranks trigger and metadata matches without returning skill bodies" do
+    skills = [
+      %{name: "deploy", description: "ship a release", triggers: ["publish"], body: "secret"},
+      %{
+        name: "diagnose",
+        description: "debug broken behavior",
+        triggers: ["broken"],
+        body: "body"
+      }
+    ]
+
+    assert [%{skill: %{name: "diagnose"}, confidence: :high}] =
+             Advisor.recommend(skills, "the TUI is broken", limit: 1)
+  end
+
+  test "reuses a cached recommendation and invalidates when metadata changes" do
+    id = "advisor-cache-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach(
+      id,
+      [:osa, :skills, :recommend],
+      fn _event, measurements, _metadata, pid -> send(pid, measurements) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach(id) end)
+    skills = [%{name: "diagnose", description: "debug failures", triggers: []}]
+
+    assert [_] = Advisor.recommend(skills, "debug")
+    assert_receive %{cache_hit: 0}
+    assert [_] = Advisor.recommend(skills, "debug")
+    assert_receive %{cache_hit: 1}
+
+    changed = [%{name: "diagnose", description: "inspect failures", triggers: []}]
+    assert Advisor.recommend(changed, "debug") == []
+    assert_receive %{cache_hit: 0}
+  end
+end

--- a/test/providers/model_limits_test.exs
+++ b/test/providers/model_limits_test.exs
@@ -37,6 +37,11 @@ defmodule OptimalSystemAgent.Providers.ModelLimitsTest do
       assert ModelLimits.reasoning(:openai, "o3") == true
     end
 
+    test "resolves OpenRouter vendor-prefixed model ids through native catalog metadata" do
+      assert ModelLimits.tool_call(:openrouter, "anthropic/claude-sonnet-4-6") == true
+      assert ModelLimits.reasoning(:openrouter, "openai/o3") == true
+    end
+
     test "returns nil when the catalog has no entry (caller uses its own heuristic)" do
       assert ModelLimits.tool_call(:ollama, "unknown-local-model-xyz") == nil
       assert ModelLimits.reasoning(:ollama, "unknown-local-model-xyz") == nil


### PR DESCRIPTION
## Summary

- Add metadata-only proactive skill ranking with bounded caching and telemetry.
- Persist active skill snapshots with hashes and restore them safely after compaction or reconnect.
- Show active skills, normalized reasoning, tool stalls, and session recovery guidance in the Rust TUI.
- Improve OpenRouter capability lookup and skip fallback models known not to support required tools.
- Document the new runtime intelligence, provider, recovery, and TUI behavior throughout the README.

## Verification

- Focused Elixir runtime and provider suites pass.
- Rust TUI status and SSE tests pass.
- `cargo check` passes.
- `git diff --check` passes.
- Independent Standards and Spec reviews found no release-blocking issues.

## Notes

The repository-wide Elixir suite still contains pre-existing host and environment dependent failures unrelated to this branch. The focused suites for every changed subsystem pass.
