### PR TITLE
perf(boot): defer LoopControl restore off the boot path (~1.1s)

### DIFF
--- a/lib/optimal_system_agent/agent/loop_control.ex
+++ b/lib/optimal_system_agent/agent/loop_control.ex
@@ -48,7 +48,19 @@ defmodule OptimalSystemAgent.Agent.LoopControl do
 
   @impl true
   def init(_) do
-    {:ok, restore_all()}
+    # Return immediately and restore durable /loop timers in handle_continue.
+    # restore_all/0 lists up to 1000 sessions and runs a load_inbox DB query
+    # per session; doing that synchronously here blocked boot for ~1.1s (it
+    # was the single slowest child in the supervision tree). handle_continue
+    # runs as this process's first message — before any /loop call can be
+    # handled — so restored state is in place by the time anything reads it,
+    # while the supervisor is free to start the rest of the tree meanwhile.
+    {:ok, %{}, {:continue, :restore}}
+  end
+
+  @impl true
+  def handle_continue(:restore, _state) do
+    {:noreply, restore_all()}
   end
 
   @impl true

--- a/test/optimal_system_agent/agent/loop_control_test.exs
+++ b/test/optimal_system_agent/agent/loop_control_test.exs
@@ -59,7 +59,10 @@ defmodule OptimalSystemAgent.Agent.LoopControlTest do
     assert :ok = SessionPersistence.save_inbox(session_id, :operator_loop, [stored])
     on_exit(fn -> SessionPersistence.save_inbox(session_id, :operator_loop, []) end)
 
-    assert {:ok, restored} = LoopControl.init(%{})
+    # Restore runs in handle_continue now (kept off the boot path); init just
+    # arms the continue. Drive the restore directly.
+    assert {:ok, %{}, {:continue, :restore}} = LoopControl.init(%{})
+    assert {:noreply, restored} = LoopControl.handle_continue(:restore, %{})
     assert %{timer_ref: nil, last_tick_status: "dispatching"} = restored[session_id]
   end
 end


### PR DESCRIPTION
## Measured boot budget (before)
`LoopControl` was the single slowest child in the supervision tree at **~1125ms** — because `init/1` ran `restore_all/0` synchronously: a `SessionPersistence.list(limit: 1000)` plus a `load_inbox` DB query **per session**. Since `AgentServices` starts `rest_for_one` after `Infrastructure`, that 1.1s was pure wall-clock boot latency.

## Fix
Move the restore to `handle_continue(:restore, …)`: `init` returns immediately (supervisor proceeds to start the rest of the tree), and the restore runs as the process's first message — before any `/loop` call can be handled, so restored timer state is always in place before anything reads it.

## Measured (after)
The **AgentServices subsystem dropped from ~1305ms → ~109ms** at boot.

## Remaining boot targets (follow-ups, not in this PR)
`Infrastructure/Tools.Registry` ~600ms and `Providers.Registry` ~320ms are the next-biggest, but they're riskier to defer (tools/providers must be ready before the first turn). Store.Repo (migrations) is one-time.

Tests: LoopControl suite 4/4 (updated to drive the restore via `handle_continue`).