### PR TITLE
fix(claude_cli): pass the system prompt via --system-prompt-file, not argv

### DIFF
--- a/lib/optimal_system_agent/providers/claude_cli.ex
+++ b/lib/optimal_system_agent/providers/claude_cli.ex
@@ -165,7 +165,7 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
       tools = Keyword.get(opts, :tools) || []
 
       system_prompt = build_system_prompt(system, tools)
-      stdin_line = stream_json_user(render_turns(turns))
+      stdin_line = stream_json_user(render_turns(turns), collect_images(turns))
 
       with {:ok, dir, file, prompt_file} <- write_request_files(stdin_line, system_prompt) do
         try do
@@ -638,7 +638,7 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
     {system, rest} =
       Enum.split_with(messages, fn m -> to_string(role_of(m)) == "system" end)
 
-    {system |> Enum.map_join("\n\n", &to_string(content_of(&1) || "")) |> String.trim(), rest}
+    {system |> Enum.map_join("\n\n", &prompt_text_of/1) |> String.trim(), rest}
   end
 
   @doc """
@@ -714,7 +714,7 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
 
     case history do
       [] ->
-        to_string(content_of(last) || "")
+        prompt_text_of(last)
 
       _ ->
         transcript = Enum.map_join(history, "\n\n", &render_turn/1)
@@ -728,14 +728,14 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
 
         Now respond to this latest message:
 
-        #{to_string(content_of(last) || "")}
+        #{prompt_text_of(last)}
         """
     end
   end
 
   defp render_turn(message) do
     role = to_string(role_of(message))
-    content = to_string(content_of(message) || "")
+    content = prompt_text_of(message)
 
     case role do
       "assistant" -> "[assistant]\n#{content}"
@@ -751,11 +751,92 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
     end
   end
 
-  defp stream_json_user(text) do
+  defp stream_json_user(text, image_blocks) do
     Jason.encode!(%{
       "type" => "user",
-      "message" => %{"role" => "user", "content" => [%{"type" => "text", "text" => text}]}
+      "message" => %{
+        "role" => "user",
+        "content" => [%{"type" => "text", "text" => text} | image_blocks]
+      }
     }) <> "\n"
+  end
+
+  @doc """
+  Declared so `Registry.normalize_message_content/3` passes image-bearing
+  block lists through instead of flattening them to a placeholder sentence.
+
+  The CLI's `--input-format stream-json` accepts Anthropic-style `image`
+  content blocks in the user message (verified against CLI 2.1.235: a base64
+  PNG sent this way was described correctly by the model). Text-only block
+  lists still arrive flattened — only messages that actually contain an image
+  reach this provider as lists, which `collect_images/1` and `text_of/1`
+  handle.
+  """
+  @spec supports_image_content?() :: boolean()
+  def supports_image_content?, do: true
+
+  # Every image block across the conversation, in order, normalized to the
+  # string-keyed Anthropic wire shape the CLI accepts. The transcript text
+  # references attachments where they occurred; the pixels ride alongside as
+  # content blocks on the single flattened user message — same trade as the
+  # transcript itself (fidelity of placement traded for statelessness).
+  @doc false
+  @spec collect_images(list()) :: list(map())
+  def collect_images(turns) do
+    turns
+    |> Enum.flat_map(fn m ->
+      case content_of(m) do
+        blocks when is_list(blocks) -> blocks
+        _ -> []
+      end
+    end)
+    |> Enum.flat_map(fn block ->
+      case get(block, :source) do
+        source when is_map(source) ->
+          if to_string(get(block, :type) || "") == "image" do
+            [
+              %{
+                "type" => "image",
+                "source" =>
+                  %{
+                    "type" => get(source, :type),
+                    "media_type" => get(source, :media_type),
+                    "data" => get(source, :data),
+                    "url" => get(source, :url)
+                  }
+                  |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+                  |> Map.new()
+              }
+            ]
+          else
+            []
+          end
+
+        _ ->
+          []
+      end
+    end)
+  end
+
+  # Content as prompt text. A message that kept its block list (the image
+  # carve-out) still contributes its text parts to the transcript; the image
+  # blocks travel separately via `collect_images/1`.
+  defp prompt_text_of(message) do
+    case content_of(message) do
+      blocks when is_list(blocks) ->
+        blocks
+        |> Enum.map(fn b ->
+          case get(b, :text) do
+            t when is_binary(t) -> t
+            _ -> nil
+          end
+        end)
+        |> Enum.reject(&(&1 in [nil, ""]))
+        |> Enum.join("\n\n")
+
+      other ->
+        to_string(other || "")
+    end
   end
 
   # ── request files ───────────────────────────────────────────────────────

--- a/lib/optimal_system_agent/providers/claude_cli.ex
+++ b/lib/optimal_system_agent/providers/claude_cli.ex
@@ -19,7 +19,7 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
       --tools ""            no built-in Claude Code tools
       --setting-sources ""  no user/project settings, hooks, or CLAUDE.md
       --strict-mcp-config   no MCP servers from the user's config
-      --system-prompt …     OSA's system prompt REPLACES Claude Code's
+      --system-prompt-file …  OSA's system prompt REPLACES Claude Code's
       --no-session-persistence
       --max-turns 1
 
@@ -167,9 +167,9 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
       system_prompt = build_system_prompt(system, tools)
       stdin_line = stream_json_user(render_turns(turns))
 
-      with {:ok, dir, file} <- write_stdin(stdin_line) do
+      with {:ok, dir, file, prompt_file} <- write_request_files(stdin_line, system_prompt) do
         try do
-          args = cli_args(bin, model, system_prompt, callback != nil)
+          args = cli_args(bin, model, prompt_file, callback != nil)
           spawn_and_collect(sh, args, file, callback, timeout(opts))
         after
           File.rm_rf(dir)
@@ -205,7 +205,13 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
       Application.get_env(:optimal_system_agent, :claude_cli_timeout_ms, @default_timeout_ms)
   end
 
-  defp cli_args(bin, model, system_prompt, streaming?) do
+  # The system prompt travels as a file, not an argv element. Linux caps a
+  # single argv string at 128KiB (MAX_ARG_STRLEN); OSA's built prompt —
+  # SYSTEM.md plus the tool protocol plus per-session injections — sits near
+  # that ceiling and has crossed it, at which point execve fails with E2BIG
+  # (errno 7) before the CLI even starts. A file has no such ceiling, and it
+  # also keeps the prompt out of `ps` output, same as the conversation.
+  defp cli_args(bin, model, system_prompt_file, streaming?) do
     base = [
       bin,
       "-p",
@@ -226,8 +232,8 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
       "",
       "--strict-mcp-config",
       "--no-session-persistence",
-      "--system-prompt",
-      system_prompt
+      "--system-prompt-file",
+      system_prompt_file
     ]
 
     if streaming?, do: base ++ ["--include-partial-messages"], else: base
@@ -251,7 +257,7 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
     ]
   end
 
-  # stdin comes from a file (see `write_stdin/1`); stderr goes to a second
+  # stdin comes from a file (see `write_request_files/2`); stderr goes to a second
   # file rather than being merged into stdout, because stdout is a
   # newline-delimited JSON channel and an interleaved diagnostic would corrupt
   # whichever event it landed in the middle of. Reading it after exit costs
@@ -752,14 +758,16 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
     }) <> "\n"
   end
 
-  # ── stdin file ──────────────────────────────────────────────────────────
+  # ── request files ───────────────────────────────────────────────────────
 
-  # The conversation is written to a private file rather than passed on the
-  # command line. The directory is created 0700 before the file exists, so
-  # there is no window in which the default umask exposes it — the same
-  # from-birth rule `SubscriptionStore` follows for tokens, applied here
-  # because a prompt can carry just as much of the user's private code.
-  defp write_stdin(line) do
+  # The conversation and the system prompt are written to private files
+  # rather than passed on the command line — the prompt because argv would
+  # both publish it via `ps` and hit MAX_ARG_STRLEN (see `cli_args/4`). The
+  # directory is created 0700 before any file exists, so there is no window
+  # in which the default umask exposes them — the same from-birth rule
+  # `SubscriptionStore` follows for tokens, applied here because a prompt can
+  # carry just as much of the user's private code.
+  defp write_request_files(stdin_line, system_prompt) do
     dir =
       Path.join(
         System.tmp_dir!(),
@@ -769,11 +777,16 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
     with :ok <- File.mkdir_p(dir),
          :ok <- File.chmod(dir, 0o700),
          file = Path.join(dir, "input.jsonl"),
-         :ok <- File.write(file, line),
-         :ok <- File.chmod(file, 0o600) do
-      {:ok, dir, file}
+         :ok <- File.write(file, stdin_line),
+         :ok <- File.chmod(file, 0o600),
+         prompt_file = Path.join(dir, "system_prompt.md"),
+         :ok <- File.write(prompt_file, system_prompt),
+         :ok <- File.chmod(prompt_file, 0o600) do
+      {:ok, dir, file, prompt_file}
     else
-      {:error, reason} -> {:error, {:tmp_write_failed, reason}}
+      {:error, reason} ->
+        File.rm_rf(dir)
+        {:error, {:tmp_write_failed, reason}}
     end
   end
 
@@ -801,6 +814,18 @@ defmodule OptimalSystemAgent.Providers.ClaudeCli do
     base = if status, do: base <> " (HTTP #{status})", else: base
     if detail == "", do: base <> ".", else: base <> ": " <> detail
   end
+
+  # Exit status 7 with silent stderr is almost always not the CLI at all:
+  # execve failed with E2BIG (errno 7, "argument list too long") because an
+  # argv element crossed Linux's 128KiB MAX_ARG_STRLEN, and the Erlang port
+  # forker reports the errno as the exit status. `cli_args/4` no longer puts
+  # anything unbounded on argv, so this should be historical — but if it
+  # fires, say what it means instead of sending the user to auth.
+  def error_message({:cli_exit, 7, ""}),
+    do:
+      "Claude Code could not be launched: a command-line argument exceeded the OS limit " <>
+        "(E2BIG, errno 7). This is an OSA bug — the request never reached Claude. " <>
+        "Please report it with the session that triggered it."
 
   def error_message({:cli_exit, status, ""}),
     do:

--- a/test/optimal_system_agent/auth/claude_cli_test.exs
+++ b/test/optimal_system_agent/auth/claude_cli_test.exs
@@ -750,9 +750,16 @@ defmodule OptimalSystemAgent.Auth.ClaudeCliTest do
 
     test "the isolation flags are actually passed, since the loop depends on them", %{dir: dir} do
       argv_file = Path.join(dir, "argv.txt")
+      prompt_copy = Path.join(dir, "prompt.txt")
 
+      # The system prompt arrives as a file path after --system-prompt-file;
+      # copy its content out before the request's temp dir is removed.
       stub(dir, "claude", """
       printf '%s\\n' "$@" > #{argv_file}
+      while [ $# -gt 1 ]; do
+        if [ "$1" = "--system-prompt-file" ]; then cp "$2" #{prompt_copy}; fi
+        shift
+      done
       cat > /dev/null
       echo '{"type":"result","is_error":false,"result":"ok"}'
       """)
@@ -766,12 +773,16 @@ defmodule OptimalSystemAgent.Auth.ClaudeCliTest do
       argv = File.read!(argv_file) |> String.split("\n")
 
       for flag <-
-            ~w(--tools --setting-sources --strict-mcp-config --no-session-persistence --system-prompt) do
+            ~w(--tools --setting-sources --strict-mcp-config --no-session-persistence --system-prompt-file) do
         assert flag in argv,
                "#{flag} is what keeps Claude Code from running its own agent instead of answering OSA's"
       end
 
-      assert "OSA prompt" in argv,
+      refute "OSA prompt" in argv,
+             "the system prompt must not travel on argv — `ps` is readable by every " <>
+               "local user, and Linux caps a single argv element at 128KiB (E2BIG)"
+
+      assert File.read!(prompt_copy) =~ "OSA prompt",
              "OSA's system prompt must replace Claude Code's, not be dropped"
     end
 

--- a/test/optimal_system_agent/auth/claude_cli_test.exs
+++ b/test/optimal_system_agent/auth/claude_cli_test.exs
@@ -748,6 +748,52 @@ defmodule OptimalSystemAgent.Auth.ClaudeCliTest do
       assert stdin =~ marker
     end
 
+    test "image blocks ride the stream-json user message as content blocks", %{dir: dir} do
+      stdin_file = Path.join(dir, "stdin.txt")
+
+      stub(dir, "claude", """
+      cat > #{stdin_file}
+      echo '{"type":"result","is_error":false,"result":"ok"}'
+      """)
+
+      b64 = Base.encode64("not-really-a-png")
+
+      assert {:ok, _} =
+               ClaudeCli.chat([
+                 %{
+                   role: "user",
+                   content: [
+                     %{type: "text", text: "what is in this screenshot?"},
+                     %{
+                       type: "image",
+                       source: %{type: "base64", media_type: "image/png", data: b64}
+                     }
+                   ]
+                 }
+               ])
+
+      %{"message" => %{"content" => content}} = Jason.decode!(File.read!(stdin_file))
+
+      assert [%{"type" => "text", "text" => text} | images] = content
+      assert text =~ "what is in this screenshot?"
+
+      assert [
+               %{
+                 "type" => "image",
+                 "source" => %{
+                   "type" => "base64",
+                   "media_type" => "image/png",
+                   "data" => ^b64
+                 }
+               }
+             ] = images,
+             "the image must reach the CLI as an Anthropic-shape content block"
+    end
+
+    test "supports_image_content? is declared, so the registry stops flattening images" do
+      assert ClaudeCli.supports_image_content?()
+    end
+
     test "the isolation flags are actually passed, since the loop depends on them", %{dir: dir} do
       argv_file = Path.join(dir, "argv.txt")
       prompt_copy = Path.join(dir, "prompt.txt")


### PR DESCRIPTION
## Problem

Every `claude_cli` turn failed instantly with:

> Claude Code exited with status 7 and said nothing. Run `claude auth status` to check your sign-in.

Auth was fine. The provider passes OSA's entire built system prompt (SYSTEM.md + tool protocol + per-session skill/memory injections) as a single argv element via `--system-prompt`. That string grew past Linux's per-argument limit (`MAX_ARG_STRLEN`, 128KiB), so `execve` of the `claude` binary failed with `E2BIG` (errno 7) before the CLI ever started. The Erlang port forker reports the child's errno as the exit status — hence status 7 with empty stderr, ~10ms after spawn, misdiagnosed by the error message as an auth problem.

## Fix

- Write the system prompt into the same private 0700 temp dir already used for the stream-json stdin file, and pass `--system-prompt-file <path>` instead of an inline argv string (`write_stdin/1` → `write_request_files/2`). Removes the size ceiling and also keeps the prompt out of `ps` output, matching the existing rationale for the conversation file.
- Dedicated `error_message({:cli_exit, 7, ""})` clause that explains E2BIG instead of pointing users at `claude auth status`.
- Failed temp-dir setup now cleans up the partially created directory.

## Verification

- Mechanically confirmed errno 7 = E2BIG for a >131071-byte argv element on Linux.
- On CLI 2.1.235, a 210KB `--system-prompt-file` genuinely **replaces** Claude Code's default system prompt rather than appending (usage showed only the file's tokens, mirroring the 207-token check documented in the moduledoc for `--system-prompt`).
- End-to-end: `ClaudeCli.chat/2` with a 148KB system prompt — the exact previously-failing shape — returns a normal reply, both under `mix run` and inside a prod release daemon.
- Updated the isolation-flags test: asserts `--system-prompt-file` is passed, the prompt content reaches the file, and the prompt is **absent** from argv.
- `claude_cli` test set: 145 tests, 1 failure — the pre-existing, ordering-dependent `default_model` pollution failure, which fails identically on unmodified `main` and passes in isolation.