### PR TITLE
fix(tui): request timeout is an idle guard, not a total-turn cap

### DIFF
--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -139,6 +139,15 @@ impl App {
     }
 
     pub(super) fn handle_backend_event(&mut self, event: BackendEvent) -> bool {
+        // Any event from the backend is proof of life for the active turn, so
+        // it resets the request-timeout idle clock. This is what lets a long
+        // but healthy turn survive — most importantly a goal-verifier skeptic
+        // panel, whose subagents each run several minutes and emit lifecycle /
+        // LLM events throughout. Harmless when no turn is processing: the
+        // timeout check is gated on `is_processing()`, and a fresh turn's
+        // `processing_start` dominates any stale value (see the `since`
+        // computation in `update.rs`).
+        self.last_turn_activity = Some(std::time::Instant::now());
         match event {
             BackendEvent::HealthResult(result) => {
                 self.handle_health_result(result);

--- a/priv/rust/tui/src/app/mod.rs
+++ b/priv/rust/tui/src/app/mod.rs
@@ -264,6 +264,15 @@ pub struct App {
     pub pace_msg_id: Option<String>,
     pub thinking_buf: String,
     pub processing_start: Option<Instant>,
+    /// Last moment the backend showed turn progress (a token, a tool
+    /// heartbeat, an LLM request/response, a goal-verify status). The request
+    /// timeout is measured from HERE, not `processing_start`, so it is an IDLE
+    /// guard against a silent backend rather than a total-turn guillotine —
+    /// which is what its own doc always claimed it was. A long but healthy
+    /// turn (e.g. a multi-call goal-verifier skeptic panel) keeps resetting
+    /// this and is never killed; only genuine silence trips the timeout.
+    /// `processing_start` stays put so the elapsed-time display is unaffected.
+    pub last_turn_activity: Option<Instant>,
     /// Spinner-clock elapsed captured at the agent_response turn-end edge (just
     /// before `activity.stop()`), consumed by the trailing turn_recap event so
     /// "✻ Worked for Ns" prints the same number the live spinner last showed —
@@ -806,6 +815,7 @@ impl App {
             pace_msg_id: None,
             thinking_buf: String::new(),
             processing_start: None,
+            last_turn_activity: None,
             last_turn_client_elapsed_secs: None,
             last_submitted_prompt: None,
             cancelled: false,

--- a/priv/rust/tui/src/app/update.rs
+++ b/priv/rust/tui/src/app/update.rs
@@ -96,6 +96,24 @@ fn is_overlay_dismiss(key: crossterm::event::KeyEvent) -> bool {
     )
 }
 
+/// Reference instant the request-timeout idle clock is measured from.
+///
+/// The LATER of `processing_start` and the last backend activity: a fresh
+/// turn's `processing_start` is `now`, so it dominates any stale activity
+/// timestamp from a previous turn (no false immediate timeout); activity
+/// landing DURING this turn is more recent, so it dominates `processing_start`
+/// and keeps a healthy long turn (e.g. a multi-minute goal-verifier skeptic
+/// panel) alive. Only genuine silence lets the clock run out.
+fn timeout_since(
+    processing_start: std::time::Instant,
+    last_turn_activity: Option<std::time::Instant>,
+) -> std::time::Instant {
+    match last_turn_activity {
+        Some(a) if a > processing_start => a,
+        _ => processing_start,
+    }
+}
+
 impl App {
     /// Main update function. Returns true if the app should quit.
     pub fn update(&mut self, event: Event) -> bool {
@@ -1575,7 +1593,9 @@ impl App {
 
         if self.state.is_processing() {
             if let Some(start) = self.processing_start {
-                let elapsed = start.elapsed();
+                // Measure IDLE time, not total turn time. See `timeout_since`.
+                let since = timeout_since(start, self.last_turn_activity);
+                let elapsed = since.elapsed();
                 let timeout_secs = self.config.request_timeout_secs;
                 let warning_secs = (timeout_secs * 4) / 5; // 80% threshold
 
@@ -1684,5 +1704,37 @@ mod paste_path_tests {
         let s = path.to_string_lossy().to_string();
         assert!(paste_is_file_paths(&s));
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn timeout_measures_from_recent_activity_not_turn_start() {
+        use std::time::{Duration, Instant};
+        // Turn started a while ago, but the backend spoke recently: the clock
+        // is measured from the recent activity, so a healthy long turn is not
+        // killed.
+        let start = Instant::now() - Duration::from_secs(1000);
+        let recent = Instant::now() - Duration::from_secs(2);
+        let since = super::timeout_since(start, Some(recent));
+        assert!(since.elapsed() < Duration::from_secs(10));
+    }
+
+    #[test]
+    fn timeout_ignores_stale_activity_from_a_previous_turn() {
+        use std::time::{Duration, Instant};
+        // A fresh turn (start = now) with a leftover activity timestamp from
+        // before it must measure from the fresh start, not the stale value —
+        // otherwise the turn would time out the instant it began.
+        let start = Instant::now();
+        let stale = Instant::now() - Duration::from_secs(5000);
+        let since = super::timeout_since(start, Some(stale));
+        assert_eq!(since, start);
+    }
+
+    #[test]
+    fn timeout_falls_back_to_start_when_no_activity_yet() {
+        use std::time::{Duration, Instant};
+        let start = Instant::now() - Duration::from_secs(3);
+        let since = super::timeout_since(start, None);
+        assert_eq!(since, start);
     }
 }


### PR DESCRIPTION
A `/goal` auto-continue kept pausing with **"the turn timed out before completing"** while the goal-verifier skeptic panel was running.

## Cause
The TUI's client-side request timeout measured wall-clock from `processing_start` (turn start). When it fired during a goal turn it cancelled the SSE and **paused the goal**. But a skeptic panel runs several subagents back-to-back — observed `@goal-skeptic-*-correctness ended · 4m 10s` ×3 — which, on top of the turn's own generation, blows past the ceiling. So a healthy verification got guillotined. (On v1.0.122 the ceiling is 900s/15min, making it trivial to hit.) The timeout's own doc calls it "a guard against a backend that has stopped answering" — an *idle* guard — but it was implemented as a total-turn cap.

## Fix
- Track `last_turn_activity`, reset on **every** backend event (any event = backend is alive: tokens, tool heartbeats, LLM req/resp, goal-verify status, skeptic-subagent lifecycle).
- Measure the timeout from `max(processing_start, last_turn_activity)` via `timeout_since/2`: a fresh turn's `processing_start` dominates stale values (no false immediate timeout); in-turn activity dominates `processing_start` (a live long turn is never killed). Only genuine silence trips it.
- `processing_start` untouched → elapsed-time display unchanged.

## Tests
3 new for `timeout_since` (recent activity dominates, stale timestamp ignored, no-activity fallback). Full TUI suite: 1522 pass.