### PR TITLE
test(context): pin context window so the token-budget suite is deterministic

### DIFF
--- a/test/agent/context_test.exs
+++ b/test/agent/context_test.exs
@@ -33,7 +33,13 @@ defmodule OptimalSystemAgent.Agent.ContextTest do
         channel: :cli,
         messages: [],
         plan_mode: false,
-        working_dir: "/tmp"
+        working_dir: "/tmp",
+        # Pin the context window so token_budget/1 is deterministic. Without it,
+        # max_tok is derived from the GLOBALLY-active model, so an async sibling
+        # test that switched the active model flipped response_reserve from 8192
+        # to 4096 — the recurring `response_reserve is 8192` flake. 200k keeps
+        # response_reserve at its 8192 ceiling regardless of global model state.
+        effective_context_window: 200_000
       },
       overrides
     )


### PR DESCRIPTION
Kills the recurring `response_reserve is 8192` flake (hand-merged past ~6 times this session). `token_budget/1` derived `max_tok` from the globally-active model when the test didn't pin a window, so an async sibling switching models flipped `response_reserve` 8192→4096. Pinning `effective_context_window` in `base_state` makes the suite deterministic; other assertions are relative and unaffected. 39 tests green.