### PR TITLE
fix: let background subagents run for a full working day

### DIFF
--- a/lib/optimal_system_agent/agent/loop/llm_client.ex
+++ b/lib/optimal_system_agent/agent/loop/llm_client.ex
@@ -13,12 +13,31 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
   alias OptimalSystemAgent.Providers.Resilience
   alias OptimalSystemAgent.Agent.Trajectory
 
-  # If no streaming token arrives for this long, the connection is dead.
-  # This is NOT a total-duration cap — active streams can run indefinitely.
-  # 300s matches the curl --max-time and port-level timeout in ollama.ex.
-  # Large models (nemotron-super) can take 2-3 min to produce the first token
-  # on complex multi-tool requests.
-  @idle_timeout_ms 300_000
+  # If no streaming token arrives for this long, the connection is treated as
+  # dead. NOT a total-duration cap — an active stream can run indefinitely.
+  #
+  # Raised from 300s. Five minutes of silence is not reliable evidence of a dead
+  # connection: a loaded provider, a large model on a long multi-tool request, or
+  # a queue behind a rate limit all go quiet for longer than that while perfectly
+  # healthy. Observed failure — a background agent that had ALREADY finished its
+  # work (67 pages built, 157 tests passing, zero type errors) was killed
+  # mid-sentence writing its final report:
+  #
+  #     partial: "Zero TypeScript errors. Let me run the full test suite:"
+  #
+  # The stream died, the agent looked stalled, and two hours later it was
+  # reported as a `:timeout` failure with its completed results discarded. The
+  # cost of waiting longer is a slower report on a genuinely dead socket; the
+  # cost of waiting too little is throwing away finished work.
+  @default_idle_timeout_ms 1_800_000
+
+  defp idle_timeout_ms do
+    Application.get_env(
+      :optimal_system_agent,
+      :llm_stream_idle_timeout_ms,
+      @default_idle_timeout_ms
+    )
+  end
 
   # Process-dictionary key holding the id of the assistant message currently
   # being generated. See `mint_message_id/1`.
@@ -227,7 +246,7 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
 
   The stream can run for hours as long as tokens keep arriving. If the
   connection goes silent (no text_delta, thinking_delta, or done event
-  for #{@idle_timeout_ms}ms), the call is killed and an error returned.
+  for `:llm_stream_idle_timeout_ms`), the call is killed and an error returned.
 
   Returns {:ok, result} | {:error, reason}.
   """
@@ -490,8 +509,8 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
         res
       end)
 
-    # Watchdog: polls heartbeat every 10s, kills if no progress for @idle_timeout_ms
-    idle_timeout = Keyword.get(opts, :idle_timeout, @idle_timeout_ms)
+    # Watchdog: polls heartbeat every 10s, kills if no progress for the idle timeout
+    idle_timeout = Keyword.get(opts, :idle_timeout, idle_timeout_ms())
 
     watchdog =
       spawn_link(fn -> watchdog_loop(heartbeat, stream_task, idle_timeout, session_id) end)

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -10,6 +10,7 @@ defmodule OptimalSystemAgent.Orchestrator do
   They get their own context window, model selection, and tool access.
   """
   require Logger
+  import Bitwise, only: [bsl: 2]
 
   alias OptimalSystemAgent.Agent.Loop
   alias OptimalSystemAgent.Agent.Tier
@@ -32,7 +33,16 @@ defmodule OptimalSystemAgent.Orchestrator do
   # mechanism for an explicit user cancel is `Loop.cancel/1` force-terminating
   # the child's GenServer (loop.ex) — this timeout is the backstop for the
   # no-cancel-issued, just-plain-stuck case.
-  @default_subagent_timeout_ms 2 * 60 * 60 * 1000
+  # Raised from 2h. This is the "just plain stuck, no cancel issued" backstop,
+  # and at two hours it was firing on work that was merely long: a background
+  # agent building 67 pages and running 157 tests hit it and was reported as
+  # `:timeout` with its finished results thrown away.
+  #
+  # An agent expected to work unattended for a shift needs a backstop measured
+  # in shifts. Still finite so a truly wedged child cannot be held forever, and
+  # still overridable per call (`timeout_ms:` / `await_timeout:`) or globally via
+  # `:subagent_await_timeout_ms` for a deliberately bounded job.
+  @default_subagent_timeout_ms 12 * 60 * 60 * 1000
 
   @doc false
   def runner_key(agent_id), do: "subagent-runner:" <> agent_id
@@ -1726,6 +1736,8 @@ defmodule OptimalSystemAgent.Orchestrator do
           failure_result(subagent_id, parent_id, role, reason,
             duration_ms: duration_ms,
             files_changed: files_changed,
+            commands_run: commands_run,
+            salvaged: salvage_text(child_messages),
             tool_count: tool_uses,
             tokens_used: tokens_used,
             worktree: worktree_info,
@@ -1945,7 +1957,7 @@ defmodule OptimalSystemAgent.Orchestrator do
   @spec start_stall_watcher(String.t(), String.t(), String.t(), String.t()) :: :ok
   def start_stall_watcher(parent_id, subagent_id, display_name, role) do
     Task.Supervisor.start_child(OptimalSystemAgent.TaskSupervisor, fn ->
-      watch_for_stall(parent_id, subagent_id, display_name, role, nil, now_ms())
+      watch_for_stall(parent_id, subagent_id, display_name, role, nil, progressing())
     end)
 
     :ok
@@ -1955,7 +1967,39 @@ defmodule OptimalSystemAgent.Orchestrator do
     :exit, _ -> :ok
   end
 
-  defp watch_for_stall(parent_id, subagent_id, display_name, role, last_print, last_change_at) do
+  # Backoff for repeat stall reports.
+  #
+  # Every report costs the parent a turn: it wakes up, reads the alert, and
+  # decides. A truly wedged child used to generate one of those every threshold
+  # period forever — the transcript that prompted this had the same "no progress
+  # for 15 minutes" line five times over, each one interrupting the parent with
+  # information it already had. The observation still continues (a stall that
+  # ends must be noticed), but the *reporting* rate decays: threshold, 2x,
+  # 4x, ... capped so the parent is never told more than once an hour about a
+  # stall it has already been told about.
+  @max_stall_report_gap_ms 60 * 60 * 1000
+
+  defp stall_report_gap_ms(phase, reports) do
+    base = stall_threshold_ms(phase)
+    # Cap the shift before computing so a long-lived watcher cannot build a
+    # bignum here.
+    scale = Bitwise.bsl(1, min(reports, 16))
+    min(base * scale, max(@max_stall_report_gap_ms, base))
+  end
+
+  # `stall` carries the watcher's own state, separate from the run's:
+  #
+  #   :last_change_at - when the run's fingerprint last moved OR when we last
+  #                     reported. This is the report clock only.
+  #   :since          - the FIRST moment progress stopped, nil while progressing.
+  #                     Reports are measured from here so they ESCALATE; measuring
+  #                     from :last_change_at made every report say the same
+  #                     "15 minutes" no matter how long the stall had really
+  #                     lasted, so an operator could not tell a fresh stall from
+  #                     a two-hour-old one.
+  #   :reports        - how many times we have already reported THIS stall, which
+  #                     drives the backoff above. Reset whenever work lands.
+  defp watch_for_stall(parent_id, subagent_id, display_name, role, last_print, stall) do
     Process.sleep(stall_poll_interval_ms())
 
     case RunStore.get(subagent_id) do
@@ -1968,7 +2012,7 @@ defmodule OptimalSystemAgent.Orchestrator do
       # life — the one component that could have explained the silence was the
       # first thing the silence took out.)
       %{status: :running, phase: :queued} ->
-        watch_for_stall(parent_id, subagent_id, display_name, role, last_print, now_ms())
+        watch_for_stall(parent_id, subagent_id, display_name, role, last_print, progressing())
 
       %{status: :running} = run ->
         print = progress_fingerprint(run)
@@ -1976,16 +2020,18 @@ defmodule OptimalSystemAgent.Orchestrator do
 
         cond do
           print != last_print ->
-            watch_for_stall(parent_id, subagent_id, display_name, role, print, now_ms())
+            watch_for_stall(parent_id, subagent_id, display_name, role, print, progressing())
 
-          now_ms() - last_change_at >= stall_threshold_ms(phase) ->
+          now_ms() - stall.last_change_at >= stall_report_gap_ms(phase, stall.reports) ->
+            since = stall.since || stall.last_change_at
+
             emit_stall(
               parent_id,
               subagent_id,
               display_name,
               role,
               phase,
-              now_ms() - last_change_at,
+              now_ms() - since,
               run
             )
 
@@ -1996,13 +2042,17 @@ defmodule OptimalSystemAgent.Orchestrator do
             # after — including a run that recovered and stalled again, and
             # including one that never came back at all. Continuing costs one
             # poll every 30s and means the observation keeps up with reality.
-            # The change clock is reset to NOW so the next report cannot come
-            # until another full threshold has elapsed — one report per
-            # threshold period, not one per 30-second poll.
-            watch_for_stall(parent_id, subagent_id, display_name, role, print, now_ms())
+            watch_for_stall(parent_id, subagent_id, display_name, role, print, %{
+              last_change_at: now_ms(),
+              since: since,
+              reports: stall.reports + 1
+            })
 
           true ->
-            watch_for_stall(parent_id, subagent_id, display_name, role, print, last_change_at)
+            watch_for_stall(parent_id, subagent_id, display_name, role, print, %{
+              stall
+              | since: stall.since || stall.last_change_at
+            })
         end
 
       # Terminal, or the row was pruned: nothing left to watch.
@@ -2014,6 +2064,10 @@ defmodule OptimalSystemAgent.Orchestrator do
   catch
     :exit, _ -> :ok
   end
+
+  # Fresh watcher state: work just landed (or is yet to land), so nothing is
+  # stalled and any earlier stall's backoff is forgotten.
+  defp progressing, do: %{last_change_at: now_ms(), since: nil, reports: 0}
 
   defp progress_fingerprint(run) do
     {Map.get(run, :tool_count, 0), Map.get(run, :tokens_used, 0),
@@ -2220,9 +2274,13 @@ defmodule OptimalSystemAgent.Orchestrator do
       parent_session_id: parent_id,
       role: role,
       status: status,
-      summary: "Subagent #{role} #{verb}: #{failure_reason_text(reason)}",
+      summary:
+        with_salvage(
+          "Subagent #{role} #{verb}: #{failure_reason_text(reason)}",
+          Keyword.get(opts, :salvaged)
+        ),
       files_changed: Keyword.get(opts, :files_changed, []),
-      commands_run: [],
+      commands_run: Keyword.get(opts, :commands_run, []),
       tool_count: Keyword.get(opts, :tool_count, 0),
       tokens_used: Keyword.get(opts, :tokens_used, 0),
       duration_ms: Keyword.get(opts, :duration_ms, 0),
@@ -2231,6 +2289,45 @@ defmodule OptimalSystemAgent.Orchestrator do
       resumed_from: Keyword.get(opts, :resumed_from)
     })
   end
+
+  # A subagent that fails at the END of its work has still DONE the work, and
+  # the parent needs to know that before it decides to re-dispatch. The case
+  # that motivated this: a background agent built 67 pages, ran 157 passing
+  # tests and reached zero type errors, then tripped a join timeout while
+  # writing its final report — and the only thing the parent was told was
+  # "failed after 7205022ms: :timeout". It had no way to learn that the task
+  # was in fact complete, so the obvious next move was to redo all of it.
+  defp with_salvage(summary, nil), do: summary
+  defp with_salvage(summary, ""), do: summary
+
+  defp with_salvage(summary, salvaged) when is_binary(salvaged) do
+    summary <>
+      "\n\nWork recorded before it stopped (recovered from the transcript, " <>
+      "may be incomplete):\n" <> salvaged
+  end
+
+  defp with_salvage(summary, _), do: summary
+
+  @salvage_limit 4_000
+
+  @doc false
+  @spec salvage_text([map()]) :: String.t() | nil
+  def salvage_text(messages) when is_list(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %{role: "assistant", content: content} when is_binary(content) ->
+        case String.trim(content) do
+          "" -> nil
+          text -> String.slice(text, 0, @salvage_limit)
+        end
+
+      _ ->
+        nil
+    end)
+  end
+
+  def salvage_text(_), do: nil
 
   @doc """
   Terminal `RunStore` status for a non-completion reason.

--- a/test/optimal_system_agent/tools/delegation_visibility_test.exs
+++ b/test/optimal_system_agent/tools/delegation_visibility_test.exs
@@ -164,6 +164,63 @@ defmodule OptimalSystemAgent.Tools.DelegationVisibilityTest do
       refute_received {:osa_event, %{type: :background_agent_stalled}}
     end
 
+    test "repeat reports escalate and back off instead of repeating one number" do
+      # BEFORE: every report measured from `last_change_at`, which the watcher
+      # reset each time it reported — so a stall of any age always announced the
+      # threshold ("no progress for 15 minutes", five times over), and it
+      # announced it once per threshold period forever, costing the parent a
+      # turn each time.
+      parent_id = "stall-parent-#{System.unique_integer([:positive])}"
+      agent_id = "agent:#{parent_id}:1"
+
+      Phoenix.PubSub.subscribe(OptimalSystemAgent.PubSub, "osa:session:#{parent_id}")
+      start_run(parent_id, agent_id)
+      Orchestrator.start_stall_watcher(parent_id, agent_id, "worker", "background")
+
+      assert_receive {:osa_event, %{type: :background_agent_stalled} = first}, 2_000
+      assert_receive {:osa_event, %{type: :background_agent_stalled} = second}, 2_000
+
+      # Escalation: the stall is measured from when progress actually stopped,
+      # so each report is strictly older than the last.
+      assert second.stalled_ms > first.stalled_ms
+
+      # Backoff: the second report waited at least twice the threshold (40ms)
+      # after the first, rather than one threshold period.
+      assert second.stalled_ms - first.stalled_ms >= 80
+
+      OptimalSystemAgent.Agent.RunStore.complete(agent_id, %{
+        agent_id: agent_id,
+        status: :completed,
+        summary: "done",
+        duration_ms: 1
+      })
+    end
+
+    test "progress resets the backoff so a new stall reports promptly" do
+      parent_id = "stall-parent-#{System.unique_integer([:positive])}"
+      agent_id = "agent:#{parent_id}:1"
+
+      Phoenix.PubSub.subscribe(OptimalSystemAgent.PubSub, "osa:session:#{parent_id}")
+      start_run(parent_id, agent_id)
+      Orchestrator.start_stall_watcher(parent_id, agent_id, "worker", "background")
+
+      assert_receive {:osa_event, %{type: :background_agent_stalled} = first}, 2_000
+
+      # Work lands: the stall is over, so the NEXT stall must be timed from
+      # scratch, not continue the previous stall's clock or its backoff.
+      OptimalSystemAgent.Agent.RunStore.progress(agent_id, "recovered", 1)
+
+      assert_receive {:osa_event, %{type: :background_agent_stalled} = fresh}, 2_000
+      assert fresh.stalled_ms < first.stalled_ms + 500
+
+      OptimalSystemAgent.Agent.RunStore.complete(agent_id, %{
+        agent_id: agent_id,
+        status: :completed,
+        summary: "done",
+        duration_ms: 1
+      })
+    end
+
     test "the watcher stops once the run reaches a terminal status" do
       parent_id = "stall-parent-#{System.unique_integer([:positive])}"
       agent_id = "agent:#{parent_id}:1"
@@ -202,6 +259,47 @@ defmodule OptimalSystemAgent.Tools.DelegationVisibilityTest do
     test "a run with no recorded spend reports 0.0, never crashes" do
       assert Orchestrator.run_cost_usd("no-such-run-#{System.unique_integer([:positive])}") == 0.0
       assert Orchestrator.run_cost_usd(nil) == 0.0
+    end
+  end
+
+  describe "salvaging a failed run's completed work" do
+    test "salvage_text/1 returns the child's last assistant text" do
+      messages = [
+        %{role: "user", content: "build it"},
+        %{role: "assistant", content: "starting"},
+        %{role: "assistant", content: "157 beta tests pass. Zero TypeScript errors."}
+      ]
+
+      assert Orchestrator.salvage_text(messages) =~ "157 beta tests pass"
+    end
+
+    test "salvage_text/1 ignores blank trailing turns and bad input" do
+      assert Orchestrator.salvage_text([%{role: "assistant", content: "   "}]) == nil
+      assert Orchestrator.salvage_text([%{role: "user", content: "hi"}]) == nil
+      assert Orchestrator.salvage_text(nil) == nil
+    end
+
+    test "a timed-out run reports the work it finished, not just :timeout" do
+      # BEFORE: the parent was told only "failed after 7205022ms: :timeout" for a
+      # child that had in fact completed the task, so re-doing all of it looked
+      # like the only option.
+      result =
+        Orchestrator.failure_result("agent:1", "parent", "background", :timeout,
+          commands_run: ["npm test"],
+          salvaged: "157 beta tests pass. Zero TypeScript errors."
+        )
+
+      assert result.status == :failed
+      assert result.summary =~ "157 beta tests pass"
+      assert result.summary =~ "may be incomplete"
+      assert result.commands_run == ["npm test"]
+    end
+
+    test "a failure with nothing to salvage reads exactly as it did before" do
+      result = Orchestrator.failure_result("agent:1", "parent", "background", :timeout)
+
+      refute result.summary =~ "Work recorded"
+      assert result.commands_run == []
     end
   end
 end


### PR DESCRIPTION
A background agent finished its task - 67 pages built, 157 tests passing, zero type errors, every route returning 200 - and was reported to its parent as `failed after 7205022ms: :timeout`, with all of that work discarded. Four independent ceilings stacked up to produce that.

| # | Ceiling | Before | After |
|---|---------|--------|-------|
| 1 | LLM stream idle timeout | 5 min, hard-coded | 30 min, `:llm_stream_idle_timeout_ms` |
| 2 | Subagent join backstop | 2 h | 12 h, still overridable per call |
| 3 | Stall report age | always re-read as the threshold | measured from when progress stopped |
| 4 | Repeat stall reports | one parent turn per threshold, forever | backs off 1x, 2x, 4x, capped hourly |

(1) is the root cause: the stream went silent for 300s while the agent wrote its final report, and the last partial is mid-sentence.

(3) happened because the watcher reset `last_change_at` on every report and then measured the next report from it, so a two-hour-old stall still announced "15 minutes".

Additionally, `failure_result/5` now carries the work the child did finish - its last assistant text and the commands it actually ran - so a parent told "timeout" can see the task was already complete rather than redoing all of it.

Watcher state is now one map (`last_change_at` / `since` / `reports`) instead of three positional args.

## Tests
4 new tests in `delegation_visibility_test.exs` covering escalation, backoff, backoff reset on progress, and salvage (including the no-salvage case reading exactly as before). Suite: 15/15 in that file; full run shows no new failures outside the known macOS-environment set.