### PR TITLE
fix: repair UTF-8 mojibake for all providers at one chokepoint

### DIFF
--- a/lib/optimal_system_agent/agent/loop/llm_client.ex
+++ b/lib/optimal_system_agent/agent/loop/llm_client.ex
@@ -12,6 +12,7 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
   alias OptimalSystemAgent.Events.Bus
   alias OptimalSystemAgent.Providers.Resilience
   alias OptimalSystemAgent.Agent.Trajectory
+  alias OptimalSystemAgent.Utils.Mojibake
 
   # If no streaming token arrives for this long, the connection is treated as
   # dead. NOT a total-duration cap — an active stream can run indefinitely.
@@ -281,6 +282,16 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
     callback = fn
       {:text_delta, text} ->
         :atomics.add(heartbeat, 1, 1)
+        # Every provider's streamed text funnels through here before it reaches
+        # the screen, the partial buffer, or the persisted transcript — so this
+        # is the ONE place to undo the UTF-8-as-Latin-1 corruption some backends
+        # emit (an em-dash arriving as the bytes for "â€""). Doing it per
+        # provider left gaps: the local Ollama path repaired, its cloud path
+        # (glm-*:cloud) did not, and every other provider not at all. `repair/1`
+        # is conservative — it only rewrites text that re-decodes to valid UTF-8
+        # with fewer mojibake markers, so clean tokens and legitimately accented
+        # text pass through untouched.
+        text = Mojibake.repair(text)
         # One-way door: this byte is about to be on the user's screen. Past this
         # point a same-provider retry would re-emit it into the SAME live
         # callback and the user would watch the paragraph appear twice, so the
@@ -330,6 +341,21 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
       {:done, result} ->
         :atomics.add(heartbeat, 1, 1)
         Logger.debug("[stream] done → session:#{session_id}")
+
+        # Repair the FINAL assembled content, not just the live deltas. This is
+        # the string that is persisted to the transcript and re-rendered on
+        # resume; the deltas above fix the live view, this fixes the copy that
+        # outlives the turn. A provider that sends all its content in one final
+        # chunk (some cloud models do) is only covered here.
+        result =
+          case result do
+            %{content: content} when is_binary(content) ->
+              %{result | content: Mojibake.repair(content)}
+
+            _ ->
+              result
+          end
+
         # Broadcast token usage via PubSub for TUI status bar
         # `|| %{}`: a provider that reports `usage: nil` is a present key, so
         # the Map.get/3 default does not fire and the `usage != %{}` guard
@@ -365,7 +391,7 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
         # read — .env dumps, Authorization headers, key material. It lands in
         # terminal scrollback and in persisted session state, so it gets the
         # same redaction every other user-visible provider text gets.
-        text = Trajectory.redact(text)
+        text = text |> Mojibake.repair() |> Trajectory.redact()
 
         Bus.emit(:system_event, %{
           event: :thinking_delta,

--- a/test/optimal_system_agent/utils/mojibake_test.exs
+++ b/test/optimal_system_agent/utils/mojibake_test.exs
@@ -24,4 +24,21 @@ defmodule OptimalSystemAgent.Utils.MojibakeTest do
   test "repairs the single-pass form whose controls render as a lone a-circumflex" do
     assert Mojibake.repair("paused â I spent time") == "paused — I spent time"
   end
+
+  # The exact production failure: glm-*:cloud (and other backends) emit an
+  # em-dash's UTF-8 bytes (E2 80 94) already reinterpreted as Latin-1 and
+  # re-encoded, so each byte becomes its own two-byte UTF-8 char. Pin the raw
+  # byte sequence so a future refactor of the marker heuristic cannot silently
+  # stop repairing the case that prompted the fix.
+  test "reverses a byte-for-byte double-encoded em-dash" do
+    corrupt =
+      <<0xE2, 0x80, 0x94>>
+      |> :binary.bin_to_list()
+      |> Enum.map_join(fn b -> <<b::utf8>> end)
+
+    assert String.valid?(corrupt),
+           "the corruption is valid UTF-8, which is why it survives to display"
+
+    assert Mojibake.repair(corrupt) == <<0xE2, 0x80, 0x94>>
+  end
 end


### PR DESCRIPTION
Backends sometimes emit a char's UTF-8 bytes already reinterpreted as Latin-1 and re-encoded — an em-dash `E2 80 94` arriving as the bytes that render `â`. The bytes are valid UTF-8, so nothing flags them and the corruption reaches both the screen and the persisted transcript. Seen live on `glm-*:cloud` and in a background agent's re-read transcript.

`Mojibake.repair` already reverses this (and is well-tested), but was applied on only 3 paths — the **local** Ollama NDJSON path and two transcript read-back paths — so the Ollama **cloud** path and every other provider went unrepaired.

## Fix
Move repair to the single chokepoint every provider funnels through: the `LLMClient` stream callback.
- `text_delta` / `thinking_delta` → fix the live view
- `done` → repair the final assembled content (the copy persisted + re-rendered on resume; also covers models that send all content in one final chunk)

`repair/1` is conservative: it only rewrites text that re-decodes to valid UTF-8 with *fewer* mojibake markers, so clean tokens and legitimately accented text pass untouched.

Read-side repairs stay — they fix transcripts already saved corrupt. This stops **new** corruption for **all models**.

## Tests
New byte-level regression pinning the exact production sequence (double-encoded em-dash → `—`). Existing 5 mojibake tests + 443 loop tests pass.