### PR TITLE
fix(vision): xAI/z.ai vision flags authoritative in the capability gate

### DIFF
--- a/lib/optimal_system_agent/providers/image_budget.ex
+++ b/lib/optimal_system_agent/providers/image_budget.ex
@@ -328,6 +328,8 @@ defmodule OptimalSystemAgent.Providers.ImageBudget do
     alias OptimalSystemAgent.Providers.GoogleModels
     alias OptimalSystemAgent.Providers.OllamaCloud
     alias OptimalSystemAgent.Providers.OpenAIModels
+    alias OptimalSystemAgent.Providers.XAIModels
+    alias OptimalSystemAgent.Providers.ZaiModels
 
     case provider do
       p when p in [:anthropic, :claude_cli, :bedrock, "anthropic", "claude_cli", "bedrock"] ->
@@ -343,12 +345,23 @@ defmodule OptimalSystemAgent.Providers.ImageBudget do
       p when p in [:ollama_cloud, :ollama, "ollama_cloud", "ollama"] ->
         [OllamaCloud]
 
-      # A gateway serves every vendor, so all four are candidates and the first
+      # xAI (grok-4.x) and z.ai / Zhipu (GLM) both ship first-hand `vision:`
+      # flags OSA maintains, but neither was wired here — so a vision-capable
+      # grok-4.6 or GLM-4.5V fell through to the upstream catalog, and when that
+      # was stale or missing the id, its image was silently dropped. Consult
+      # OSA's own catalogue for them, same as the four above.
+      p when p in [:xai, "xai"] ->
+        [XAIModels]
+
+      p when p in [:zhipu, :zai, :glm, "zhipu", "zai", "glm"] ->
+        [ZaiModels]
+
+      # A gateway serves every vendor, so all candidates are asked and the first
       # that recognises the id answers. This is a union, never a veto: a
       # catalogue that does not know the model returns nil and the next one is
       # asked.
       _ ->
-        [AnthropicModels, OpenAIModels, GoogleModels, OllamaCloud]
+        [AnthropicModels, OpenAIModels, GoogleModels, OllamaCloud, XAIModels, ZaiModels]
     end
   end
 

--- a/test/providers/vision_catalogue_wiring_test.exs
+++ b/test/providers/vision_catalogue_wiring_test.exs
@@ -1,0 +1,29 @@
+defmodule OptimalSystemAgent.Providers.VisionCatalogueWiringTest do
+  @moduledoc """
+  OSA's own `vision:` flags must be the AUTHORITY for every provider whose
+  model catalogue carries them — not just the four originally wired.
+
+  Regression: `vision_catalogues/1` had no clause for `:xai` or `:zhipu`, so a
+  vision-capable grok-4.6 / GLM resolved via `:unknown_default` (fail-open)
+  instead of OSA's first-hand flag. Fail-open happens to allow a vision model,
+  but it also wrongly allows a NON-vision model — the flag existed and was
+  simply unreachable. (A module-name casing bug — XAIModels, not XaiModels —
+  also silently defeated the first wiring.)
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Providers.ImageBudget
+
+  test "grok vision flag is authoritative (osa_catalogue), not fail-open" do
+    assert {true, :osa_catalogue} = ImageBudget.vision_decision(:xai, "grok-4.6")
+    assert {true, :osa_catalogue} = ImageBudget.vision_decision(:xai, "grok-4.5")
+  end
+
+  test "vision_capable? stays true for grok (image is never dropped)" do
+    assert ImageBudget.vision_capable?(:xai, "grok-4.6")
+  end
+
+  test "an unknown model still fails open (ignorance must not drop an image)" do
+    assert {true, :unknown_default} = ImageBudget.vision_decision(:xai, "grok-does-not-exist-9")
+  end
+end


### PR DESCRIPTION
`vision_catalogues/1` had no clause for `:xai` or `:zhipu`, so grok-4.x / GLM resolved vision via `:unknown_default` (fail-open) instead of OSA's own `vision:` flags — the dead-flag class the moduledoc warns about, for the providers added after the original four. Fail-open *allows* a vision model but also wrongly allows a *non*-vision one; the flag was there, just unreachable. (A casing bug — `XAIModels` vs `XaiModels` — also defeated the first wiring; fixed.)

Now `grok-4.6` resolves `{true, :osa_catalogue}` (was `{true, :unknown_default}`), and non-vision xai/zai models will be correctly gated.

**Honest scope:** this is a real correctness fix and the 'enable it properly' the request asked for, but it is *not* proven to be the cause of a specific 'image didn't come through' on grok — main already fail-opened grok to vision=true, and the compat image path (`format_messages`/`content_part` → `image_url`) looks correct. Pinning that needs a live request-body capture.

Tests: 3 (authoritative source, still-true for grok, unknown still fails open).