### PR TITLE
fix(delegation): degrade soft requirements instead of blocking subagents

### DIFF
--- a/lib/optimal_system_agent/agent/delegation_router.ex
+++ b/lib/optimal_system_agent/agent/delegation_router.ex
@@ -18,7 +18,13 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
     "monorepo",
     "audit broadly"
   ]
-  @vision_phrases ~w(screenshot image diagram photo visual attached)
+  @vision_phrases ~w(screenshot screenshots image images diagram diagrams photo photos photograph)
+
+  # Soft requirements narrow the model pool but must never block a delegation
+  # on their own: vision is easily a false positive from an incidental keyword,
+  # and a provider pool may simply have no vision or huge-context model. Only
+  # :tools is a hard requirement.
+  @soft_requirements [:vision, :large_context]
 
   @doc "Resolve provider/model plus an operator-readable selection rationale."
   @spec resolve(String.t(), map(), keyword()) :: map()
@@ -44,7 +50,7 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
 
     [:tools]
     |> maybe_add(:large_context, contains_any?(normalized, @large_context_phrases))
-    |> maybe_add(:vision, contains_any?(normalized, @vision_phrases))
+    |> maybe_add(:vision, mentions_vision?(normalized))
   end
 
   defp choose(_task, config, requirements, opts) do
@@ -57,33 +63,34 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
     context_window = Keyword.get(opts, :context_window, &Registry.context_window/1)
     vision_capable = Keyword.get(opts, :vision_capable, &ImageBudget.vision_capable?/2)
 
-    selected =
+    find = fn reqs ->
       Enum.find_value(candidates, fn provider ->
         model = model_for.(tier, provider)
 
         if configured?.(provider) and
-             compatible?(
-               requirements,
-               provider,
-               model,
-               tool_call,
-               context_window,
-               vision_capable
-             ) do
+             compatible?(reqs, provider, model, tool_call, context_window, vision_capable) do
           {provider, model}
+        end
+      end)
+    end
+
+    # Walk the relaxation ladder: full requirements first, then progressively
+    # drop soft requirements so a missing vision/large-context model degrades
+    # to the best tools-capable model instead of blocking the delegation.
+    selected =
+      Enum.find_value(relaxation_ladder(requirements), fn reqs ->
+        case find.(reqs) do
+          {provider, model} -> {provider, model, reqs}
+          nil -> nil
         end
       end)
 
     case selected do
-      {provider, model} ->
-        reason =
-          "selected #{provider}/#{model} for task requirements: " <>
-            describe_requirements(requirements)
-
+      {provider, model, met} ->
         config
         |> Map.put(:provider, provider)
         |> Map.put(:model, model)
-        |> Map.put(:model_reason, reason)
+        |> Map.put(:model_reason, selection_reason(provider, model, met, requirements -- met))
         |> Map.put(:model_requirements, Enum.map(requirements, &to_string/1))
 
       nil ->
@@ -97,6 +104,28 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
         |> Map.put(:model_reason, "delegation blocked because no capable model was found")
         |> Map.put(:model_requirements, Enum.map(requirements, &to_string/1))
     end
+  end
+
+  # Full requirement set first, then the same set with each soft requirement
+  # dropped in turn (vision before large_context). Deduped, hard requirements
+  # (:tools) never dropped.
+  defp relaxation_ladder(requirements) do
+    @soft_requirements
+    |> Enum.reduce([requirements], fn soft, [current | _] = acc ->
+      if soft in current, do: [current -- [soft] | acc], else: acc
+    end)
+    |> Enum.reverse()
+    |> Enum.uniq()
+  end
+
+  defp selection_reason(provider, model, met, []) do
+    "selected #{provider}/#{model} for task requirements: " <> describe_requirements(met)
+  end
+
+  defp selection_reason(provider, model, met, dropped) do
+    "selected #{provider}/#{model} for task requirements: " <>
+      describe_requirements(met) <>
+      " (no configured model satisfied #{describe_requirements(dropped)}; proceeding without it)"
   end
 
   defp compatible?(requirements, provider, model, tool_call, context_window, vision_capable) do
@@ -133,6 +162,11 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
   end
 
   defp contains_any?(text, phrases), do: Enum.any?(phrases, &String.contains?(text, &1))
+
+  # Word-boundary match so incidental substrings (imagemagick, visualize,
+  # reimagine) do not force a vision requirement onto a plain code task.
+  defp mentions_vision?(text),
+    do: Enum.any?(@vision_phrases, &Regex.match?(~r/\b#{&1}\b/u, text))
   defp maybe_add(list, item, true), do: list ++ [item]
   defp maybe_add(list, _item, false), do: list
 end

--- a/test/optimal_system_agent/agent/delegation_router_test.exs
+++ b/test/optimal_system_agent/agent/delegation_router_test.exs
@@ -73,7 +73,7 @@ defmodule OptimalSystemAgent.Agent.DelegationRouterTest do
     assert routed.provider == :second
   end
 
-  test "blocks delegation when no configured model satisfies the requirements" do
+  test "degrades to a tools-capable model when no vision model exists rather than blocking" do
     routed =
       DelegationRouter.resolve("Inspect the attached screenshot", %{provider: :first},
         candidates: [:first],
@@ -84,8 +84,49 @@ defmodule OptimalSystemAgent.Agent.DelegationRouterTest do
         vision_capable: fn _, _ -> false end
       )
 
+    refute Map.has_key?(routed, :routing_error)
+    assert routed.provider == :first
+    assert routed.model == "text-only"
+    assert routed.model_reason =~ "proceeding without it"
+    assert routed.model_reason =~ "vision-aware task"
+    # the ORIGINAL requirements are still reported, transparently
+    assert routed.model_requirements == ["tools", "vision"]
+  end
+
+  test "blocks delegation only when not even a tools-capable model exists" do
+    routed =
+      DelegationRouter.resolve("Inspect the attached screenshot", %{provider: :first},
+        candidates: [:first],
+        configured?: fn _ -> true end,
+        model_for: fn _, _ -> "text-only" end,
+        tool_call: fn _, _ -> false end,
+        context_window: fn _ -> 200_000 end,
+        vision_capable: fn _, _ -> false end
+      )
+
     assert routed.routing_error =~ "no configured model"
     assert routed.model_reason =~ "blocked"
     refute Map.has_key?(routed, :model)
+  end
+
+  test "an incidental vision-like word does not force a vision requirement" do
+    # "reimagine", "visualize", "images/" style substrings must not trigger vision
+    assert DelegationRouter.requirements("Reimagine and visualize the imagestore module") ==
+             [:tools]
+  end
+
+  test "drops large-context before refusing when no huge-context model is known" do
+    routed =
+      DelegationRouter.resolve("Audit the entire repository codebase", %{provider: :first},
+        candidates: [:first],
+        configured?: fn _ -> true end,
+        model_for: fn _, _ -> "small-ctx" end,
+        tool_call: fn _, _ -> true end,
+        context_window: fn _ -> 8_000 end
+      )
+
+    refute Map.has_key?(routed, :routing_error)
+    assert routed.provider == :first
+    assert routed.model_reason =~ "proceeding without it"
   end
 end


### PR DESCRIPTION
Fixes the `no_capable_model: "supports tools, vision-aware task"` failure where subagent dispatch was blocked even though the main session ran fine on the same provider.

**Root cause:** an incidental substring (`image`/`visual`/`attached`) forced a `:vision` requirement onto a plain code task; when no configured model was vision-capable the router hard-failed the whole delegation instead of degrading.

**Fix:**
1. Relaxation ladder — `:tools` is the only hard requirement; soft requirements (`:vision`, `:large_context`) are dropped one at a time and the router only refuses when not even a tools-capable model exists. Dropped requirements are named in `model_reason` for transparency.
2. Word-boundary vision detection so `imagemagick`/`visualize`/`reimagine` no longer trip vision.

9 delegation-router tests green (degradation path, genuine tools-only block, incidental-keyword non-trigger, large-context drop).