### PR TITLE
feat(subagents): sliding-window fan-out (C) + orchestrate swarm visibility (B)

### DIFF
--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -154,38 +154,53 @@ defmodule OptimalSystemAgent.Orchestrator do
         # are re-sorted by original index below.
         cap = delegate_concurrency_cap()
 
-        results =
-          indexed_configs
-          |> Enum.chunk_every(cap)
-          |> Enum.flat_map(fn batch ->
-            # Spawn one batch as async Tasks. Thread the stable batch_id
-            # (team_id) and wave number into each config so run_subagent can
-            # carry them onto lifecycle events — the TUI groups per-workstream
-            # by batch_id and per-wave.
-            tasks =
-              Enum.map(batch, fn {config, original_idx} ->
-                config =
-                  config
-                  |> Map.put(:parent_session_id, parent_id)
-                  |> Map.put(:batch_id, team_id)
-                  |> Map.put(:wave, wave_num)
+        # Sliding-window fan-out. This used to `Enum.chunk_every(cap)` and run
+        # the wave in fixed batches, joining every agent in a batch before
+        # starting the next — so a fast agent stuck in a batch behind a slow one
+        # sat idle until the whole batch drained, wasting up to (batch-1) slots.
+        # `async_stream` instead keeps up to `cap` agents running at ALL times,
+        # refilling a slot the instant one finishes.
+        #
+        # Each stream worker owns its own subagent Task and runs the SAME
+        # two-clock `join_subagent_task/3` ladder it always did, so the
+        # per-config inner timeout and the brutal-kill backstop are preserved
+        # exactly (Task.yield/shutdown require the owner process, which is this
+        # worker). `timeout: :infinity` defers entirely to that inner ladder,
+        # which always returns; `ordered: true` yields results in input order —
+        # already original-index order within a wave — so no post-sort is needed.
+        # batch_id (team_id) + wave are threaded onto each config so the TUI can
+        # group per-workstream and per-wave.
+        OptimalSystemAgent.TaskSupervisor
+        |> Task.Supervisor.async_stream_nolink(
+          indexed_configs,
+          fn {config, _original_idx} ->
+            config =
+              config
+              |> Map.put(:parent_session_id, parent_id)
+              |> Map.put(:batch_id, team_id)
+              |> Map.put(:wave, wave_num)
 
-                {original_idx, subagent_join_timeout_ms(config),
-                 Task.Supervisor.async_nolink(
-                   OptimalSystemAgent.TaskSupervisor,
-                   fn -> run_subagent(config) end
-                 )}
-              end)
+            inner_timeout = subagent_join_timeout_ms(config)
 
-            Enum.map(tasks, fn {original_idx, inner_timeout, task} ->
-              {original_idx, join_subagent_task(task, await_timeout, inner_timeout)}
-            end)
-          end)
+            task =
+              Task.Supervisor.async_nolink(
+                OptimalSystemAgent.TaskSupervisor,
+                fn -> run_subagent(config) end
+              )
 
-        # Sort by original index to maintain order
-        results
-        |> Enum.sort_by(fn {idx, _} -> idx end)
-        |> Enum.map(fn {_, result} -> result end)
+            join_subagent_task(task, await_timeout, inner_timeout)
+          end,
+          max_concurrency: cap,
+          timeout: :infinity,
+          ordered: true
+        )
+        |> Enum.map(fn
+          {:ok, result} -> result
+          # A stream worker crashing (not the child — join_subagent_task already
+          # turns a child crash into {:error, {:crashed, _}}) is still a failure,
+          # never laundered into success.
+          {:exit, reason} -> {:error, {:crashed, reason}}
+        end)
       end)
 
     # Emit synthesizing

--- a/lib/optimal_system_agent/swarm/patterns.ex
+++ b/lib/optimal_system_agent/swarm/patterns.ex
@@ -299,8 +299,19 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
   @spec dispatch(String.t() | atom(), String.t(), String.t(), keyword()) ::
           {:ok, String.t()} | {:error, term()}
   def dispatch(pattern, parent_id, task, opts \\ []) when is_binary(task) do
+    norm = normalize_pattern(pattern)
+
+    # Task-level lifecycle so an `orchestrate` swarm is VISIBLE in the TUI, the
+    # same way a `delegate` fan-out is. run_subagent already emits per-AGENT
+    # events, but this path never emitted the outer task grouping that
+    # Orchestrator.run_parallel wraps around a delegate fan-out, so a swarm
+    # showed up as loose agents with no "started / synthesizing / completed"
+    # frame. Best-effort; never affects execution.
+    team_id = "swarm:#{parent_id}:#{normalized_unique(task)}"
+    emit_task_event(parent_id, %{event: "orchestrator_task_started", task_id: team_id, strategy: to_string(norm)})
+
     result =
-      case normalize_pattern(pattern) do
+      case norm do
         :parallel -> parallel(parent_id, build_configs(:parallel, task, opts), opts)
         :pipeline -> pipeline(parent_id, build_configs(:pipeline, task, opts), opts)
         :debate -> debate(parent_id, build_configs(:debate, task, opts), opts)
@@ -309,11 +320,40 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
         :auto -> auto_dispatch(parent_id, task, opts)
       end
 
+    emit_task_event(parent_id, %{event: "orchestrator_task_completed", task_id: team_id})
+
     case result do
       {:ok, results} -> {:ok, flatten_results(results)}
       {:error, _} = err -> err
       other -> {:ok, flatten_results(other)}
     end
+  end
+
+  # Broadcast a task-level orchestration event on the parent's session topic,
+  # in the exact shape the TUI's SSE parser expects (see
+  # Orchestrator.emit_event/2). Best-effort — a broadcast failure must never
+  # break a swarm.
+  defp emit_task_event(parent_id, event_data) do
+    full =
+      event_data
+      |> Map.put(:type, :system_event)
+      |> Map.put(:session_id, parent_id)
+
+    Phoenix.PubSub.broadcast(
+      OptimalSystemAgent.PubSub,
+      "osa:session:#{parent_id}",
+      {:osa_event, full}
+    )
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  # A stable-enough id fragment from the task text without Date/System time in
+  # hot equality paths — just a content hash, so the same dispatch reuses one id.
+  defp normalized_unique(task) do
+    :erlang.phash2(task)
   end
 
   @doc "Normalize a pattern name (string/atom) to a known pattern atom; :auto fallback."


### PR DESCRIPTION
Closes the last two subagent items.

**C — true sliding-window parallelism.** `run_parallel` used `chunk_every(cap)` and joined every agent in a fixed batch before starting the next, so a fast agent behind a slow one in the same batch idled its slot. Replaced with `async_stream_nolink` at `max_concurrency: cap` — keeps `cap` agents running at all times, refilling instantly. Each worker owns its subagent Task and runs the **same two-clock `join_subagent_task` ladder**, so per-config `timeout_ms` and the brutal-kill backstop are preserved exactly. `ordered: true` keeps original order (post-sort removed).

**B — orchestrate swarms now visible in the TUI.** `run_subagent` already emits per-agent events, but the swarm path never emitted the **task-level** grouping (`orchestrator_task_started`/`_completed`) that `run_parallel` wraps around a delegate fan-out. `dispatch/4` now emits it. Additive, best-effort, no execution change.

The governance half of B (shared cap/timeout/**depth**) already shipped in #168.

Tests: 61 orchestrator (ordering + join robustness + timeout) + all swarm green.