### PR TITLE
feat: cost-efficient long-running agents — speed tiers, $/task, budget policy, service_tier

### DIFF
--- a/lib/optimal_system_agent/agent/delegation_router.ex
+++ b/lib/optimal_system_agent/agent/delegation_router.ex
@@ -54,9 +54,19 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
   end
 
   defp choose(_task, config, requirements, opts) do
-    tier = Map.get(config, :tier, :specialist)
+    # Speed/priority tier: a latency-tolerance axis ORTHOGONAL to the quality
+    # tier. `:loose` (non-urgent, long-horizon work) trades speed/quality for
+    # cost — step the quality tier down one (floored at :specialist so tool use
+    # stays reliable) and prefer free/local providers first. `:immediate` steps
+    # up toward :elite for the best model. `:standard` (default) is unchanged.
+    priority = normalize_priority(Map.get(config, :priority))
+    tier = adjust_tier(Map.get(config, :tier, :specialist), priority)
     primary = Map.get(config, :provider) || default_provider()
-    candidates = Keyword.get(opts, :candidates, candidate_providers(primary))
+
+    candidates =
+      opts
+      |> Keyword.get(:candidates, candidate_providers(primary))
+      |> order_for_priority(priority)
     configured? = Keyword.get(opts, :configured?, &Registry.provider_configured?/1)
     model_for = Keyword.get(opts, :model_for, &Tier.model_for/2)
     tool_call = Keyword.get(opts, :tool_call, &ModelLimits.tool_call/2)
@@ -90,7 +100,11 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
         config
         |> Map.put(:provider, provider)
         |> Map.put(:model, model)
-        |> Map.put(:model_reason, selection_reason(provider, model, met, requirements -- met))
+        |> Map.put(:priority, priority)
+        |> Map.put(
+          :model_reason,
+          selection_reason(provider, model, met, requirements -- met) <> priority_note(priority)
+        )
         |> Map.put(:model_requirements, Enum.map(requirements, &to_string/1))
 
       nil ->
@@ -142,6 +156,50 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
 
     tools_ok and context_ok and vision_ok
   end
+
+  # ── Speed / priority tier ─────────────────────────────────────────────
+
+  @priorities [:immediate, :standard, :loose]
+  # Best → cheapest. Quality tier ordering used to step a priority bias.
+  @tier_order [:elite, :specialist, :utility]
+
+  @spec normalize_priority(term()) :: :immediate | :standard | :loose
+  defp normalize_priority(p) when p in @priorities, do: p
+  defp normalize_priority("immediate"), do: :immediate
+  defp normalize_priority("loose"), do: :loose
+  defp normalize_priority(_), do: :standard
+
+  # :immediate → one tier better (toward :elite). :loose → one tier cheaper
+  # (toward :utility) but floored at :specialist, the minimum tier that calls
+  # tools reliably, so a loose task never lands on a model that can't act.
+  defp adjust_tier(tier, :standard), do: tier
+  defp adjust_tier(tier, :immediate), do: step_tier(tier, -1)
+
+  defp adjust_tier(tier, :loose) do
+    stepped = step_tier(tier, +1)
+    if tier_index(stepped) > tier_index(:specialist), do: :specialist, else: stepped
+  end
+
+  defp step_tier(tier, delta) do
+    idx = tier_index(tier)
+    new_idx = (idx + delta) |> min(length(@tier_order) - 1) |> max(0)
+    Enum.at(@tier_order, new_idx)
+  end
+
+  defp tier_index(tier), do: Enum.find_index(@tier_order, &(&1 == tier)) || 1
+
+  # Loose work prefers free/local providers (zero cost, prompt stays on the
+  # machine); if none is configured/capable the relaxation walk still reaches
+  # the paid candidates. Other priorities keep the caller's order (primary first).
+  defp order_for_priority(candidates, :loose) do
+    {free, paid} = Enum.split_with(candidates, &FallbackChain.free?/1)
+    free ++ paid
+  end
+
+  defp order_for_priority(candidates, _), do: candidates
+
+  defp priority_note(:standard), do: ""
+  defp priority_note(p), do: " [priority: #{p}]"
 
   defp candidate_providers(primary) do
     allowed = FallbackChain.cost_gated_chain(FallbackChain.chain(), primary)

--- a/lib/optimal_system_agent/agent/loop.ex
+++ b/lib/optimal_system_agent/agent/loop.ex
@@ -175,7 +175,11 @@ defmodule OptimalSystemAgent.Agent.Loop do
     # Tri-mode delegation policy (primitive #34): :disabled | :explicit_only |
     # :proactive. nil defers to `config :optimal_system_agent, :delegation_policy`
     # (default :proactive). Read by ToolFilter + the delegate handler.
-    delegation_policy: nil
+    delegation_policy: nil,
+    # Speed/cost priority for this session (:immediate | :standard | :loose),
+    # inherited from the delegating task's config. Read by LLMClient to select a
+    # provider service_tier (OpenAI flex/priority) for cheaper long-horizon work.
+    priority: :standard
   ]
 
   @cancel_table :osa_cancel_flags
@@ -1197,6 +1201,7 @@ defmodule OptimalSystemAgent.Agent.Loop do
           default_permission_mode(),
       delegation_depth: Keyword.get(opts, :delegation_depth, 0),
       delegation_policy: Keyword.get(opts, :delegation_policy),
+      priority: Keyword.get(opts, :priority) || :standard,
       parent_session_id: Keyword.get(opts, :parent_session_id),
       allowed_tools: Keyword.get(opts, :allowed_tools),
       blocked_tools: Keyword.get(opts, :blocked_tools, []),

--- a/lib/optimal_system_agent/agent/loop/accounting.ex
+++ b/lib/optimal_system_agent/agent/loop/accounting.ex
@@ -816,9 +816,18 @@ defmodule OptimalSystemAgent.Agent.Loop.Accounting do
   @spec snapshot(map()) :: map()
   def snapshot(state) do
     tree = safe_tree_spend(state)
+    cost = get(state, :session_cost_usd, 0.0)
+    # A completed task ≈ one user turn (each user message drives one turn to a
+    # terminal answer). $/completed-task is the number Vetta-style comparisons
+    # turn on, and it is the honest efficiency figure for long-running work:
+    # total spend amortised over tasks actually finished. turn_count is 0 before
+    # the first turn completes, so guard the divide.
+    tasks = max(get(state, :turn_count, 0), 1)
 
     %{
-      cost_usd: round6(get(state, :session_cost_usd, 0.0)),
+      cost_usd: round6(cost),
+      cost_per_task_usd: round6(cost / tasks),
+      completed_tasks: get(state, :turn_count, 0),
       tree_cost_usd: tree.usd,
       tree_cost_complete: tree.complete,
       input_tokens: get(state, :session_input_tokens, 0),

--- a/lib/optimal_system_agent/agent/loop/llm_client.ex
+++ b/lib/optimal_system_agent/agent/loop/llm_client.ex
@@ -73,6 +73,30 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
 
   def capped_retry_delay_ms(_), do: 0
 
+
+  # Map the session's speed priority to an OpenAI processing tier. Only OpenAI
+  # honours `service_tier`; openai_compat gates it to that provider, so setting
+  # it for any provider is safe (ignored elsewhere). :loose → "flex" (~50%
+  # cheaper, slower — right for long-horizon background work); :immediate →
+  # "priority" (faster); :standard / unknown → unset (provider default).
+  defp maybe_put_service_tier(opts, state) do
+    case service_tier_for(state) do
+      nil -> opts
+      tier -> Keyword.put_new(opts, :service_tier, tier)
+    end
+  end
+
+  defp service_tier_for(state) when is_map(state) do
+    case Map.get(state, :priority) do
+      :loose -> "flex"
+      :immediate -> "priority"
+      _ -> nil
+    end
+  end
+
+  defp service_tier_for(_), do: nil
+
+
   defp retry_after_cap_ms do
     case Application.get_env(:optimal_system_agent, :retry_after_cap_ms, @retry_after_cap_ms) do
       n when is_integer(n) and n > 0 -> n
@@ -236,6 +260,7 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
 
     opts = if provider, do: Keyword.put(opts, :provider, provider), else: opts
     opts = if model, do: Keyword.put(opts, :model, model), else: opts
+    opts = maybe_put_service_tier(opts, state)
 
     # Session identity for the provider layer: it keys the prompt-cache
     # attributor's per-scope comparison, and on OpenAI it becomes the
@@ -304,7 +329,7 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
 
   Returns {:ok, result} | {:error, reason}.
   """
-  def llm_chat_stream(%{session_id: session_id, provider: provider, model: model}, messages, opts) do
+  def llm_chat_stream(%{session_id: session_id, provider: provider, model: model} = state, messages, opts) do
     Logger.debug(
       "[llm] stream — #{length(messages)} messages (sanitized): #{inspect(sanitize_for_log(messages))} session=#{session_id}"
     )
@@ -490,6 +515,7 @@ defmodule OptimalSystemAgent.Agent.Loop.LLMClient do
 
     opts = if provider, do: Keyword.put(opts, :provider, provider), else: opts
     opts = if model, do: Keyword.put(opts, :model, model), else: opts
+    opts = maybe_put_service_tier(opts, state)
     opts = maybe_put_session(opts, session_id)
 
     # TEMP measurement instrumentation (OSA_CONTEXT_TRACE=1). No-op when unset.

--- a/lib/optimal_system_agent/agent/loop/tool_executor.ex
+++ b/lib/optimal_system_agent/agent/loop/tool_executor.ex
@@ -804,19 +804,61 @@ defmodule OptimalSystemAgent.Agent.Loop.ToolExecutor do
   # OBSERVABLE: both outcomes are announced above debug. An auto-ALLOW under the
   # bypass is the one that matters most — it is a permission decision taken with
   # no human in it — and it used to be entirely silent.
+  # True when the unattended budget-approval policy should allow this call:
+  # the operator enabled :budget_auto_approve AND a positive per-session cap is
+  # set AND spend is still under it. Strictly bounded — the loop still halts at
+  # the cap. Default OFF.
+  defp budget_policy_allows?(state) when is_map(state) do
+    cap = Map.get(state, :max_budget_usd)
+
+    Application.get_env(:optimal_system_agent, :budget_auto_approve, false) and
+      is_number(cap) and cap > 0 and
+      Map.get(state, :session_cost_usd, 0.0) < cap
+  end
+
+  defp budget_policy_allows?(_), do: false
+
   defp non_interactive_decision(tool_call, state) do
     sid = if is_map(state), do: Map.get(state, :session_id), else: nil
     why = Attendance.reason(state)
 
-    if Application.get_env(:optimal_system_agent, :non_interactive_permission_bypass, false) do
-      Logger.warning(
-        "[permissions] auto-ALLOWED #{tool_call.name} without asking — unattended session " <>
-          "(#{why}) and :non_interactive_permission_bypass is set"
-      )
+    cond do
+      Application.get_env(:optimal_system_agent, :non_interactive_permission_bypass, false) ->
+        Logger.warning(
+          "[permissions] auto-ALLOWED #{tool_call.name} without asking — unattended session " <>
+            "(#{why}) and :non_interactive_permission_bypass is set"
+        )
 
-      emit_non_interactive(:allow, tool_call.name, sid, why)
-      :allow
-    else
+        emit_non_interactive(:allow, tool_call.name, sid, why)
+        :allow
+
+      # Budget-policy approval (governance for unattended long runs): when the
+      # operator has enabled the policy AND set a per-session spend cap AND spend
+      # is still under it, an otherwise-fail-closed :ask is ALLOWED. This runs
+      # AFTER every security check (deny rules, circuit breaker, bypass-immune
+      # safety, plan mode, tier) — it only ever converts a would-fail-closed ask
+      # into an allow, never overrides a block. Autonomy stays strictly bounded
+      # by dollars: Loop.Limits.budget_exceeded? halts the whole run the moment
+      # the cap is crossed. Default OFF, so fail-closed behaviour is unchanged.
+      budget_policy_allows?(state) ->
+        cap = Map.get(state, :max_budget_usd)
+        spent = Map.get(state, :session_cost_usd, 0.0)
+
+        Logger.info(
+          "[permissions] auto-ALLOWED #{tool_call.name} — unattended within budget policy " <>
+            "($#{Float.round(spent / 1, 4)}/$#{cap})"
+        )
+
+        emit_non_interactive(:allow, tool_call.name, sid, why)
+        :allow
+
+      true -> nil
+    end
+    |> case do
+      :allow ->
+        :allow
+
+      nil ->
       Logger.info(
         "[permissions] auto-DENIED #{tool_call.name} — unattended session (#{why}), " <>
           "permissions fail closed"

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -470,7 +470,10 @@ defmodule OptimalSystemAgent.Orchestrator do
       # own run mid-loop via `Loop.Limits.budget_exceeded?` once it crosses the
       # cap, so a wide fan-out cannot burn unbounded spend. Enforced per child;
       # the parent's own budget is independent.
-      max_budget_usd: Map.get(config, :max_budget_usd)
+      max_budget_usd: Map.get(config, :max_budget_usd),
+      # Speed/cost priority (routes a service_tier for OpenAI; also set the
+      # quality tier + provider order in DelegationRouter).
+      priority: Map.get(config, :priority)
     ]
 
     # Start event forwarder BEFORE spawning the subagent so it catches

--- a/lib/optimal_system_agent/providers/openai_compat.ex
+++ b/lib/optimal_system_agent/providers/openai_compat.ex
@@ -95,6 +95,7 @@ defmodule OptimalSystemAgent.Providers.OpenAICompat do
       |> maybe_add_temperature(model, opts)
       |> maybe_add_tools(opts)
       |> maybe_add_max_tokens(model, opts)
+      |> maybe_add_service_tier(opts)
       |> maybe_add_reasoning(model, opts)
       # LAST: DeepSeek accepts only low/high/max, so this must overwrite the
       # generic "medium" that maybe_add_reasoning/3 would otherwise leave.
@@ -281,6 +282,7 @@ defmodule OptimalSystemAgent.Providers.OpenAICompat do
     |> maybe_add_temperature(model, opts)
     |> maybe_add_tools(opts)
     |> maybe_add_max_tokens(model, opts)
+    |> maybe_add_service_tier(opts)
     |> maybe_add_reasoning(model, opts)
     # LAST: DeepSeek accepts only low/high/max, so this must overwrite the
     # generic "medium" that maybe_add_reasoning/3 would otherwise leave.
@@ -1316,6 +1318,23 @@ defmodule OptimalSystemAgent.Providers.OpenAICompat do
   # field and require `max_completion_tokens`. Every other OpenAI-compatible
   # provider uses `max_tokens`. Route the value to the right key so o-series
   # calls don't 400 ("max_tokens is not supported with this model").
+  # OpenAI processing tier ("flex" ~50% cheaper + slower for non-urgent work,
+  # "priority" faster, "default"/"auto" standard). Added ONLY for the real
+  # OpenAI provider — other OpenAI-compatible backends (xAI/grok, OpenRouter,
+  # local) reject an unknown `service_tier` with a 422, so we never send it
+  # there. Off unless a caller (llm_client, from the task's speed priority) set
+  # :service_tier.
+  defp maybe_add_service_tier(body, opts) do
+    tier = Keyword.get(opts, :service_tier)
+    provider = Keyword.get(opts, :provider, image_provider(opts))
+
+    if is_binary(tier) and tier != "" and provider == :openai do
+      Map.put(body, :service_tier, tier)
+    else
+      body
+    end
+  end
+
   defp maybe_add_max_tokens(body, model, opts) do
     case Keyword.get(opts, :max_tokens) do
       nil ->

--- a/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
@@ -238,7 +238,11 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
       # the child Loop aborts its own run once it crosses the cap, so a wide
       # fan-out cannot burn unbounded spend. Each child is capped independently.
       max_budget_usd:
-        parse_budget_usd(Map.get(args, "max_budget_usd") || Map.get(args, "maxBudgetUsd"))
+        parse_budget_usd(Map.get(args, "max_budget_usd") || Map.get(args, "maxBudgetUsd")),
+      # Speed/cost tier, normalized by DelegationRouter (nil → :standard). Biases
+      # model tier + provider order toward cheaper/local for :loose long-horizon
+      # work and toward the best model for :immediate.
+      priority: Map.get(args, "priority")
     }
 
     DelegationRouter.resolve(child_task, config)

--- a/lib/optimal_system_agent/tools/builtins/delegate/tool.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/tool.ex
@@ -124,6 +124,14 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Tool do
             "Per-subagent USD spend ceiling. The subagent stops itself once it " <>
               "crosses this cap. Omit for no cap. Use on wide fan-outs to bound total spend."
         },
+        "priority" => %{
+          "type" => "string",
+          "enum" => ["immediate", "standard", "loose"],
+          "description" =>
+            "Speed/cost tier. 'loose' (non-urgent, long-horizon work) routes to a " <>
+              "cheaper model and prefers free/local providers to cut cost; 'immediate' " <>
+              "picks the best model; 'standard' (default) is balanced."
+        },
         "model" => %{
           "type" => "string",
           "description" => "Model override for this subagent."

--- a/test/optimal_system_agent/agent/delegation_router_test.exs
+++ b/test/optimal_system_agent/agent/delegation_router_test.exs
@@ -129,4 +129,71 @@ defmodule OptimalSystemAgent.Agent.DelegationRouterTest do
     assert routed.provider == :first
     assert routed.model_reason =~ "proceeding without it"
   end
+
+  describe "speed/priority tier biases tier and provider order" do
+    # Capture the tier the router asks model_for for, so we can assert the
+    # priority bias without depending on a real model table.
+    defp capture_tier_router(task, config, extra \\ []) do
+      test_pid = self()
+
+      opts =
+        [
+          candidates: [:paid_primary, :free_local],
+          configured?: fn _ -> true end,
+          model_for: fn tier, provider ->
+            send(test_pid, {:asked, tier, provider})
+            "#{provider}-#{tier}-model"
+          end,
+          tool_call: fn _, _ -> true end,
+          context_window: fn _ -> 200_000 end,
+          vision_capable: fn _, _ -> true end
+        ] ++ extra
+
+      DelegationRouter.resolve(task, config, opts)
+    end
+
+    test "loose steps the quality tier DOWN one, floored at :specialist" do
+      # elite → specialist under loose
+      routed = capture_tier_router("do it", %{provider: :paid_primary, tier: :elite, priority: "loose"})
+      assert_received {:asked, :specialist, _}
+      assert routed.priority == :loose
+      assert routed.model_reason =~ "priority: loose"
+    end
+
+    test "loose never drops below :specialist (stays tool-capable)" do
+      capture_tier_router("do it", %{provider: :paid_primary, tier: :specialist, priority: "loose"})
+      # specialist stepped toward utility would be :utility, but loose is floored
+      assert_received {:asked, :specialist, _}
+    end
+
+    test "immediate steps the quality tier UP toward :elite" do
+      capture_tier_router("do it", %{provider: :paid_primary, tier: :specialist, priority: "immediate"})
+      assert_received {:asked, :elite, _}
+    end
+
+    test "loose prefers a free/local provider over the paid primary" do
+      # FallbackChain.free?/1 decides; :ollama is free in the default set. Use it
+      # as the free candidate so ordering puts it first for loose.
+      test_pid = self()
+
+      DelegationRouter.resolve("do it", %{provider: :openai, tier: :specialist, priority: "loose"},
+        candidates: [:openai, :ollama],
+        configured?: fn _ -> true end,
+        model_for: fn _tier, provider -> send(test_pid, {:picked, provider}); "#{provider}-m" end,
+        tool_call: fn _, _ -> true end,
+        context_window: fn _ -> 200_000 end,
+        vision_capable: fn _, _ -> true end
+      )
+
+      # The FIRST provider offered to model_for under loose must be the free one.
+      assert_received {:picked, :ollama}
+    end
+
+    test "standard (default) leaves tier and order unchanged" do
+      routed = capture_tier_router("do it", %{provider: :paid_primary, tier: :specialist})
+      assert_received {:asked, :specialist, :paid_primary}
+      assert routed.priority == :standard
+      refute routed.model_reason =~ "priority:"
+    end
+  end
 end

--- a/test/optimal_system_agent/agent/loop/accounting_test.exs
+++ b/test/optimal_system_agent/agent/loop/accounting_test.exs
@@ -436,5 +436,17 @@ defmodule OptimalSystemAgent.Agent.Loop.AccountingTest do
       assert snap.input_tokens == 1_000_000
       assert Map.has_key?(snap, :max_budget_usd)
     end
+
+    test "reports $/completed-task amortised over turns" do
+      snap = Accounting.snapshot(%{session_cost_usd: 0.60, turn_count: 3})
+      assert snap.completed_tasks == 3
+      assert snap.cost_per_task_usd == 0.2
+    end
+
+    test "$/task is guarded before the first task completes (no divide-by-zero)" do
+      snap = Accounting.snapshot(%{session_cost_usd: 0.0, turn_count: 0})
+      assert snap.completed_tasks == 0
+      assert snap.cost_per_task_usd == 0.0
+    end
   end
 end

--- a/test/optimal_system_agent/agent/loop/budget_auto_approve_test.exs
+++ b/test/optimal_system_agent/agent/loop/budget_auto_approve_test.exs
@@ -1,0 +1,82 @@
+defmodule OptimalSystemAgent.Agent.Loop.BudgetAutoApproveTest do
+  @moduledoc """
+  Phase 3 governance: an unattended agent with a per-session spend cap and the
+  :budget_auto_approve policy enabled acts freely UP TO the cap, then falls
+  closed. The policy only ever converts a would-fail-closed :ask into an allow;
+  it runs after every security check and never overrides a block. A saved `ask`
+  rule on the tool forces the interactive path so these tests exercise exactly
+  that decision point.
+  """
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Agent.Loop
+  alias OptimalSystemAgent.Agent.Loop.ToolExecutor
+  alias OptimalSystemAgent.Settings
+
+  @flag_file Path.join(System.tmp_dir!(), "osa-bap-settings.json")
+
+  setup do
+    prior_policy = Application.get_env(:optimal_system_agent, :budget_auto_approve, false)
+    prior_flag = Application.get_env(:optimal_system_agent, :settings_flag_path)
+    prior_interactive = Application.get_env(:optimal_system_agent, :interactive_permissions, false)
+    # The test env sets :non_interactive_permission_bypass true (auto-allow all
+    # unattended). Turn it OFF here so the budget policy / fail-closed actually
+    # decide, which is the whole point of these tests.
+    prior_bypass = Application.get_env(:optimal_system_agent, :non_interactive_permission_bypass, false)
+    Application.put_env(:optimal_system_agent, :non_interactive_permission_bypass, false)
+
+    # Force an ASK rule on shell_execute so it needs approval, and mark the
+    # session unattended so the decision falls to non_interactive_decision.
+    File.write!(@flag_file, Jason.encode!(%{"permissions" => %{"ask" => ["shell_execute"]}}))
+    Application.put_env(:optimal_system_agent, :settings_flag_path, @flag_file)
+    Application.put_env(:optimal_system_agent, :interactive_permissions, false)
+    Settings.reset_cache()
+
+    on_exit(fn ->
+      Application.put_env(:optimal_system_agent, :budget_auto_approve, prior_policy)
+      Application.put_env(:optimal_system_agent, :interactive_permissions, prior_interactive)
+      Application.put_env(:optimal_system_agent, :non_interactive_permission_bypass, prior_bypass)
+
+      case prior_flag do
+        nil -> Application.delete_env(:optimal_system_agent, :settings_flag_path)
+        p -> Application.put_env(:optimal_system_agent, :settings_flag_path, p)
+      end
+
+      File.rm(@flag_file)
+      Settings.reset_cache()
+    end)
+
+    :ok
+  end
+
+  defp unattended(overrides),
+    do:
+      struct(
+        Loop,
+        [session_id: "bap-#{System.unique_integer([:positive])}", channel: :internal, permission_mode: :ask] ++
+          overrides
+      )
+
+  defp tool,
+    do: %{id: "tc-#{System.unique_integer([:positive])}", name: "shell_execute", arguments: %{"command" => "echo hi"}}
+
+  test "within budget + policy on → allowed" do
+    Application.put_env(:optimal_system_agent, :budget_auto_approve, true)
+    assert ToolExecutor.approve_tool_call(tool(), unattended(max_budget_usd: 1.0, session_cost_usd: 0.10)) == :allow
+  end
+
+  test "over budget + policy on → blocked (bounded by dollars)" do
+    Application.put_env(:optimal_system_agent, :budget_auto_approve, true)
+    assert {:blocked, _} = ToolExecutor.approve_tool_call(tool(), unattended(max_budget_usd: 1.0, session_cost_usd: 2.0))
+  end
+
+  test "policy OFF → fails closed even within budget (unchanged default)" do
+    Application.put_env(:optimal_system_agent, :budget_auto_approve, false)
+    assert {:blocked, _} = ToolExecutor.approve_tool_call(tool(), unattended(max_budget_usd: 1.0, session_cost_usd: 0.10))
+  end
+
+  test "no cap set → policy does not fire (blocked)" do
+    Application.put_env(:optimal_system_agent, :budget_auto_approve, true)
+    assert {:blocked, _} = ToolExecutor.approve_tool_call(tool(), unattended(max_budget_usd: nil, session_cost_usd: 0.10))
+  end
+end

--- a/test/providers/openai_compat_test.exs
+++ b/test/providers/openai_compat_test.exs
@@ -834,4 +834,23 @@ defmodule OptimalSystemAgent.Providers.OpenAICompatTest do
       assert body.stream_options == %{include_usage: true}
     end
   end
+
+  describe "service_tier (speed/cost priority)" do
+    @msgs [%{role: "user", content: "hi"}]
+
+    test "adds service_tier for the real OpenAI provider" do
+      body = OpenAICompat.build_stream_body("gpt-5", @msgs, provider: :openai, service_tier: "flex")
+      assert body.service_tier == "flex"
+    end
+
+    test "NEVER sends service_tier to other OpenAI-compatible backends (422 guard)" do
+      body = OpenAICompat.build_stream_body("grok-4.6", @msgs, provider: :xai, service_tier: "flex")
+      refute Map.has_key?(body, :service_tier)
+    end
+
+    test "omitted when no priority/service_tier is set" do
+      body = OpenAICompat.build_stream_body("gpt-5", @msgs, provider: :openai)
+      refute Map.has_key?(body, :service_tier)
+    end
+  end
 end


### PR DESCRIPTION
All four cost/robustness phases (Vetta-inspired), **one version**:

**1. Speed/priority tier** — `delegate priority: immediate|standard|loose`. `loose` steps the quality tier down (floored at `specialist`) + prefers free/local providers; `immediate` steps up toward `elite`. Pure routing, composes with `max_budget_usd`.

**2. $/completed-task metric** — `cost_per_task_usd` + `completed_tasks` in the accounting snapshot (flows to TUI status + `get_state`). Divide-by-zero guarded.

**3. Budget-policy approval** — `:budget_auto_approve` (default OFF): an unattended agent with a spend cap acts freely up to the cap then falls closed. Evaluated after every security check, so it only converts a would-fail-closed ask into an allow, never overrides a block. Bounded by dollars (`Loop.Limits` halts at the cap).

**4. Provider service_tier** — priority selects an OpenAI processing tier (`loose→flex` ~50% off, `immediate→priority`). Gated to the real `:openai` provider so other OpenAI-compatible backends never get a 422. Off by default.

Also confirmed: **zero-spend idle is already true** — an idle OSA Loop is a blocked GenServer with no keepalive, so OSA already beats the 'only pay while working' pitch; no work needed.

Tests: 668 loop/orchestrator/delegate/provider/accounting + router + budget-policy + service_tier-gating, all green.