### PR TITLE
fix(goal-verifier): infra failures abstain instead of counting as refutes

### DIFF
--- a/lib/optimal_system_agent/agent/loop/goal_verifier.ex
+++ b/lib/optimal_system_agent/agent/loop/goal_verifier.ex
@@ -140,7 +140,18 @@ defmodule OptimalSystemAgent.Agent.Loop.GoalVerifier do
   # Wall-clock bound for a SINGLE skeptic (env-overridable via
   # `:goal_verifier_skeptic_timeout_ms`). See `panel_runner/0` for why the
   # generic subagent backstop is the wrong bound here.
-  @default_skeptic_timeout_ms 120_000
+  #
+  # Raised from 120s. A skeptic is not a classification call — it reads the
+  # repo (file_grep / file_glob / file_read) to judge the work, and on a slower
+  # cloud model that legitimately takes several minutes. At 120s the panel was
+  # reaped mid-search on every real engagement, and because a reaped skeptic
+  # counts as a non-vote (see `aggregate/1`), the panel returned no verdict and
+  # the goal could not be judged. The turn-level timeout is idle-based (it
+  # resets on any backend activity), so a panel that runs for minutes no longer
+  # risks killing the turn — which is what made the tight bound necessary
+  # before. Ten minutes gives a real review room to finish; override down for
+  # a fast local model.
+  @default_skeptic_timeout_ms 600_000
 
   # Tool inventory available to a skeptic (must stay a subset of ToolExecutor's
   # :read_only tier — enforced again, redundantly, by
@@ -1274,22 +1285,45 @@ defmodule OptimalSystemAgent.Agent.Loop.GoalVerifier do
   end
 
   defp aggregate(results) do
-    total = length(results)
-    refuters = Enum.filter(results, & &1.refuted)
-    refuted_count = length(refuters)
-    needed = div(total, 2) + 1
+    # A skeptic that CRASHED or TIMED OUT produced no judgment about the WORK -
+    # only about the harness. `parse_skeptic_result/1` flags those `internal:
+    # true`. They used to be counted as substantive refutes, which meant a slow
+    # or flaky provider masqueraded as "your work is incomplete": on a slow
+    # cloud model two reaped skeptics were two "refutes", the majority tipped to
+    # :incomplete, and the goal could NEVER be judged complete no matter how
+    # finished it was. Decide the verdict only among skeptics that actually
+    # returned a verdict; a non-vote is not a vote against completion.
+    votes = Enum.reject(results, &(&1[:internal] == true))
 
-    cond do
-      refuted_count >= needed and majority_off_track?(refuters, needed) ->
-        {refuted_count, total, :off_track, off_track_reason(refuters), gap_list(refuters)}
+    case votes do
+      [] ->
+        # Every skeptic failed to produce a real verdict. We still cannot vouch
+        # for completion - nothing reviewed the work - so fail closed, but name
+        # it an infrastructure failure (not a substantive gap) so the tracker
+        # retries verification instead of churning the goal as if work were
+        # missing.
+        {0, length(results), :incomplete,
+         "verification could not run: no skeptic returned a verdict " <>
+           "(infrastructure failure, not a finding) - will retry", []}
 
-      refuted_count >= needed ->
-        {refuted_count, total, :incomplete, incomplete_reason(refuted_count, total),
-         gap_list(refuters)}
+      votes ->
+        total = length(votes)
+        refuters = Enum.filter(votes, & &1.refuted)
+        refuted_count = length(refuters)
+        needed = div(total, 2) + 1
 
-      true ->
-        {refuted_count, total, :complete,
-         "#{total - refuted_count}/#{total} skeptics found the goal met", []}
+        cond do
+          refuted_count >= needed and majority_off_track?(refuters, needed) ->
+            {refuted_count, total, :off_track, off_track_reason(refuters), gap_list(refuters)}
+
+          refuted_count >= needed ->
+            {refuted_count, total, :incomplete, incomplete_reason(refuted_count, total),
+             gap_list(refuters)}
+
+          true ->
+            {refuted_count, total, :complete,
+             "#{total - refuted_count}/#{total} skeptics found the goal met", []}
+        end
     end
   end
 

--- a/test/optimal_system_agent/agent/loop/goal_verifier_test.exs
+++ b/test/optimal_system_agent/agent/loop/goal_verifier_test.exs
@@ -247,19 +247,56 @@ defmodule OptimalSystemAgent.Agent.Loop.GoalVerifierTest do
       assert result.refuted_count == 1
     end
 
-    test "a crashed/errored skeptic counts as a refute, not silently dropped", %{
+    test "a crashed/timed-out skeptic ABSTAINS — it is excluded, not counted as a refute", %{
       session_id: sid
     } do
+      # A crash/timeout is a harness failure, not a judgment about the work.
+      # Counting it as a refute let a slow provider permanently block a goal
+      # from ever completing. The real votes decide: here a genuine majority
+      # still refutes, and the excluded infra failure is not in the tally.
       mark_write(sid)
 
       stub_runner(fn _sid, _configs ->
-        [{:error, :timeout}, json_result(true), json_result(false)]
+        [{:error, :timeout}, json_result(true), json_result(true)]
       end)
 
       {result, _state} = GoalVerifier.verify(base_state(sid))
 
       assert result.refuted_count == 2
+      assert result.total == 2, "the timed-out skeptic is excluded from the denominator"
       assert result.verdict == :incomplete
+    end
+
+    test "an infra failure does not tip a genuine pass to incomplete", %{session_id: sid} do
+      # THE regression this fixes: with two of three skeptics reaped on a slow
+      # model, the old tally counted both as refutes (2/3) and the goal could
+      # never be judged complete. Now the single real vote — a pass — decides.
+      mark_write(sid)
+
+      stub_runner(fn _sid, _configs ->
+        [{:error, :timeout}, {:error, :timeout}, json_result(false)]
+      end)
+
+      {result, _state} = GoalVerifier.verify(base_state(sid))
+
+      assert result.verdict == :complete,
+             "two infra failures must not masquerade as 'work incomplete' over a real pass"
+
+      assert result.refuted_count == 0
+      assert result.total == 1
+    end
+
+    test "a fully-failed panel fails closed but names it as infrastructure", %{session_id: sid} do
+      mark_write(sid)
+
+      stub_runner(fn _sid, _configs ->
+        [{:error, :timeout}, {:error, :timeout}, {:error, :timeout}]
+      end)
+
+      {result, _state} = GoalVerifier.verify(base_state(sid))
+
+      assert result.verdict == :incomplete
+      assert result.reason =~ "infrastructure"
     end
 
     test "empty panel result fails closed to :incomplete", %{session_id: sid} do
@@ -797,9 +834,11 @@ defmodule OptimalSystemAgent.Agent.Loop.GoalVerifierTest do
 
       {result, _state} = GoalVerifier.verify(base_state(sid))
 
-      # Still fail-closed on the VOTE — nothing vouched for completion.
+      # Still fail-closed on the VOTE — the two returned-but-unparseable
+      # responses count (a model that answered garbage did not vouch for
+      # completion), while the timed-out skeptic abstains and is excluded.
       assert result.verdict == :incomplete
-      assert result.refuted_count == 3
+      assert result.refuted_count == 2
 
       assert_receive {:goal_verifier_event, %{phase: :start}}, 2000
       assert_receive {:goal_verifier_event, %{phase: :done} = done}, 2000


### PR DESCRIPTION
## The real bug behind "it verifies forever but never completes"

The goal-verifier lifecycle worked, but its **failure policy** made a goal un-completable on a slow model. Each skeptic that crashed or timed out became `%{refuted: true, internal: true}`, and `aggregate/1` counted those harness failures in the **same tally** as real evidence-based refutes. On `glm-5.2:cloud`, where read-only skeptics are slow and get reaped mid-search, the panel saw "2 of 3 refuted" → `:incomplete` → the goal could never be judged done, however finished it was.

Observed: `@goal-skeptic-*-completeness failed · 2h` — a reaped skeptic voting "incomplete" purely because it was slow.

## Fix
- **A timeout is not evidence of incompleteness.** `aggregate/1` now decides the verdict only among skeptics that actually returned one (`internal: false`); crash/timeout (`{:error,_}`) failures are excluded from numerator and denominator. A returned-but-unparseable answer still counts (the model responded and didn't vouch); only a true crash/timeout abstains.
- **Whole-panel failure** still fails closed (nothing reviewed the work) but is labelled infrastructure so the tracker retries verification instead of churning the goal.
- **Per-skeptic timeout 120s → 600s.** A skeptic reads the repo to judge; 120s reaped it mid-search on every real engagement. Safe now that the turn timeout is idle-based (#140).

## Tests
227 goal tests green, incl. new: infra failure abstains; two infra failures don't tip a real pass to incomplete; fully-failed panel fails closed as infrastructure.