### PR TITLE
fix(streaming): repair mojibake split across streamed deltas

### DIFF
--- a/lib/optimal_system_agent/agent/loop/llm_client.ex
+++ b/lib/optimal_system_agent/agent/loop/llm_client.ex
@@ -168,6 +168,59 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
     id
   end
 
+  # Emit one repaired, non-empty text delta to every consumer: the retry
+  # one-way-door, the partial-recovery buffer, the local event bus, and the
+  # PubSub bridge the TUI reads. Factored out of the `:text_delta` callback arm
+  # so the arm can skip it when the stateful mojibake repair held the whole
+  # delta back as an incomplete sequence.
+  defp emit_text_delta(text, session_id, message_id, heartbeat) do
+    _ = heartbeat
+
+    # One-way door: this byte is about to be on the user's screen. Past this
+    # point a same-provider retry would re-emit it into the SAME live callback
+    # and the user would watch the paragraph appear twice, so the retry budget
+    # for this request collapses to zero. Runs in the stream task process, which
+    # is also the process `Resilience.with_retry/2` is looping in.
+    Resilience.mark_output_observed()
+
+    # WS5 — accumulate the partial text (reverse-prepended iodata; single writer
+    # = this stream task) so a hard abort can persist what the model had already
+    # produced.
+    try do
+      case :ets.lookup(:osa_stream_partial, session_id) do
+        [{^session_id, acc}] when is_list(acc) ->
+          :ets.insert(:osa_stream_partial, {session_id, [text | acc]})
+
+        _ ->
+          :ets.insert(:osa_stream_partial, {session_id, [text]})
+      end
+    rescue
+      ArgumentError -> :ok
+    end
+
+    Bus.emit(:system_event, %{
+      event: :streaming_token,
+      session_id: session_id,
+      message_id: message_id,
+      delta: text
+    })
+
+    # Bridge to PubSub for SSE delivery to TUI. `message_id` marks which
+    # assistant message this delta belongs to — the client starts a fresh buffer
+    # when it changes instead of appending onto the superseded one.
+    Phoenix.PubSub.broadcast(
+      OptimalSystemAgent.PubSub,
+      "osa:session:#{session_id}",
+      {:osa_event,
+       %{
+         type: :streaming_token,
+         session_id: session_id,
+         message_id: message_id,
+         text: text
+       }}
+    )
+  end
+
   @doc """
   Synchronous LLM chat — routes through the configured provider/model for this session.
   """
@@ -277,70 +330,55 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
       ArgumentError -> :ok
     end
 
+    # Start with an empty mojibake carry so a prior stream that aborted before
+    # its `:done` (leaving a held partial sequence in this reused task process)
+    # cannot prepend stale bytes onto this stream's first delta.
+    Process.delete({:moji_carry, session_id})
+
     caller = self()
 
     callback = fn
       {:text_delta, text} ->
         :atomics.add(heartbeat, 1, 1)
-        # Every provider's streamed text funnels through here before it reaches
-        # the screen, the partial buffer, or the persisted transcript — so this
-        # is the ONE place to undo the UTF-8-as-Latin-1 corruption some backends
-        # emit (an em-dash arriving as the bytes for "â€""). Doing it per
-        # provider left gaps: the local Ollama path repaired, its cloud path
-        # (glm-*:cloud) did not, and every other provider not at all. `repair/1`
-        # is conservative — it only rewrites text that re-decodes to valid UTF-8
-        # with fewer mojibake markers, so clean tokens and legitimately accented
-        # text pass through untouched.
-        text = Mojibake.repair(text)
-        # One-way door: this byte is about to be on the user's screen. Past this
-        # point a same-provider retry would re-emit it into the SAME live
-        # callback and the user would watch the paragraph appear twice, so the
-        # retry budget for this request collapses to zero. Runs in the stream
-        # task process, which is also the process `Resilience.with_retry/2` is
-        # looping in (providers drive `into: :self` receive loops).
-        Resilience.mark_output_observed()
+        # Stateful mojibake repair. Per-delta repair cannot fix a corruption
+        # sequence split across two streamed chunks (a delta ending in a lone
+        # "â" has nothing to re-decode), which is the common case when a
+        # provider streams token-by-token — so we thread a carry buffer through
+        # the stream, holding an in-flight partial sequence until it is whole.
+        # The carry lives in the process dictionary because this callback runs
+        # in the single stream-task process for the whole request; it is flushed
+        # in the `:done` arm below.
+        {text, moji_carry} =
+          Mojibake.repair_stream(Process.get({:moji_carry, session_id}, ""), text)
 
-        # WS5 — accumulate the partial text (reverse-prepended iodata; single
-        # writer = this stream task) so a hard abort can persist what the model
-        # had already produced.
-        try do
-          case :ets.lookup(:osa_stream_partial, session_id) do
-            [{^session_id, acc}] when is_list(acc) ->
-              :ets.insert(:osa_stream_partial, {session_id, [text | acc]})
+        Process.put({:moji_carry, session_id}, moji_carry)
 
-            _ ->
-              :ets.insert(:osa_stream_partial, {session_id, [text]})
-          end
-        rescue
-          ArgumentError -> :ok
+        # Everything below emits to the screen/buffer/transcript; skip it when
+        # this delta was entirely held back as a possibly-incomplete sequence,
+        # so we neither broadcast an empty token nor burn the retry budget on
+        # output the user has not actually seen yet.
+        if text != "" do
+          emit_text_delta(text, session_id, message_id, heartbeat)
         end
 
-        Bus.emit(:system_event, %{
-          event: :streaming_token,
-          session_id: session_id,
-          message_id: message_id,
-          delta: text
-        })
-
-        # Bridge to PubSub for SSE delivery to TUI. `message_id` marks which
-        # assistant message this delta belongs to — the client starts a fresh
-        # buffer when it changes instead of appending a new generation onto the
-        # superseded one.
-        Phoenix.PubSub.broadcast(
-          OptimalSystemAgent.PubSub,
-          "osa:session:#{session_id}",
-          {:osa_event,
-           %{
-             type: :streaming_token,
-             session_id: session_id,
-             message_id: message_id,
-             text: text
-           }}
-        )
 
       {:done, result} ->
         :atomics.add(heartbeat, 1, 1)
         Logger.debug("[stream] done → session:#{session_id}")
+
+        # Flush whatever the stateful mojibake repair was still holding as a
+        # possibly-incomplete sequence, so the live view is not missing the last
+        # few characters of the answer. Emitted as one final repaired delta.
+        case Process.get({:moji_carry, session_id}, "") do
+          "" ->
+            :ok
+
+          carry ->
+            flushed = Mojibake.flush(carry)
+            if flushed != "", do: emit_text_delta(flushed, session_id, message_id, heartbeat)
+        end
+
+        Process.delete({:moji_carry, session_id})
 
         # Repair the FINAL assembled content, not just the live deltas. This is
         # the string that is persisted to the transcript and re-rendered on

--- a/lib/optimal_system_agent/utils/mojibake.ex
+++ b/lib/optimal_system_agent/utils/mojibake.ex
@@ -10,6 +10,68 @@ defmodule OptimalSystemAgent.Utils.Mojibake do
 
   @markers ["Ã", "Â", "â"]
 
+  # Codepoints a UTF-8 lead byte lands on when its bytes are misread as Latin-1:
+  # Â (0xC2), Ã (0xC3), â (0xE2). A mojibake run is one of these followed by the
+  # original char's continuation bytes, which decode to the 0x80..0xBF range.
+  @marker_cps [0xC2, 0xC3, 0xE2]
+  # A single UTF-8 char is at most 4 bytes → at most 4 mojibake codepoints, so a
+  # trailing run longer than this is already several complete chars, not one
+  # in-flight one.
+  @max_moji_cps 4
+
+  @doc """
+  Stateful repair for a STREAM of deltas: `{text_to_emit, carry_for_next_delta}`.
+
+  Per-delta `repair/1` fails when a mojibake sequence is split across two
+  streamed chunks — a delta ending in a lone `â` cannot be re-decoded, so the
+  corruption survives. This holds back a possibly-incomplete trailing mojibake
+  run (a marker codepoint followed only by continuation-range codepoints, up to
+  one char's worth) and prepends it to the next delta, so the sequence is only
+  repaired once it is whole. Non-mojibake text is never held.
+
+  Thread `carry` through the stream (start `""`) and call `flush/1` at the end
+  to emit whatever remained held.
+  """
+  @spec repair_stream(String.t(), String.t()) :: {String.t(), String.t()}
+  def repair_stream(carry, delta) when is_binary(carry) and is_binary(delta) do
+    combined = carry <> delta
+
+    case incomplete_tail_start(String.to_charlist(combined)) do
+      nil ->
+        {repair(combined), ""}
+
+      i ->
+        {safe, tail} = combined |> String.to_charlist() |> Enum.split(i)
+        {repair(List.to_string(safe)), List.to_string(tail)}
+    end
+  end
+
+  @doc "Repair and return whatever `repair_stream/2` was still holding."
+  @spec flush(String.t()) :: String.t()
+  def flush(carry) when is_binary(carry), do: repair(carry)
+
+  # Index where a possibly-incomplete trailing mojibake run begins, or nil when
+  # the text does not end mid-sequence. The run is the last marker codepoint
+  # when everything after it, to the end, is continuation-range and the whole
+  # run is no longer than a single char's worth of bytes.
+  defp incomplete_tail_start(cps) do
+    last_marker =
+      cps
+      |> Enum.with_index()
+      |> Enum.reduce(nil, fn {cp, idx}, acc -> if cp in @marker_cps, do: idx, else: acc end)
+
+    with i when is_integer(i) <- last_marker,
+         after_cps = Enum.drop(cps, i + 1),
+         true <- length(after_cps) < @max_moji_cps,
+         true <- Enum.all?(after_cps, &continuation?/1) do
+      i
+    else
+      _ -> nil
+    end
+  end
+
+  defp continuation?(cp), do: cp >= 0x80 and cp <= 0xBF
+
   @spec repair(String.t()) :: String.t()
   def repair(text) when is_binary(text) do
     text

--- a/test/optimal_system_agent/utils/mojibake_test.exs
+++ b/test/optimal_system_agent/utils/mojibake_test.exs
@@ -41,4 +41,47 @@ defmodule OptimalSystemAgent.Utils.MojibakeTest do
 
     assert Mojibake.repair(corrupt) == <<0xE2, 0x80, 0x94>>
   end
+
+  # A helper: the on-the-wire mojibake form of an original UTF-8 byte sequence -
+  # each byte re-encoded as its own UTF-8 char (latin1-as-utf8 double encoding).
+  defp corrupt(orig_bytes) do
+    orig_bytes |> :binary.bin_to_list() |> Enum.map_join(fn b -> <<b::utf8>> end)
+  end
+
+  describe "repair_stream/2 handles corruption split across streamed deltas" do
+    test "a sequence split mid-mojibake is repaired once whole" do
+      # "'" is E2 80 99; its mojibake is corrupt(<<0xE2,0x80,0x99>>). Split it
+      # between the first corrupted char and the rest, as a token stream would.
+      moji = corrupt(<<0xE2, 0x80, 0x99>>)
+      <<first::binary-size(2), rest::binary>> = moji
+      deltas = ["That", first, rest, "s the app"]
+
+      {out, carry} =
+        Enum.reduce(deltas, {"", ""}, fn d, {acc, carry} ->
+          {emit, new_carry} = Mojibake.repair_stream(carry, d)
+          {acc <> emit, new_carry}
+        end)
+
+      assert out <> Mojibake.flush(carry) == "That’s the app"
+    end
+
+    test "clean and legitimately-accented text streams through untouched" do
+      deltas = ["Hello ", "world ", "café ", "naïve"]
+
+      {out, carry} =
+        Enum.reduce(deltas, {"", ""}, fn d, {acc, carry} ->
+          {emit, new_carry} = Mojibake.repair_stream(carry, d)
+          {acc <> emit, new_carry}
+        end)
+
+      assert out <> Mojibake.flush(carry) == "Hello world café naïve"
+    end
+
+    test "a lone real accented word ending in a marker char is preserved" do
+      # a real "â" is a marker char; it must survive, only delayed by the carry.
+      {e1, c1} = Mojibake.repair_stream("", "goâ")
+      {e2, c2} = Mojibake.repair_stream(c1, " on")
+      assert e1 <> e2 <> Mojibake.flush(c2) == "goâ on"
+    end
+  end
 end


### PR DESCRIPTION
**The recurring "Thatâs" / "â¢" mojibake.** Per-delta `Mojibake.repair` cannot fix a UTF-8-as-Latin-1 sequence split across two streamed chunks — a delta ending in a lone `â` has nothing to re-decode, so it survives to screen. Providers that stream token-by-token (grok included) hit this constantly. Proven: streaming `["That", "â", "€™", "s"]` reassembles to the original mojibake.

**Fix:** stateful `repair_stream/2` threads a carry buffer that holds a possibly-incomplete trailing mojibake run and prepends it to the next delta, repairing only once the sequence is whole; `flush/1` emits the remainder at end-of-stream. Wired into `llm_client`'s `:text_delta` path (carry in the per-stream process dict), flushed on `:done`, reset at stream start. Non-mojibake and legitimately accented text (`café`, `naïve`) are never held.

Tests: split repair, clean/accented passthrough, real trailing-marker preservation. 9 mojibake + 653 loop tests green.