### PR TITLE
fix(subagents): propagate delegation depth through orchestrate path + real dashboard counts

### DIFF
--- a/lib/optimal_system_agent/agent/loop/tool_executor.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_executor.ex
@@ -1306,6 +1306,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
           modified_args
           |> Map.put("__session_id__", state.session_id)
           |> Map.put("__tool_use_id__", tool_call.id)
+          |> Map.put("__delegation_depth__", Map.get(state, :delegation_depth, 0))
           |> Map.put("__surface__", authority_surface(state))
 
         execute_tool(tool_call.name, enriched_args)
@@ -1316,6 +1317,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
           tool_call.arguments
           |> Map.put("__session_id__", state.session_id)
           |> Map.put("__tool_use_id__", tool_call.id)
+          |> Map.put("__delegation_depth__", Map.get(state, :delegation_depth, 0))
           |> Map.put("__surface__", authority_surface(state))
 
         execute_tool(tool_call.name, enriched_args)

--- a/lib/optimal_system_agent/command_center.ex
+++ b/lib/optimal_system_agent/command_center.ex
@@ -8,6 +8,7 @@ defmodule OptimalSystemAgent.CommandCenter do
   """
 
   alias OptimalSystemAgent.Agent.Roster
+  alias OptimalSystemAgent.Orchestrator
 
   @doc "Top-level dashboard summary."
   @spec dashboard_summary() :: map()
@@ -15,10 +16,15 @@ defmodule OptimalSystemAgent.CommandCenter do
     agents = Roster.all() |> Map.values()
     total = length(agents)
 
+    # Live count of admitted (non-queued) subagent runs. Previously hardcoded to
+    # `running: 0, idle: total`, so the dashboard always reported zero running
+    # agents no matter how many were mid-flight.
+    running = Orchestrator.live_agent_count()
+
     %{
       total_agents: total,
-      running: 0,
-      idle: total,
+      running: running,
+      idle: max(total - running, 0),
       tiers: tier_counts(agents),
       patterns: pattern_list()
     }

--- a/lib/optimal_system_agent/swarm/patterns.ex
+++ b/lib/optimal_system_agent/swarm/patterns.ex
@@ -34,13 +34,14 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
 
     runner = Keyword.get(opts, :runner, &Orchestrator.run_subagent/1)
     timeout = Keyword.get(opts, :timeout, 600_000)
+    depth = Keyword.get(opts, :depth, 0)
 
     results =
       OptimalSystemAgent.TaskSupervisor
       |> Task.Supervisor.async_stream_nolink(
         configs,
         fn config ->
-          runner.(Map.put(config, :parent_session_id, parent_id))
+          runner.(with_lineage(config, parent_id, depth))
         end,
         # `length(configs)` was no cap at all: a 40-agent swarm started 40
         # concurrent subagent Loops, each with its own provider connection,
@@ -81,8 +82,9 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
   Sequential chain. Each agent receives the previous agent's output prepended
   to its task, enabling iterative refinement.
   """
-  def pipeline(parent_id, configs, _opts \\ []) do
+  def pipeline(parent_id, configs, opts \\ []) do
     Logger.info("[Swarm.Patterns] pipeline — #{length(configs)} agents")
+    depth = Keyword.get(opts, :depth, 0)
 
     {results, _} =
       Enum.map_reduce(configs, nil, fn config, prev_output ->
@@ -93,7 +95,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
             config.task
           end
 
-        config = Map.put(config, :parent_session_id, parent_id) |> Map.put(:task, task)
+        config = config |> with_lineage(parent_id, depth) |> Map.put(:task, task)
         result = Orchestrator.run_subagent(config)
 
         output =
@@ -116,12 +118,13 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
   First N-1 agents propose in parallel. Last agent is the critic/evaluator
   and receives all proposals. Falls back to parallel if fewer than 2 agents.
   """
-  def debate(parent_id, configs, _opts \\ []) do
+  def debate(parent_id, configs, opts \\ []) do
     Logger.info("[Swarm.Patterns] debate — #{length(configs)} agents")
+    depth = Keyword.get(opts, :depth, 0)
 
     if length(configs) < 2 do
       Logger.warning("[Swarm.Patterns] debate requires ≥2 agents, falling back to parallel")
-      parallel(parent_id, configs)
+      parallel(parent_id, configs, opts)
     else
       {proposers, [evaluator_config]} = Enum.split(configs, length(configs) - 1)
 
@@ -131,7 +134,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
         |> Task.Supervisor.async_stream_nolink(
           proposers,
           fn config ->
-            Orchestrator.run_subagent(Map.put(config, :parent_session_id, parent_id))
+            Orchestrator.run_subagent(with_lineage(config, parent_id, depth))
           end,
           # Same cap as `parallel/3` — an uncapped fan-out here is the identical
           # defect, just reached through a different pattern.
@@ -160,7 +163,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
 
       evaluator_config =
         evaluator_config
-        |> Map.put(:parent_session_id, parent_id)
+        |> with_lineage(parent_id, depth)
         |> Map.put(:task, evaluator_task)
 
       evaluator_result = Orchestrator.run_subagent(evaluator_config)
@@ -180,15 +183,16 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
   """
   def review_loop(parent_id, configs, opts \\ []) do
     max_iterations = Keyword.get(opts, :max_iterations, 3)
+    depth = Keyword.get(opts, :depth, 0)
     Logger.info("[Swarm.Patterns] review_loop max_iterations=#{max_iterations}")
 
     case configs do
       [worker_config, reviewer_config | _] ->
-        run_review_loop(parent_id, worker_config, reviewer_config, max_iterations)
+        run_review_loop(parent_id, worker_config, reviewer_config, max_iterations, depth)
 
       [single | _] ->
         Logger.warning("[Swarm.Patterns] review_loop needs ≥2 agents, running single")
-        result = Orchestrator.run_subagent(Map.put(single, :parent_session_id, parent_id))
+        result = Orchestrator.run_subagent(with_lineage(single, parent_id, depth))
         {:ok, [result]}
 
       [] ->
@@ -196,7 +200,8 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
     end
   end
 
-  defp run_review_loop(_parent_id, _worker_cfg, _reviewer_cfg, max_iter) when max_iter < 1 do
+  defp run_review_loop(_parent_id, _worker_cfg, _reviewer_cfg, max_iter, _depth)
+       when max_iter < 1 do
     Logger.warning(
       "[Swarm.Patterns] review_loop max_iterations=#{max_iter} < 1, returning empty result"
     )
@@ -204,7 +209,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
     {:ok, [{:ok, "[no iterations]"}]}
   end
 
-  defp run_review_loop(parent_id, worker_cfg, reviewer_cfg, max_iter) do
+  defp run_review_loop(parent_id, worker_cfg, reviewer_cfg, max_iter, depth) do
     {final_output, _iterations, approved} =
       Enum.reduce_while(1..max_iter, {nil, 0, false}, fn iteration,
                                                          {prev_output, _iter, _approved} ->
@@ -218,7 +223,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
 
         worker_result =
           worker_cfg
-          |> Map.put(:parent_session_id, parent_id)
+          |> with_lineage(parent_id, depth)
           |> Map.put(:task, worker_task)
           |> Orchestrator.run_subagent()
 
@@ -234,7 +239,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
 
         reviewer_result =
           reviewer_cfg
-          |> Map.put(:parent_session_id, parent_id)
+          |> with_lineage(parent_id, depth)
           |> Map.put(:task, reviewer_task)
           |> Orchestrator.run_subagent()
 
@@ -260,6 +265,21 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
         else: "\n\n[Note: max iterations (#{max_iter}) reached without explicit approval]"
 
     {:ok, [{:ok, final_output <> note}]}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Lineage
+  # ---------------------------------------------------------------------------
+
+  # Stamp a config with its parent session AND the parent's delegation depth, so
+  # `Orchestrator.run_subagent/1` increments from the true nesting level. Without
+  # the depth, every orchestrate-spawned child started at depth 1 and the
+  # fork-bomb ceiling in `ToolFilter.apply_delegation_depth_guard` was never
+  # reached on this path.
+  defp with_lineage(config, parent_id, depth) do
+    config
+    |> Map.put(:parent_session_id, parent_id)
+    |> Map.put(:delegation_depth, depth)
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/optimal_system_agent/tools/builtins/orchestrate.ex
+++ b/lib/optimal_system_agent/tools/builtins/orchestrate.ex
@@ -60,10 +60,17 @@ defmodule OptimalSystemAgent.Tools.Builtins.Orchestrate do
     # nil strategy defaults to :auto (heuristic single-vs-pipeline decision).
     strategy = params["strategy"] || "auto"
 
-    Logger.info("[Orchestrate] strategy=#{strategy} task=#{String.slice(task, 0, 100)}")
+    # The caller's own delegation depth, injected by the agent loop's
+    # ToolExecutor. Threaded into every spawned config so `run_subagent`
+    # increments from the TRUE nesting level — without it, orchestrate-spawned
+    # children always started at depth 1, so a subagent that called orchestrate
+    # again reset the counter and the fork-bomb ceiling was never reached.
+    depth = params["__delegation_depth__"] || 0
+
+    Logger.info("[Orchestrate] strategy=#{strategy} depth=#{depth} task=#{String.slice(task, 0, 100)}")
 
     try do
-      case OptimalSystemAgent.Swarm.Patterns.dispatch(strategy, session_id, task) do
+      case OptimalSystemAgent.Swarm.Patterns.dispatch(strategy, session_id, task, depth: depth) do
         {:ok, result} -> {:ok, result}
         {:error, reason} -> {:error, "Orchestration failed: #{inspect(reason)}"}
       end

--- a/test/optimal_system_agent/swarm/patterns_depth_test.exs
+++ b/test/optimal_system_agent/swarm/patterns_depth_test.exs
@@ -1,0 +1,40 @@
+defmodule OptimalSystemAgent.Swarm.PatternsDepthTest do
+  @moduledoc """
+  The fork-bomb ceiling (`ToolFilter.apply_delegation_depth_guard`) depends on a
+  subagent's delegation_depth growing with true nesting. The swarm patterns used
+  to stamp only `:parent_session_id`, so `run_subagent` incremented from a
+  default of 0 and every orchestrate-spawned child started at depth 1 regardless
+  of how deep the caller already was. These tests pin that each pattern now
+  threads the caller's depth into every spawned config.
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Swarm.Patterns
+
+  test "parallel stamps the caller's depth onto every config" do
+    parent = self()
+    runner = fn config -> send(parent, {:cfg, config}); {:ok, "done"} end
+
+    configs = [%{task: "a", role: "a"}, %{task: "b", role: "b"}]
+    {:ok, _} = Patterns.parallel("p1", configs, runner: runner, depth: 2, timeout: 5_000)
+
+    depths =
+      for _ <- configs do
+        assert_receive {:cfg, cfg}
+        assert cfg.parent_session_id == "p1"
+        cfg.delegation_depth
+      end
+
+    assert Enum.all?(depths, &(&1 == 2)), "every config must carry the caller depth (2)"
+  end
+
+  test "depth defaults to 0 when the caller does not pass one" do
+    parent = self()
+    runner = fn config -> send(parent, {:cfg, config}); {:ok, "done"} end
+
+    {:ok, _} = Patterns.parallel("p2", [%{task: "x", role: "x"}], runner: runner, timeout: 5_000)
+
+    assert_receive {:cfg, cfg}
+    assert cfg.delegation_depth == 0
+  end
+end


### PR DESCRIPTION
Two subagent-system fixes from an architecture review.

**1. Fork-bomb ceiling defeat on the `orchestrate`/`Swarm.Patterns` path.** The `delegate` tool threads the caller's `delegation_depth` into every child config so the fork-bomb guard (strip spawn tools at depth 3) works. The `Swarm.Patterns` path stamped only `:parent_session_id`, so `run_subagent` incremented from 0 and every orchestrate-spawned child started at depth 1 regardless of true nesting — a subagent calling `orchestrate` again reset the counter, so the ceiling was never reached and nesting was **unbounded**.
Fix: ToolExecutor injects `__delegation_depth__`; `orchestrate` passes `depth:` through `dispatch`; a `with_lineage/3` helper stamps parent session + depth on every config across all four patterns.

**2. `CommandCenter.dashboard_summary` reported `running: 0` unconditionally.** Now reads `Orchestrator.live_agent_count/0`.

Tests: depth-propagation + depth-defaults pinned; 222 executor/delegate + all swarm tests green.

Deferred (larger, noted for follow-up): unifying the two delegation stacks and a per-subagent token budget.