### PR TITLE
fix(edit): re-capture read/drift baseline after the :file_changed hook (Bug 4)

### DIFF
--- a/lib/optimal_system_agent/tools/builtins/file_edit/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/file_edit/handler.ex
@@ -183,6 +183,15 @@ defmodule OptimalSystemAgent.Tools.Builtins.FileEdit.Handler do
                 operation: :edit
               })
 
+            # The :file_changed hook may be a formatter/linter that REWRITES the
+            # file. If so, the baseline recorded above (from OUR bytes) is now
+            # stale versus disk, and the NEXT edit would trip the read-before-
+            # edit / drift guard with a spurious "re-read the file first" — the
+            # rapid-edit churn users hit when a format-on-save hook is active.
+            # Re-capture from the final on-disk bytes so the guards reflect what
+            # is actually there.
+            refresh_write_baseline(session, expanded)
+
             # Generate unified diff (delegates to Utils.Diff for proper unified format)
             {diff_text, diff_stats} =
               OptimalSystemAgent.Utils.Diff.unified(content, new_content, display_path)
@@ -410,6 +419,27 @@ defmodule OptimalSystemAgent.Tools.Builtins.FileEdit.Handler do
   # Returns "" when the hook reports nothing (the common case: no post-edit
   # validation hook registered). Always non-fatal — never raises into the caller.
   @spec file_changed_note(map()) :: String.t()
+  @doc false
+  # Re-capture the read-before-edit and drift baselines from a file's CURRENT
+  # on-disk bytes, after a `:file_changed` hook (e.g. a formatter) may have
+  # rewritten it. Without this, a format-on-save hook leaves every write's
+  # baseline stale and the next edit is falsely rejected as "re-read first".
+  # Best-effort: a vanished/unreadable file just leaves the prior baseline.
+  @spec refresh_write_baseline(term(), String.t()) :: :ok
+  def refresh_write_baseline(session, path) do
+    with {:ok, content} <- File.read(path),
+         {:ok, %{mtime: mtime, size: size}} <- File.stat(path, time: :posix) do
+      # record_write re-stats + re-hashes internally; pass the fresh content to
+      # DriftGuard so both guards agree with disk.
+      FileState.record_write(session, path)
+      DriftGuard.record(session, path, content, mtime, size)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
   def file_changed_note(payload) do
     diagnostic =
       try do

--- a/lib/optimal_system_agent/tools/builtins/file_write/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/file_write/handler.ex
@@ -136,6 +136,11 @@ defmodule OptimalSystemAgent.Tools.Builtins.FileWrite.Handler do
                 operation: operation
               })
 
+            # The :file_changed hook may reformat the file; re-capture the
+            # read-state baseline from the final on-disk bytes so the NEXT write
+            # in a rapid sequence is not falsely flagged stale ("read first").
+            FileEditHandler.refresh_write_baseline(session, expanded)
+
             line_count = content |> String.split("\n") |> length()
             preview = content |> String.split("\n") |> Enum.take(10) |> Enum.join("\n")
 

--- a/lib/optimal_system_agent/tools/builtins/multi_file_edit/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/multi_file_edit/handler.ex
@@ -180,11 +180,18 @@ defmodule OptimalSystemAgent.Tools.Builtins.MultiFileEdit.Handler do
         hook_note =
           edited_paths
           |> Enum.map(fn ep ->
-            FileEditHandler.file_changed_note(%{
-              path: ep,
-              tool: "multi_file_edit",
-              operation: :edit
-            })
+            note =
+              FileEditHandler.file_changed_note(%{
+                path: ep,
+                tool: "multi_file_edit",
+                operation: :edit
+              })
+
+            # A :file_changed formatter hook may have rewritten this path;
+            # re-capture its baseline from the final on-disk bytes so a
+            # follow-up edit isn't falsely flagged stale.
+            FileEditHandler.refresh_write_baseline(session, ep)
+            note
           end)
           |> Enum.join("")
 

--- a/test/optimal_system_agent/tools/refresh_write_baseline_test.exs
+++ b/test/optimal_system_agent/tools/refresh_write_baseline_test.exs
@@ -1,0 +1,50 @@
+defmodule OptimalSystemAgent.Tools.RefreshWriteBaselineTest do
+  @moduledoc """
+  Bug 4: a :file_changed hook that reformats a file after a write left the
+  read-before-edit / drift baseline pointing at the pre-format bytes, so the
+  NEXT edit was falsely rejected with "re-read the file first" — the churn
+  users hit under rapid edits with a format-on-save hook. refresh_write_baseline
+  re-captures from the final on-disk bytes; these tests pin that.
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Tools.FileState
+  alias OptimalSystemAgent.Tools.Builtins.FileEdit.Handler
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "osa_rwb_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+    # A concrete (non-exempt) session so read-before-edit enforcement is live.
+    {:ok, dir: dir, session: "sess-#{System.unique_integer([:positive])}"}
+  end
+
+  test "a formatter rewrite after a write does NOT leave the next edit flagged stale",
+       %{dir: dir, session: session} do
+    path = Path.join(dir, "m.ts")
+    File.write!(path, "const x=1\n")
+
+    # The tool records the baseline from what it wrote.
+    FileState.record_write(session, path)
+    assert FileState.check_read(session, path) == :ok
+
+    # A :file_changed formatter hook rewrites the file (different bytes/size).
+    # Force a distinct mtime granule so the staleness check would trip.
+    File.write!(path, "const x = 1;\n")
+    stat = File.stat!(path, time: :posix)
+    File.touch!(path, stat.mtime + 2)
+
+    # Without a refresh this is now stale. The fix re-captures the baseline.
+    assert {:error, _} = FileState.check_read(session, path),
+           "precondition: the post-format file is stale versus the pre-format baseline"
+
+    assert :ok = Handler.refresh_write_baseline(session, path)
+    assert FileState.check_read(session, path) == :ok,
+           "after refresh, the next edit must not be falsely flagged stale"
+  end
+
+  test "refresh on a vanished file is a harmless no-op", %{dir: dir, session: session} do
+    path = Path.join(dir, "gone.ts")
+    assert :ok = Handler.refresh_write_baseline(session, path)
+  end
+end


### PR DESCRIPTION
**Bug 4 — "you must read the file first" churn during rapid edits.** `file_write`/`file_edit`/`multi_file_edit` recorded the read-before-edit (`FileState`) and drift baselines from the bytes they wrote, then ran the `:file_changed` hook — where a **format-on-save/linter** lives. When that hook rewrites the file, the baseline points at pre-format bytes while disk holds post-format bytes, so the next edit trips the staleness guard. With an active formatter this fired on nearly every write.

**Fix:** `refresh_write_baseline/2`, called in all three handlers **after** the hook, re-reads the final on-disk bytes and re-records both guards. A genuine external change after the tool's pipeline still trips the guard, as intended.

Test: formatter-style rewrite is stale WITHOUT the refresh (precondition) and NOT stale after; vanished-file refresh is a no-op. 101 edit/file_state/drift tests green.

This closes the last open item from the 2026-08-24 bug report — figured out from the code path (rapid-edit + format hook), no repro needed.