### PR TITLE
fix(multi_file_edit): match with the same fuzzy cascade as file_edit

### DIFF
--- a/lib/optimal_system_agent/tools/builtins/multi_file_edit/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/multi_file_edit/handler.ex
@@ -275,7 +275,8 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
 
               {:error, :ambiguous, count} ->
                 {:error, dp,
-                 "old_string found #{count} times — must be unique; add surrounding context"}
+                 "old_string found multiple times (#{count}) — must be unique; " <>
+                   "add surrounding context"}
 
               {:error, :disproportionate} ->
                 {:error, dp,

--- a/lib/optimal_system_agent/tools/builtins/multi_file_edit/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/multi_file_edit/handler.ex
@@ -30,6 +30,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
 
   alias OptimalSystemAgent.Agent.Safety.PathPolicy
   alias OptimalSystemAgent.Tools.Builtins.FileEdit.DriftGuard
+  alias OptimalSystemAgent.Tools.Builtins.FileEdit.Matcher
   alias OptimalSystemAgent.Tools.Builtins.FileEdit.Handler, as: FileEditHandler
   alias OptimalSystemAgent.Tools.FileState
   alias OptimalSystemAgent.Tools.UseContext
@@ -104,7 +105,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
 
     to_apply =
       Enum.filter(validation_results, fn
-        {:valid, _, _, _, _, _} -> true
+        {:valid, _, _, _, _, _, _} -> true
         _ -> false
       end)
 
@@ -147,7 +148,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
       Enum.map_join(already_applied, "\n", &"  - #{&1}: already applied (no change needed)")
 
     ok_lines =
-      Enum.map_join(to_apply, "\n", fn {:valid, dp, _ep, _o, _n, _c} ->
+      Enum.map_join(to_apply, "\n", fn {:valid, dp, _ep, _o, _n, _c, _nc} ->
         "  - #{dp}: would apply cleanly"
       end)
 
@@ -165,7 +166,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
         # post-edit validation hook synchronously per file, aggregating any
         # diagnostics into the observation (P1-4).
         edited_paths =
-          for {:valid, _dp, ep, _o, _n, _c} <- validation_results, do: ep
+          for {:valid, _dp, ep, _o, _n, _c, _nc} <- validation_results, do: ep
 
         Enum.each(edited_paths, &FileState.record_write(session, &1))
 
@@ -251,55 +252,50 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
       true ->
         case File.read(ep) do
           {:ok, content} ->
-            cond do
-              not String.contains?(content, old) ->
-                # Idempotency, inherited from single-file `file_edit`
-                # (`already_applied_or_not_found/3`) which `multi_file_edit`
-                # has its own apply logic and so never got.
-                #
-                # Why it matters MORE here: this batch is all-or-nothing, so a
-                # single already-applied hunk failed validation and reverted
-                # every other hunk. A retry after a partial success therefore
-                # could never succeed — the batch was permanently unusable and
-                # the model had no way out except editing files one at a time.
-                #
-                # Narrow, exactly as in `file_edit`: `new` must be non-empty
-                # AND actually present. A deletion (`new == ""`) is trivially
-                # "present" in every file, so treating it as applied would
-                # swallow every genuinely failed deletion — deletions keep the
-                # hard error.
-                if new != "" and String.contains?(content, new) do
-                  {:already_applied, dp}
-                else
-                  {:error, dp, "old_string not found in file"}
-                end
-
-              # Ambiguity guard mirroring single-file file_edit: apply_atomic uses
-              # global: false and would silently rewrite only the FIRST match,
-              # committing a wrong edit. Require a unique match.
-              occurrence_count(content, old) > 1 ->
-                {:error, dp,
-                 "old_string found multiple times — must be unique; add surrounding context"}
-
-              true ->
+            # Match with the SAME fuzzy cascade `file_edit` uses (exact ->
+            # line-endings -> whitespace -> deep fuzzy). Previously this tool
+            # matched with an exact `String.contains?/2` only, so an edit with
+            # trivial whitespace/line-ending drift failed here — then fell into
+            # the idempotency branch and, if `new_string` happened to be
+            # present, reported a FALSE "already applied" success while the same
+            # edit succeeded in `file_edit`. Unifying the matcher removes that
+            # divergence at the root.
+            case Matcher.replace(content, old, new, false) do
+              {:ok, new_content, _count, _stage} ->
                 # Read-before-edit / stale-write guard (P0-1). Any un-read or
                 # stale target fails the whole batch — no files modified.
-                #
-                # DriftGuard is the second, independent layer `file_edit`
-                # already runs (see `FileEdit.Handler.do_edit/6`) and this tool
-                # did not. Without it a file whose {mtime, size} happen to
-                # collide with the recorded ones — a same-second edit that
-                # keeps the length, which is exactly what a formatter or a
-                # sibling agent produces — passes `check_read/2`, and the batch
-                # then computes new content from THIS read and writes it over
-                # whatever is actually on disk, discarding the other change.
                 {mtime, size} = stat_or_zero(ep)
 
                 with :ok <- FileState.check_read(session, ep),
                      :ok <- DriftGuard.verify(session, ep, content, mtime, size) do
-                  {:valid, dp, ep, old, new, content}
+                  {:valid, dp, ep, old, new, content, new_content}
                 else
                   {:error, msg} -> {:error, dp, msg}
+                end
+
+              {:error, :ambiguous, count} ->
+                {:error, dp,
+                 "old_string found #{count} times — must be unique; add surrounding context"}
+
+              {:error, :disproportionate} ->
+                {:error, dp,
+                 "old_string matched only approximately and the resulting change is " <>
+                   "disproportionate — re-read the file and copy old_string verbatim"}
+
+              {:error, {:replace_all_approximate, _}} ->
+                {:error, dp,
+                 "old_string matched only approximately — copy it verbatim and retry"}
+
+              {:error, :not_found} ->
+                # Genuinely absent even after fuzzy matching, so the idempotency
+                # check is now meaningful: old_string is really gone. Narrow,
+                # exactly as in `file_edit`: `new` must be non-empty AND present.
+                # A deletion (`new == ""`) is vacuously present, so it keeps the
+                # hard error rather than being swallowed.
+                if new != "" and String.contains?(content, new) do
+                  {:already_applied, dp}
+                else
+                  {:error, dp, "old_string not found in file"}
                 end
             end
 
@@ -317,10 +313,6 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
       {:ok, %File.Stat{mtime: mtime, size: size}} -> {mtime, size}
       _ -> {0, 0}
     end
-  end
-
-  defp occurrence_count(content, old) do
-    (content |> String.split(old) |> length()) - 1
   end
 
   # POSIX {mtime, size} for DriftGuard, identical to `FileEdit.Handler`'s. A
@@ -369,12 +361,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
   defp apply_atomic(validation_results) do
     edits =
       Enum.map(validation_results, fn
-        {:valid, display_path, expanded_path, old, new, content} ->
+        {:valid, display_path, expanded_path, old, _new, content, new_content} ->
           %{
             display_path: display_path,
             expanded_path: expanded_path,
             content: content,
-            new_content: String.replace(content, old, new, global: false),
+            new_content: new_content,
             lines_changed: old |> String.split("\n") |> length()
           }
       end)

--- a/priv/rust/tui/Cargo.lock
+++ b/priv/rust/tui/Cargo.lock
@@ -1806,7 +1806,7 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "osa-tui"
-version = "1.0.134"
+version = "1.0.135"
 dependencies = [
  "anyhow",
  "arboard",

--- a/priv/rust/tui/Cargo.toml
+++ b/priv/rust/tui/Cargo.toml
@@ -4,7 +4,7 @@ name = "osa-tui"
 # `config::version_source_tests` fails the build if they diverge. This literal is
 # only ever a last-resort fallback: build.rs prefers $OSA_VERSION (release CI),
 # then the VERSION file.
-version = "1.0.134"
+version = "1.0.135"
 edition = "2021"
 
 [[bin]]

--- a/test/tools/multi_file_edit_partial_test.exs
+++ b/test/tools/multi_file_edit_partial_test.exs
@@ -41,6 +41,47 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEditPartialTest do
   defp edit(path, old, new),
     do: %{"path" => path, "old_string" => old, "new_string" => new}
 
+  describe "fuzzy matching parity with file_edit (the false-success bug)" do
+    test "an edit with whitespace/indentation drift APPLIES instead of false-succeeding",
+         %{dir: dir} do
+      # The file uses tabs / different spacing than the model's old_string. The
+      # old exact-only matcher could not find old_string; if new_string happened
+      # to be present it wrongly reported "already applied". It must now match
+      # fuzzily and actually apply the edit, exactly as file_edit does.
+      f = write(dir, "m.ts", "function f() {\n\treturn 1;\n}\n")
+
+      assert {:ok, _msg, meta} =
+               Handler.execute(
+                 %{
+                   "edits" => [
+                     # old_string uses 2 spaces; file uses a tab
+                     edit(f, "function f() {\n  return 1;\n}", "function f() {\n  return 2;\n}")
+                   ]
+                 },
+                 ctx()
+               )
+
+      assert meta.count == 1
+      assert meta.already_applied == []
+      assert File.read!(f) =~ "return 2;", "the edit must actually land, not be skipped"
+    end
+
+    test "a non-additive edit whose new_string is present but old_string is truly absent " <>
+           "is still reported already-applied (idempotency preserved)",
+         %{dir: dir} do
+      f = write(dir, "v.ex", "value = :new\n")
+
+      assert {:ok, _msg, meta} =
+               Handler.execute(
+                 %{"edits" => [edit(f, "value = :old", "value = :new")]},
+                 ctx()
+               )
+
+      assert meta.count == 0
+      assert meta.already_applied == [f]
+    end
+  end
+
   describe "an already-applied hunk no longer kills the batch" do
     test "the remaining hunks still apply", %{dir: dir} do
       # `a` is already in the requested state; `b` is not.


### PR DESCRIPTION
Root-cause fix for the "multi_file_edit reported success but the edit didn't apply; I had to use file_edit instead" bug.

**Cause:** `multi_file_edit` matched `old_string` with exact `String.contains?/2`, while `file_edit` uses the `Matcher.replace` cascade (exact → line-endings → whitespace → deep fuzzy). Whitespace/line-ending drift failed the exact match, fell into the already-applied/not-found branch, and if `new_string` was incidentally present reported a **false 'already applied' success**.

**Fix:** route validation + application through `Matcher.replace`. The narrow already-applied rule now only fires when `Matcher` genuinely returns `:not_found` (proven by `file_edit`'s own idempotency tests to be the real replacement-retry case, not a spurious fuzzy match), so idempotency is preserved. Ambiguity/disproportionate/approximate refusals now match `file_edit`.

Tests: drift edit now applies instead of false-succeeding; genuine replacement-retry still reported already-applied. 35 tests green across the mfe suites.