### PR TITLE
fix(doom-loop): command execution counts as progress (fixes false stall during debugging)

### DIFF
--- a/lib/optimal_system_agent/agent/loop/doom_loop/stall.ex
+++ b/lib/optimal_system_agent/agent/loop/doom_loop/stall.ex
@@ -27,13 +27,24 @@ defmodule OptimalSystemAgent.Agent.Loop.DoomLoop.Stall do
                        apply_patch str_replace str_replace_editor create_file
                        file_append multi_edit)
 
-  # Investigation tools — reading/searching IS forward progress during a long
-  # autonomous research phase (exactly what hours-long work does). A window
-  # containing any of these is not a stall, so a legitimate read/analysis phase
-  # is never wrongly halted.
+  # Investigation tools — reading/searching/running-a-command IS forward
+  # progress during a long autonomous work phase (exactly what hours-long work
+  # does). A window containing any of these is not a stall, so a legitimate
+  # read/analysis/diagnose phase is never wrongly halted.
+  #
+  # Command execution (`shell_execute`, `bash`, `pty_*`, `task_output`) is
+  # included: an iterative debugging phase — run the linter, read the errors,
+  # run it again — is dominated by shell calls that each return NEW output, and
+  # without these a real fix-the-eslint-errors loop tripped the graded nudge
+  # ("no forward progress for 12 tool calls") mid-work. A genuinely stuck shell
+  # loop is still caught: IdenticalCall halts exact repeats and FailureSignature
+  # halts a command that keeps failing the same way — Stall is only for
+  # non-progress, and a command returning fresh output is progress.
   @progress_tools ~w(file_read read_file file_grep grep dir_list list_dir
                      file_glob glob file_search web_fetch web_search
-                     semantic_search code_symbols)
+                     semantic_search code_symbols
+                     shell_execute bash run_command sh
+                     pty_send pty_read pty_start task_output task_wait)
 
   # --- Stall detection ---
   #

--- a/test/optimal_system_agent/agent/loop/doom_loop/stall_checkpoint_test.exs
+++ b/test/optimal_system_agent/agent/loop/doom_loop/stall_checkpoint_test.exs
@@ -233,11 +233,28 @@ defmodule OptimalSystemAgent.Agent.Loop.DoomLoop.StallCheckpointTest do
     end
 
     test "the directive names the tools actually being repeated" do
-      state = base_state(%{recent_tool_names: List.duplicate("shell_execute", 12)})
+      # A genuinely non-progress tool (not a read/search/command/write): 12
+      # identical calls with nothing else is a real stall. `shell_execute` is
+      # no longer usable here — it now counts as progress (see the
+      # investigative-command fix), which is the point of the test below.
+      state = base_state(%{recent_tool_names: List.duplicate("send_message", 12)})
       {:ok, state} = tick(state)
 
       assert [%{content: content}] = state.messages
-      assert content =~ "shell_execute"
+      assert content =~ "send_message"
+    end
+
+    test "an all-shell_execute window is NOT a stall (iterative debugging is progress)" do
+      # Bug 3: a fix-the-eslint-errors phase — run the linter, read output, run
+      # it again — is dominated by shell_execute calls that each return NEW
+      # output. Those must count as forward progress; the graded nudge used to
+      # fire ("no forward progress for 12 tool calls") mid-work. A truly stuck
+      # shell loop is still caught by IdenticalCall (exact repeats) and
+      # FailureSignature (same error) — Stall is only for non-progress.
+      state = base_state(%{recent_tool_names: List.duplicate("shell_execute", 12)})
+      {:ok, state} = tick(state)
+
+      assert state.messages == [], "a shell-driven debugging window must not trip the stall nudge"
     end
   end
 


### PR DESCRIPTION
**Bug 3** from the 2026-08-24 report: while fixing eslint errors, the graded stall nudge fired *'no forward progress for 12 tool calls'* during legit iterative debugging — run linter, read errors, run again. That phase is dominated by `shell_execute`, which was **absent from the stall detector's `@progress_tools`**, so a window of them read as non-progress even though each returned new output.

Add `shell_execute`/`bash`/`pty_*`/`task_output` to `@progress_tools`. A genuinely stuck shell loop is still caught — `IdenticalCall` halts exact repeats (it sees args), `FailureSignature` halts a command failing the same way, budget/call caps remain. Stall is only for *non-progress*, and a command returning fresh output is progress.

Tests: all-`shell_execute` window is no longer a stall; directive-naming test switched to a genuinely non-progress tool. 488 loop/doom-loop tests green.