### PR TITLE
perf(boot): fast-poll backend on cold start (kills the 'warming backend' wait)

### DIFF
--- a/priv/rust/tui/src/client/sse.rs
+++ b/priv/rust/tui/src/client/sse.rs
@@ -11,6 +11,14 @@ use crate::event::backend::BackendEvent;
 use crate::event::Event;
 
 const MAX_RECONNECTS: u32 = 10;
+
+// Cold-start warm-up: until the stream has EVER attached, the backend is
+// presumed to be still booting, so poll fast and attach the instant it answers
+// instead of sleeping out the mid-session exponential backoff (which starts at
+// 2s and cascaded a ~2.3s boot into a ~6s wait). Time-bounded rather than
+// attempt-bounded so a slow boot still succeeds: 250ms x 120 = a 30s window.
+const WARMUP_POLL: Duration = Duration::from_millis(250);
+const WARMUP_MAX_POLLS: u32 = 120;
 const MAX_LINE_BYTES: usize = 1024 * 1024; // 1 MB
 
 /// How long an attached stream may go completely silent before we treat it as
@@ -97,6 +105,10 @@ impl SseClient {
 
     async fn run_with_reconnect(&self) {
         let mut attempt: u32 = 0;
+        // Flips true the first time a stream actually attaches. Until then we
+        // are in cold-start warm-up (backend still booting) and poll fast.
+        let mut ever_connected = false;
+        let mut warmup_polls: u32 = 0;
 
         loop {
             if self.cancel.is_cancelled() {
@@ -139,6 +151,47 @@ impl SseClient {
                     return;
                 }
                 Err(SseError::Disconnected { err: e, connected }) => {
+                    if connected {
+                        ever_connected = true;
+                    }
+
+                    // Cold-start warm-up path: the stream has never attached, so
+                    // the backend is still coming up. Poll fast (fixed 250ms) and
+                    // attach the moment it answers, instead of paying the
+                    // mid-session exponential backoff for a process we KNOW is
+                    // booting. Bounded by time (WARMUP_MAX_POLLS) so a backend
+                    // that never comes up still surfaces an honest error.
+                    if !ever_connected {
+                        warmup_polls += 1;
+
+                        if warmup_polls > WARMUP_MAX_POLLS {
+                            error!(
+                                "SSE never attached after {} warm-up polls: {:?}",
+                                WARMUP_MAX_POLLS, e
+                            );
+                            let _ = self.send(BackendEvent::SseDisconnected {
+                                error: Some("exhausted".to_string()),
+                            });
+                            return;
+                        }
+
+                        let _ = self.send(BackendEvent::SseReconnecting {
+                            attempt: warmup_polls,
+                        });
+
+                        tokio::select! {
+                            _ = tokio::time::sleep(WARMUP_POLL) => {}
+                            _ = self.cancel.cancelled() => {
+                                let _ = self.send(BackendEvent::SseDisconnected {
+                                    error: Some("cancelled".to_string()),
+                                });
+                                return;
+                            }
+                        }
+
+                        continue;
+                    }
+
                     // D5: a drop that occurred AFTER the stream attached resets
                     // the budget (a recovered blip must not accumulate toward
                     // exhaustion); only genuine back-to-back connect FAILURES


### PR DESCRIPTION
## The real cost of 'warming OSA backend'
It was mostly the **TUI sleeping**, not the backend booting. On cold start the first SSE connect fails (backend not up yet), and the reconnect used the **mid-session exponential backoff** — 2s → 4s → 8s… — so a backend that became ready ~2.3s in wasn't attached until the **~6s** mark. The backend was up; the client was asleep on a backoff.

## Fix
Until the stream has **ever** attached, treat it as cold-start warm-up: poll every **250ms** and attach the instant the backend answers. Time-bounded (250ms × 120 = a 30s window) so a backend that never comes up still surfaces an honest `exhausted` error. Genuine **mid-session** drops (stream had attached, then dropped) keep the exponential backoff exactly as before.

## Effect
Combined with the LoopControl boot fix (#156), the cold-start experience goes from "backend ready at ~2.3s but attached at ~6s" to "attached within ~250ms of ready."

Full TUI suite: 1522 pass.