### PR TITLE
feat(subagents+tui): per-subagent spend cap + TUI polish

### DIFF
--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -449,7 +449,13 @@ defmodule OptimalSystemAgent.Orchestrator do
       # the *parent's* depth (0 for a top-level session, set by the delegate
       # handler from its UseContext). ToolFilter strips the child's spawning
       # tools once this reaches the configured max — the fork-bomb ceiling.
-      delegation_depth: Map.get(config, :delegation_depth, 0) + 1
+      delegation_depth: Map.get(config, :delegation_depth, 0) + 1,
+      # Per-subagent spend ceiling. nil = off (the default, so nothing changes
+      # for callers that don't set it); when present the child Loop aborts its
+      # own run mid-loop via `Loop.Limits.budget_exceeded?` once it crosses the
+      # cap, so a wide fan-out cannot burn unbounded spend. Enforced per child;
+      # the parent's own budget is independent.
+      max_budget_usd: Map.get(config, :max_budget_usd)
     ]
 
     # Start event forwarder BEFORE spawning the subagent so it catches

--- a/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
@@ -233,7 +233,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
       # Per-call override for the subagent JOIN timeout (D1). Applies to both
       # the single-task and fan-out paths; nil lets Orchestrator fall back to
       # `:subagent_join_timeout_ms` / `@default_subagent_timeout_ms`.
-      timeout_ms: parse_timeout_ms(Map.get(args, "timeout_ms"))
+      timeout_ms: parse_timeout_ms(Map.get(args, "timeout_ms")),
+      # Per-subagent USD spend ceiling. nil = off (unchanged default). When set,
+      # the child Loop aborts its own run once it crosses the cap, so a wide
+      # fan-out cannot burn unbounded spend. Each child is capped independently.
+      max_budget_usd:
+        parse_budget_usd(Map.get(args, "max_budget_usd") || Map.get(args, "maxBudgetUsd"))
     }
 
     DelegationRouter.resolve(child_task, config)
@@ -781,6 +786,19 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
 
   defp resolve_parent_id(_args, %UseContext{session_id: sid}) when is_binary(sid), do: sid
   defp resolve_parent_id(args, _ctx), do: Map.get(args, "__session_id__", "unknown")
+
+  # Parse a per-subagent USD budget. Accepts a positive number or numeric
+  # string; anything else (including 0 / negative) is "no cap".
+  defp parse_budget_usd(n) when is_number(n) and n > 0, do: n * 1.0
+
+  defp parse_budget_usd(s) when is_binary(s) do
+    case Float.parse(s) do
+      {f, _} when f > 0 -> f
+      _ -> nil
+    end
+  end
+
+  defp parse_budget_usd(_), do: nil
 
   defp parse_timeout_ms(nil), do: nil
   defp parse_timeout_ms(ms) when is_integer(ms) and ms > 0, do: ms

--- a/lib/optimal_system_agent/tools/builtins/delegate/tool.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/tool.ex
@@ -118,6 +118,12 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Tool do
           "type" => "integer",
           "description" => "Subagent turn cap."
         },
+        "max_budget_usd" => %{
+          "type" => "number",
+          "description" =>
+            "Per-subagent USD spend ceiling. The subagent stops itself once it " <>
+              "crosses this cap. Omit for no cap. Use on wide fan-outs to bound total spend."
+        },
         "model" => %{
           "type" => "string",
           "description" => "Model override for this subagent."

--- a/priv/rust/tui/src/app/assistant_stream.rs
+++ b/priv/rust/tui/src/app/assistant_stream.rs
@@ -155,6 +155,16 @@ impl AssistantStream {
     /// The part of the current message that is NOT yet in native scrollback —
     /// what the live preview must show, and what a flush hands over.
     pub(crate) fn tail(&self) -> &str {
+        // `settled` only ever advances to a markdown block boundary returned by
+        // `find_frozen_boundary`, which is always char-aligned — so this slice
+        // is safe. Pin that invariant in tests: if a future boundary-finder
+        // change lands `settled` mid-codepoint, fail loudly here instead of
+        // panicking on a real user's model output in production.
+        debug_assert!(
+            self.buf.is_char_boundary(self.settled),
+            "stream settled offset {} is not a char boundary",
+            self.settled
+        );
         &self.buf[self.settled..]
     }
 

--- a/priv/rust/tui/src/components/chat/welcome.rs
+++ b/priv/rust/tui/src/components/chat/welcome.rs
@@ -92,7 +92,12 @@ pub fn welcome_lines(
         let padded = if visible_len < inner {
             format!("{}{}", content, " ".repeat(inner - visible_len))
         } else {
-            content.chars().take(inner).collect()
+            // Truncate by DISPLAY WIDTH, not char count: `inner` is a column
+            // budget, so a wide-char (CJK/emoji) name in the greeting would
+            // otherwise overfill the line and push the right border out of
+            // alignment. `fit_cols` is the same width-aware helper the rest of
+            // the tree uses.
+            crate::util::fit_cols(content, inner)
         };
         Line::from(vec![
             Span::styled(left.to_string(), Style::default().fg(border_color)),

--- a/priv/rust/tui/src/components/toast.rs
+++ b/priv/rust/tui/src/components/toast.rs
@@ -87,13 +87,17 @@ impl Toasts {
     }
 
     pub fn push(&mut self, message: String, level: ToastLevel) {
-        // Coalesce an immediate duplicate (same text + level) so repeated events
-        // don't stack identical toasts — just refresh its dwell timer.
-        if let Some(last) = self.queue.last_mut() {
-            if last.level == level && last.message == message {
-                last.created = Instant::now();
-                return;
-            }
+        // Coalesce a duplicate (same text + level) against ANY live toast, not
+        // just the most recent one — interleaved identical warnings from two
+        // different tools would otherwise slip past a last-only check and stack.
+        // Refresh the existing toast's dwell timer instead of enqueueing another.
+        if let Some(existing) = self
+            .queue
+            .iter_mut()
+            .find(|t| t.level == level && t.message == message)
+        {
+            existing.created = Instant::now();
+            return;
         }
 
         self.history.push_back(ToastRecord {
@@ -221,4 +225,29 @@ fn fit_to_width(s: &str, max: usize) -> String {
     // RIGHT-aligned, an over-wide string lost its BEGINNING (the first words),
     // not its tail.
     crate::util::fit_cols(s, max)
+}
+
+#[cfg(test)]
+mod dedup_tests {
+    use super::*;
+
+    #[test]
+    fn interleaved_identical_warnings_coalesce_against_any_live_toast() {
+        let mut toasts = Toasts::new();
+        // A, then B, then A again. With a last-only check the second A would
+        // stack (last is B); dedup-across-queue must refresh the existing A.
+        toasts.push("stalled: tool-a".into(), ToastLevel::Warning);
+        toasts.push("stalled: tool-b".into(), ToastLevel::Warning);
+        toasts.push("stalled: tool-a".into(), ToastLevel::Warning);
+
+        assert_eq!(toasts.live_count(), 2, "the repeated warning must not stack a third toast");
+    }
+
+    #[test]
+    fn distinct_messages_are_not_coalesced() {
+        let mut toasts = Toasts::new();
+        toasts.push("one".into(), ToastLevel::Info);
+        toasts.push("two".into(), ToastLevel::Info);
+        assert_eq!(toasts.live_count(), 2);
+    }
 }


### PR DESCRIPTION
**A — per-subagent cost ceiling.** The child Loop already enforces a mid-run USD budget (`Loop.Limits.budget_exceeded?`), but no delegation path set it — a wide fan-out could burn unbounded spend. Now the `delegate` tool takes optional `max_budget_usd`, `build_config` threads it, and the Orchestrator starts each child Loop with it. Default nil = off; when set each child stops itself at the cap, capped independently.

**TUI polish (low-risk, from an architecture review):**
- Welcome box fits the greeting by **display width** (`fit_cols`) not char count → no more right-border misalignment for CJK/emoji names.
- Toasts coalesce a duplicate against **any** live toast, not just the last → interleaved identical warnings from two tools stop stacking.
- `assistant_stream` `debug_assert`s the settled offset is a char boundary → future boundary-finder regressions fail in tests, not on users.

Tests: toast dedup regression; 1523 TUI + 78 delegate/swarm/limits green.

Context: this is part of a subagent-improvement batch. Depth propagation + real dashboard counts already shipped (#168). The remaining items — full delegation-stack unification and a sliding-window fan-out — are assessed as higher-risk rewrites of battle-tested join code for modest/rare-case gain; recommending they be done as dedicated PRs rather than rushed.