### PR TITLE
feat: the final 3 — cost-aware routing (#10), async batch foundation (#5), cheaper wake (#3)

### DIFF
--- a/lib/optimal_system_agent/agent/cost_observations.ex
+++ b/lib/optimal_system_agent/agent/cost_observations.ex
@@ -1,0 +1,151 @@
+defmodule OptimalSystemAgent.Agent.CostObservations do
+  @moduledoc """
+  Cost-aware routing feedback (#10). Records a rolling per-turn USD cost per
+  `{provider, model}` and lets the router prefer the cheaper option for
+  non-urgent (`:loose`) work — a "cheapest observed that still did the job"
+  tie-break, never a capability/tier override.
+
+  The average is an exponential moving average (EMA) so recent turns dominate
+  without storing history. Storage is a public, self-owning named ETS table,
+  the same lazily-started-unsupervised-owner pattern `Tools.FileState` uses: if
+  the owner dies the table is recreated on next use and the worst case is a lost
+  observation (falls back to no-data = today's routing), never a crash.
+  """
+  use GenServer
+  require Logger
+
+  @table :osa_cost_observations
+  # EMA weight on the newest sample. 0.3 = ~last 5-6 turns dominate; enough to
+  # track a model getting cheaper/pricier without thrashing on one outlier.
+  @alpha 0.3
+
+  # ── owner ──────────────────────────────────────────────────────────────
+  @doc false
+  def start_link(_ \\ []), do: GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+
+  @impl true
+  def init(:ok) do
+    ensure_ets()
+    {:ok, %{}}
+  end
+
+  # ── API ────────────────────────────────────────────────────────────────
+
+  @doc """
+  Fold one turn's cost into the EMA for `{provider, model}`. Zero/nil cost and a
+  missing provider/model are ignored (no basis to learn). Best-effort.
+  """
+  @spec record(term(), term(), number() | nil) :: :ok
+  def record(provider, model, cost_usd)
+      when not is_nil(provider) and not is_nil(model) and is_number(cost_usd) and cost_usd > 0 do
+    ensure_table()
+    key = {provider, to_string(model)}
+
+    next =
+      case safe_lookup(key) do
+        [{^key, prev}] when is_number(prev) -> prev + @alpha * (cost_usd - prev)
+        _ -> cost_usd
+      end
+
+    safe_insert(key, next)
+    :ok
+  end
+
+  def record(_, _, _), do: :ok
+
+  @doc "Observed EMA cost for `{provider, model}`, or `nil` when never seen."
+  @spec avg_cost(term(), term()) :: float() | nil
+  def avg_cost(provider, model) do
+    ensure_table()
+
+    case safe_lookup({provider, to_string(model)}) do
+      [{_key, v}] when is_number(v) -> v * 1.0
+      _ -> nil
+    end
+  end
+
+  @doc "Drop all observations. Test/maintenance helper."
+  @spec reset() :: :ok
+  def reset do
+    ensure_table()
+
+    try do
+      :ets.delete_all_objects(@table)
+    rescue
+      ArgumentError -> :ok
+    end
+
+    :ok
+  end
+
+  @doc false
+  # Telemetry handler for `[:osa, :accounting, :provider_cost]`. Attached in
+  # Application.start/2. Prefers the provider's authoritative cost, falling back
+  # to the rate-card estimate. Never raises into the telemetry dispatcher.
+  def handle_telemetry(_event, measurements, metadata, _config) do
+    cost =
+      case Map.get(measurements, :provider_cost_usd) do
+        c when is_number(c) and c > 0 -> c
+        _ -> Map.get(measurements, :rate_card_estimate_usd)
+      end
+
+    record(Map.get(metadata, :provider), Map.get(metadata, :model), cost)
+  rescue
+    _ -> :ok
+  catch
+    _, _ -> :ok
+  end
+
+  # ── ETS plumbing (mirrors Tools.FileState) ───────────────────────────────
+  defp safe_lookup(key) do
+    :ets.lookup(@table, key)
+  rescue
+    ArgumentError -> []
+  end
+
+  defp safe_insert(key, val) do
+    :ets.insert(@table, {key, val})
+    :ok
+  rescue
+    ArgumentError ->
+      ensure_table()
+
+      try do
+        :ets.insert(@table, {key, val})
+      rescue
+        ArgumentError -> :ok
+      end
+
+      :ok
+  end
+
+  defp ensure_table do
+    case :ets.whereis(@table) do
+      :undefined ->
+        case GenServer.start(__MODULE__, :ok, name: __MODULE__) do
+          {:ok, _} -> :ok
+          {:error, {:already_started, _}} -> :ok
+          _ -> ensure_ets()
+        end
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp ensure_ets do
+    case :ets.whereis(@table) do
+      :undefined ->
+        try do
+          :ets.new(@table, [:named_table, :public, :set, read_concurrency: true, write_concurrency: true])
+        rescue
+          ArgumentError -> :ok
+        end
+
+      _ ->
+        :ok
+    end
+
+    :ok
+  end
+end

--- a/lib/optimal_system_agent/agent/delegation_router.ex
+++ b/lib/optimal_system_agent/agent/delegation_router.ex
@@ -8,6 +8,7 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
   Unknown capability data is treated as unknown rather than unsupported.
   """
 
+  alias OptimalSystemAgent.Agent.CostObservations
   alias OptimalSystemAgent.Agent.Tier
   alias OptimalSystemAgent.Providers.{FallbackChain, ImageBudget, ModelLimits, Registry}
 
@@ -74,14 +75,29 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
     vision_capable = Keyword.get(opts, :vision_capable, &ImageBudget.vision_capable?/2)
 
     find = fn reqs ->
-      Enum.find_value(candidates, fn provider ->
-        model = model_for.(tier, provider)
+      compatible =
+        candidates
+        |> Enum.map(fn provider -> {provider, model_for.(tier, provider)} end)
+        |> Enum.filter(fn {provider, model} ->
+          configured?.(provider) and
+            compatible?(reqs, provider, model, tool_call, context_window, vision_capable)
+        end)
 
-        if configured?.(provider) and
-             compatible?(reqs, provider, model, tool_call, context_window, vision_capable) do
-          {provider, model}
-        end
-      end)
+      case {priority, compatible} do
+        {_, []} ->
+          nil
+
+        # Cost-aware routing (#10): for non-urgent work, among the compatible
+        # candidates prefer the cheapest one we've actually OBSERVED — but never
+        # route away from a free/local provider (it's $0). No-data candidates
+        # keep their existing order, so with no history this is identical to
+        # today's first-compatible pick.
+        {:loose, list} ->
+          cheapest_observed(list)
+
+        {_, [first | _]} ->
+          first
+      end
     end
 
     # Walk the relaxation ladder: full requirements first, then progressively
@@ -191,6 +207,21 @@ defmodule OptimalSystemAgent.Agent.DelegationRouter do
   # Loose work prefers free/local providers (zero cost, prompt stays on the
   # machine); if none is configured/capable the relaxation walk still reaches
   # the paid candidates. Other priorities keep the caller's order (primary first).
+  # Among compatible candidates, pick the one with the lowest OBSERVED cost,
+  # keeping all free/local providers ahead of paid ones (free is $0) and
+  # preserving original order for candidates with no observation yet. With no
+  # history at all this returns the first candidate — identical to the plain
+  # first-compatible pick.
+  defp cheapest_observed(candidates) do
+    candidates
+    |> Enum.with_index()
+    |> Enum.min_by(fn {{provider, model}, idx} ->
+      free_rank = if FallbackChain.free?(provider), do: 0, else: 1
+      {free_rank, CostObservations.avg_cost(provider, model) || :infinity, idx}
+    end)
+    |> elem(0)
+  end
+
   defp order_for_priority(candidates, :loose) do
     {free, paid} = Enum.split_with(candidates, &FallbackChain.free?/1)
     free ++ paid

--- a/lib/optimal_system_agent/application.ex
+++ b/lib/optimal_system_agent/application.ex
@@ -26,6 +26,16 @@ defmodule OptimalSystemAgent.Application do
   def start(_type, _args) do
     Application.put_env(:optimal_system_agent, :start_time, System.system_time(:second))
 
+    # Cost-aware routing feedback (#10): learn per-model cost from the
+    # accounting cost telemetry so the router can prefer the cheaper option for
+    # non-urgent work. Best-effort, idempotent attach; the handler never raises.
+    :telemetry.attach(
+      "osa-cost-observations",
+      [:osa, :accounting, :provider_cost],
+      &OptimalSystemAgent.Agent.CostObservations.handle_telemetry/4,
+      nil
+    )
+
     # Separate from :start_time (wall-clock seconds, used for /health uptime):
     # a monotonic reading so the "boot complete" line can report MILLISECONDS.
     # At second granularity the difference between a 400ms boot and a 1400ms one

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -227,6 +227,19 @@ defmodule OptimalSystemAgent.Orchestrator do
   def run_subagent(%{routing_error: reason}), do: {:error, {:no_capable_model, reason}}
 
   def run_subagent(config) do
+    # Cheaper agent wake (#3): if this id belongs to a subagent that finished
+    # recently and is still resident in memory (lingering, see `maybe_linger/5`),
+    # reuse the live Loop directly — no terminate, no transcript replay. This is
+    # only ever reachable when `:subagent_linger_ms` > 0; with the default 0 no
+    # linger record is ever created, so `resume_lingering_if_resident/1` always
+    # returns `:no` and behavior is byte-for-byte identical to before.
+    case resume_lingering_if_resident(config) do
+      {:reused, result} -> result
+      :no -> run_fresh_subagent(config)
+    end
+  end
+
+  defp run_fresh_subagent(config) do
     task = Map.fetch!(config, :task)
     parent_id = Map.fetch!(config, :parent_session_id)
     role = Map.get(config, :role, "agent")
@@ -533,11 +546,22 @@ defmodule OptimalSystemAgent.Orchestrator do
           :exit, _ -> :ok
         end
 
-        # Cleanup
+        # Cleanup. Normally the child Loop is terminated now and its worktree
+        # torn down. When linger is enabled and the run SUCCEEDED, ownership of
+        # both is handed to a linger process that keeps the pid resident for a
+        # TTL so a quick resume can reuse it without replay. With linger disabled
+        # (the default) `maybe_linger/5` always returns `:terminate_now`, so this
+        # is exactly the original terminate-then-finish_worktree path.
         stop_event_forwarder(forwarder)
-        safely_terminate(pid)
 
-        finish_worktree(worktree_info, subagent_id, config, result)
+        case maybe_linger(pid, subagent_id, worktree_info, config, result) do
+          :lingering ->
+            :ok
+
+          :terminate_now ->
+            safely_terminate(pid)
+            finish_worktree(worktree_info, subagent_id, config, result)
+        end
 
         result
 
@@ -649,6 +673,196 @@ defmodule OptimalSystemAgent.Orchestrator do
         :subagent_join_timeout_ms,
         @default_subagent_timeout_ms
       )
+  end
+
+  # ── Cheaper agent wake (#3): keep a finished subagent RESIDENT briefly ──
+  #
+  # A terminated subagent Loop is expensive to bring back: `resume_subagent/2`
+  # restarts a fresh Loop and REPLAYS the whole durable transcript as input
+  # tokens. A never-terminated idle Loop, by contrast, costs nothing to wake —
+  # its context is already in memory.
+  #
+  # So on a SUCCESSFUL completion, when `:subagent_linger_ms` > 0, we do NOT
+  # terminate the child immediately. A linger process takes ownership of the
+  # pid + its worktree and:
+  #
+  #   * terminates + tears down after the TTL if no resume arrives, OR
+  #   * hands the pid straight back to a resume that reaches it first (the fast
+  #     path in `resume_lingering/2`), which reuses it with no replay, OR
+  #   * cleans up if the Loop dies on its own in the meantime.
+  #
+  # DEFAULT is 0 — no linger process is ever spawned and every completion takes
+  # the original terminate-immediately path. The resident-reuse path is dead
+  # code until an operator opts in.
+  @default_subagent_linger_ms 0
+
+  @doc false
+  def subagent_linger_ms do
+    Application.get_env(
+      :optimal_system_agent,
+      :subagent_linger_ms,
+      @default_subagent_linger_ms
+    )
+  end
+
+  # Registry key the linger owner process registers itself under. A tuple key
+  # can never collide with the plain-string session ids the Loops register with,
+  # and its stored value is the resident Loop pid.
+  defp linger_key(agent_id), do: {:linger, agent_id}
+
+  # Decide the fate of a just-finished child. `:lingering` means a linger owner
+  # now owns teardown of BOTH the pid and the worktree; `:terminate_now` means
+  # the caller must terminate + finish_worktree itself (the original behavior).
+  defp maybe_linger(pid, subagent_id, worktree_info, config, result) do
+    ttl = subagent_linger_ms()
+
+    if ttl > 0 and match?({:ok, _}, result) and is_pid(pid) and Process.alive?(pid) do
+      start_linger(pid, subagent_id, worktree_info, config, result, ttl)
+      :lingering
+    else
+      :terminate_now
+    end
+  rescue
+    # A linger is a pure optimization; if anything about arming it fails, fall
+    # back to terminating now so a pid is never accidentally leaked.
+    _ -> :terminate_now
+  end
+
+  defp start_linger(pid, subagent_id, worktree_info, config, result, ttl) do
+    spawn(fn ->
+      Registry.register(OptimalSystemAgent.SessionRegistry, linger_key(subagent_id), pid)
+      ref = Process.monitor(pid)
+
+      receive do
+        {:cancel_linger, caller} ->
+          # A resume claimed this resident pid. Hand back the worktree it must
+          # keep running under; DO NOT terminate — the resume owns it now.
+          Process.demonitor(ref, [:flush])
+          send(caller, {:linger_cancelled, worktree_info})
+
+        {:DOWN, ^ref, :process, _, _} ->
+          # The Loop died on its own before the TTL. Only the worktree is left
+          # to clean up.
+          finish_worktree(worktree_info, subagent_id, config, result)
+      after
+        ttl ->
+          Logger.info(
+            "[Orchestrator] Linger TTL (#{ttl}ms) elapsed for #{subagent_id} with no resume — terminating"
+          )
+
+          safely_terminate(pid)
+          finish_worktree(worktree_info, subagent_id, config, result)
+      end
+    end)
+
+    :ok
+  end
+
+  # True only for an id whose linger owner is registered AND whose resident Loop
+  # pid is still alive.
+  defp lingering?(agent_id) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, linger_key(agent_id)) do
+      [{_linger_pid, loop_pid}] -> is_pid(loop_pid) and Process.alive?(loop_pid)
+      _ -> false
+    end
+  end
+
+  # Cancel the linger for `agent_id`, taking ownership of its resident pid.
+  # Returns `{:ok, worktree_info}` on success (the linger owner will not
+  # terminate the pid), or `:error` if the linger already fired / is gone.
+  defp cancel_linger(agent_id) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, linger_key(agent_id)) do
+      [{linger_pid, _loop_pid}] ->
+        send(linger_pid, {:cancel_linger, self()})
+
+        receive do
+          {:linger_cancelled, worktree_info} -> {:ok, worktree_info}
+        after
+          5_000 -> :error
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  # Fast-resume entry point. Reachable only via `run_subagent/1`'s dispatcher,
+  # which only routes here when `lingering?/1` is true. Reuses the resident Loop
+  # with NO terminate + NO transcript replay — the new `message` is delivered to
+  # the live Loop exactly as `execute_and_collect/6` delivers a first turn.
+  defp resume_lingering_if_resident(config) do
+    agent_id = Map.get(config, :agent_id) || Map.get(config, :subagent_id)
+
+    if is_binary(agent_id) and lingering?(agent_id) do
+      {:reused, resume_lingering(agent_id, config)}
+    else
+      :no
+    end
+  end
+
+  defp resume_lingering(agent_id, config) do
+    case cancel_linger(agent_id) do
+      {:ok, worktree_info} ->
+        parent_id = Map.fetch!(config, :parent_session_id)
+        role = Map.get(config, :role, "agent")
+        task = Map.fetch!(config, :task)
+        display_name = config[:name] || role
+        batch_id = Map.get(config, :batch_id)
+        tier = Map.get(config, :tier, :specialist)
+        max_iter = Map.get(config, :max_iterations) || Tier.max_iterations(tier)
+
+        Logger.info(
+          "[Orchestrator] Fast-resume: reusing resident subagent #{agent_id} in memory (no replay)"
+        )
+
+        RunStore.start_run(%{
+          agent_id: agent_id,
+          parent_session_id: parent_id,
+          role: role,
+          task: task,
+          resumed_from: Map.get(config, :resumed_from)
+        })
+
+        ensure_execution_control(agent_id, config, %{
+          parent_session_id: parent_id,
+          task: task,
+          role: role
+        })
+
+        forwarder = start_event_forwarder(agent_id, parent_id, role)
+
+        result =
+          execute_and_collect(agent_id, task, parent_id, role, max_iter, worktree_info,
+            display_name: display_name,
+            batch_id: batch_id,
+            resumed_from: agent_id,
+            timeout_ms: Map.get(config, :timeout_ms)
+          )
+
+        stop_event_forwarder(forwarder)
+
+        pid =
+          case Registry.lookup(OptimalSystemAgent.SessionRegistry, agent_id) do
+            [{p, _}] -> p
+            _ -> nil
+          end
+
+        case maybe_linger(pid, agent_id, worktree_info, config, result) do
+          :lingering ->
+            :ok
+
+          :terminate_now ->
+            if is_pid(pid), do: safely_terminate(pid)
+            finish_worktree(worktree_info, agent_id, config, result)
+        end
+
+        result
+
+      :error ->
+        # The linger fired between `lingering?/1` and here (TTL race). The pid is
+        # gone, so fall back to the original terminate-and-replay spawn.
+        run_fresh_subagent(config)
+    end
   end
 
   # ── Worktree end-of-life ──────────────────────────────────────────────

--- a/lib/optimal_system_agent/providers/batch.ex
+++ b/lib/optimal_system_agent/providers/batch.ex
@@ -1,0 +1,387 @@
+defmodule OptimalSystemAgent.Providers.Batch do
+  @moduledoc """
+  OpenAI Batch API — asynchronous, ~50% cheaper chat completions.
+
+  See https://platform.openai.com/docs/api-reference/batch.
+
+  This module is the DEFERRED path for `:loose`, long-horizon work: submit a
+  pile of chat-completion requests as a JSONL file, get back a batch id, poll
+  until the batch completes, then download the results. OpenAI's turnaround
+  window is 24h, and the price is roughly half the synchronous rate — the trade
+  is latency for cost.
+
+  > #### NOT wired into the ReAct loop {: .warning}
+  >
+  > A ~24h async turnaround does not fit a synchronous agent turn, so this
+  > capability is entirely opt-in and is NOT called from `Agent.Loop`,
+  > `Orchestrator`, `LLMClient`, or `DelegationRouter`. Nothing in the live
+  > agent path submits, polls, or resumes a batch today.
+  >
+  > This is deliberately a self-contained foundation. A follow-up will add the
+  > async `submit → poll → resume` orchestration that lets a `:loose` task park
+  > work here and pick the results up on a later turn. Until then the only way
+  > to reach this code is to call it directly.
+
+  ## Public API
+
+      # 1. Submit a list of chat-completion request bodies.
+      {:ok, batch_id} = Batch.submit(requests, opts)
+
+      # 2. Poll for status.
+      {:ok, %{status: "in_progress", output_file_id: nil}} = Batch.status(batch_id, opts)
+
+      # 3. Once completed, fetch and parse the results.
+      {:ok, [%{custom_id: "req-0", response: %{...}}, ...]} = Batch.results(batch_id, opts)
+
+  Each entry in `requests` is a chat-completion request body — the same map you
+  would `POST /v1/chat/completions`, e.g.
+
+      %{"model" => "gpt-4o", "messages" => [%{"role" => "user", "content" => "hi"}]}
+
+  A `custom_id` is assigned per request (`"request-<index>"`) unless the request
+  already carries one under `:custom_id` / `"custom_id"`; it is echoed back by
+  `results/2` so callers can correlate outputs with inputs.
+
+  ## HTTP injection
+
+  The HTTP client is injectable via `opts[:http]` so tests never touch the
+  network. The function receives a request descriptor and returns
+  `{:ok, %{status: integer(), body: term()}}` or `{:error, reason}`:
+
+      http = fn %{method: :post, url: url, headers: headers, json: json, multipart: mp} ->
+        {:ok, %{status: 200, body: %{"id" => "batch_123"}}}
+      end
+
+      Batch.submit(requests, http: http)
+
+  When `opts[:http]` is absent the default client uses `Req` and mirrors how
+  `OpenAICompat` resolves `base_url` / `api_key` / headers for provider
+  `:openai` (the only provider offering the Batch API).
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.Providers.OpenAICompatProvider
+
+  @completion_window "24h"
+  @endpoint "/v1/chat/completions"
+
+  @typedoc "A chat-completion request body, as posted to /v1/chat/completions."
+  @type request_body :: map()
+
+  @typedoc "One parsed result row from a completed batch."
+  @type result_row :: %{custom_id: String.t(), response: map() | nil, error: map() | nil}
+
+  @doc """
+  Submit `requests` as a batch job.
+
+  Uploads the requests as a JSONL file (`POST /v1/files`, purpose `"batch"`),
+  then creates the batch (`POST /v1/batches`, `completion_window: "24h"`).
+
+  Returns `{:ok, batch_id}` or `{:error, reason}`.
+  """
+  @spec submit([request_body()], keyword()) :: {:ok, String.t()} | {:error, term()}
+  def submit(requests, opts \\ []) when is_list(requests) do
+    with {:ok, ctx} <- context(opts),
+         jsonl <- build_jsonl(requests),
+         {:ok, file_id} <- upload_file(jsonl, ctx),
+         {:ok, batch_id} <- create_batch(file_id, ctx) do
+      {:ok, batch_id}
+    end
+  end
+
+  @doc """
+  Fetch the status of a batch (`GET /v1/batches/:id`).
+
+  Returns `{:ok, %{status: status, output_file_id: id_or_nil, error_file_id: id_or_nil, raw: body}}`
+  where `status` is one of `"validating"`, `"in_progress"`, `"finalizing"`,
+  `"completed"`, `"failed"`, `"expired"`, `"cancelling"`, `"cancelled"`.
+  """
+  @spec status(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def status(batch_id, opts \\ []) when is_binary(batch_id) do
+    with {:ok, ctx} <- context(opts),
+         {:ok, body} <- get_batch(batch_id, ctx) do
+      {:ok,
+       %{
+         status: body["status"],
+         output_file_id: body["output_file_id"],
+         error_file_id: body["error_file_id"],
+         raw: body
+       }}
+    end
+  end
+
+  @doc """
+  Fetch and parse the results of a COMPLETED batch.
+
+  Reads the batch's status to find its `output_file_id`, downloads that file's
+  content (`GET /v1/files/:id/content`), and parses the JSONL into a list of
+  `%{custom_id: ..., response: ..., error: ...}` rows.
+
+  Returns `{:error, {:not_completed, status}}` if the batch is not yet
+  `"completed"`, and `{:error, {:batch_failed, status}}` for a terminal
+  failure (`"failed"`, `"expired"`, `"cancelled"`).
+  """
+  @spec results(String.t(), keyword()) :: {:ok, [result_row()]} | {:error, term()}
+  def results(batch_id, opts \\ []) when is_binary(batch_id) do
+    with {:ok, ctx} <- context(opts),
+         {:ok, body} <- get_batch(batch_id, ctx),
+         {:ok, output_file_id} <- output_file_for(body),
+         {:ok, content} <- get_file_content(output_file_id, ctx) do
+      {:ok, parse_results(content)}
+    end
+  end
+
+  # ── Internal steps ────────────────────────────────────────────────────────
+
+  defp upload_file(jsonl, ctx) do
+    request = %{
+      method: :post,
+      url: "#{ctx.base_url}/files",
+      headers: ctx.headers,
+      json: nil,
+      multipart: %{
+        "purpose" => "batch",
+        # {filename, content_type, binary} — the default client renders this as
+        # a file part; a mock can inspect the tuple directly.
+        "file" => {"batchinput.jsonl", "application/jsonl", jsonl}
+      }
+    }
+
+    case ctx.http.(request) do
+      {:ok, %{status: status, body: %{"id" => file_id}}} when status in 200..299 ->
+        {:ok, file_id}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, "Batch file upload failed (HTTP #{status}): #{error_message(body)}"}
+
+      {:error, reason} ->
+        {:error, "Batch file upload failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp create_batch(file_id, ctx) do
+    request = %{
+      method: :post,
+      url: "#{ctx.base_url}/batches",
+      headers: ctx.headers,
+      json: %{
+        "input_file_id" => file_id,
+        "endpoint" => @endpoint,
+        "completion_window" => @completion_window
+      },
+      multipart: nil
+    }
+
+    case ctx.http.(request) do
+      {:ok, %{status: status, body: %{"id" => batch_id}}} when status in 200..299 ->
+        {:ok, batch_id}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, "Batch create failed (HTTP #{status}): #{error_message(body)}"}
+
+      {:error, reason} ->
+        {:error, "Batch create failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp get_batch(batch_id, ctx) do
+    request = %{
+      method: :get,
+      url: "#{ctx.base_url}/batches/#{batch_id}",
+      headers: ctx.headers,
+      json: nil,
+      multipart: nil
+    }
+
+    case ctx.http.(request) do
+      {:ok, %{status: status, body: %{"status" => _} = body}} when status in 200..299 ->
+        {:ok, body}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, "Batch status fetch failed (HTTP #{status}): #{error_message(body)}"}
+
+      {:error, reason} ->
+        {:error, "Batch status fetch failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp get_file_content(file_id, ctx) do
+    request = %{
+      method: :get,
+      url: "#{ctx.base_url}/files/#{file_id}/content",
+      headers: ctx.headers,
+      json: nil,
+      multipart: nil
+    }
+
+    case ctx.http.(request) do
+      {:ok, %{status: status, body: body}} when status in 200..299 ->
+        {:ok, to_jsonl_string(body)}
+
+      {:ok, %{status: status, body: body}} ->
+        {:error, "Batch output download failed (HTTP #{status}): #{error_message(body)}"}
+
+      {:error, reason} ->
+        {:error, "Batch output download failed: #{inspect(reason)}"}
+    end
+  end
+
+  # A completed batch has an output file; a terminal failure does not, so name
+  # the specific reason rather than returning a confusing "no output_file_id".
+  defp output_file_for(%{"status" => "completed", "output_file_id" => id})
+       when is_binary(id) and id != "",
+       do: {:ok, id}
+
+  defp output_file_for(%{"status" => status})
+       when status in ["failed", "expired", "cancelled", "cancelling"],
+       do: {:error, {:batch_failed, status}}
+
+  defp output_file_for(%{"status" => status}), do: {:error, {:not_completed, status}}
+
+  defp output_file_for(_), do: {:error, {:not_completed, nil}}
+
+  # ── JSONL encode/decode ─────────────────────────────────────────────────────
+
+  @doc false
+  # Build the batch input as one JSONL line per request. Each line is a batch
+  # request object wrapping the chat-completion body under `body`, tagged with a
+  # `custom_id` so results can be correlated back.
+  @spec build_jsonl([request_body()]) :: String.t()
+  def build_jsonl(requests) do
+    requests
+    |> Enum.with_index()
+    |> Enum.map(fn {req, idx} ->
+      %{
+        "custom_id" => custom_id(req, idx),
+        "method" => "POST",
+        "url" => @endpoint,
+        "body" => strip_custom_id(req)
+      }
+      |> Jason.encode!()
+    end)
+    |> Enum.join("\n")
+  end
+
+  defp custom_id(req, idx) when is_map(req) do
+    case req[:custom_id] || req["custom_id"] do
+      id when is_binary(id) and id != "" -> id
+      _ -> "request-#{idx}"
+    end
+  end
+
+  defp strip_custom_id(req) when is_map(req), do: Map.drop(req, [:custom_id, "custom_id"])
+  defp strip_custom_id(req), do: req
+
+  @doc false
+  # Parse a JSONL batch output file into result rows. Each line is a batch
+  # response object: `{custom_id, response: %{status_code, body}, error}`.
+  @spec parse_results(String.t()) :: [result_row()]
+  def parse_results(content) when is_binary(content) do
+    content
+    |> String.split("\n", trim: true)
+    |> Enum.flat_map(fn line ->
+      case Jason.decode(line) do
+        {:ok, %{} = row} ->
+          [
+            %{
+              custom_id: row["custom_id"],
+              response: extract_response_body(row["response"]),
+              error: row["error"]
+            }
+          ]
+
+        _ ->
+          # A malformed line is skipped rather than failing the whole download —
+          # a partial output is still useful, and the row's absence is visible.
+          Logger.warning("[Batch] skipping unparseable JSONL result line")
+          []
+      end
+    end)
+  end
+
+  # OpenAI wraps the chat-completion body under response.body; hand callers the
+  # completion body directly, falling back to the whole response when the shape
+  # is unexpected.
+  defp extract_response_body(%{"body" => body}), do: body
+  defp extract_response_body(other), do: other
+
+  defp to_jsonl_string(body) when is_binary(body), do: body
+  # A mock may hand back already-decoded rows; re-encode to the JSONL the parser
+  # expects so the same parse path is exercised.
+  defp to_jsonl_string(rows) when is_list(rows) do
+    rows |> Enum.map(&Jason.encode!/1) |> Enum.join("\n")
+  end
+
+  defp to_jsonl_string(other), do: inspect(other)
+
+  # Pull a human-readable message out of an OpenAI error body, falling back to
+  # an inspect of whatever shape arrived.
+  defp error_message(%{"error" => %{"message" => msg}}) when is_binary(msg), do: msg
+  defp error_message(body) when is_binary(body), do: body
+  defp error_message(body), do: inspect(body)
+
+  # ── Context / credential resolution ─────────────────────────────────────────
+
+  # Resolve base_url, api_key, headers, and the HTTP client for this call.
+  # Mirrors OpenAICompatProvider's resolution for the one provider that offers
+  # the Batch API (:openai). Never edits that module — only reads through its
+  # public accessors.
+  defp context(opts) do
+    provider = Keyword.get(opts, :provider, :openai)
+
+    if provider != :openai do
+      {:error, "Batch API is only supported for provider :openai (got #{inspect(provider)})"}
+    else
+      base_url = Keyword.get(opts, :base_url) || OpenAICompatProvider.base_url(provider)
+      http = Keyword.get(opts, :http) || (&default_http/1)
+
+      case resolve_api_key(provider, opts) do
+        {:ok, api_key} ->
+          {:ok, %{base_url: base_url, http: http, headers: build_headers(api_key)}}
+
+        {:error, _} = err ->
+          err
+      end
+    end
+  end
+
+  # A test that injects `:http` and passes an explicit `:api_key` (or none) must
+  # not depend on a real key being configured; only fall back to the live
+  # resolver when no key was supplied.
+  defp resolve_api_key(provider, opts) do
+    case Keyword.get(opts, :api_key) || OpenAICompatProvider.resolved_api_key(provider) do
+      key when is_binary(key) and key != "" -> {:ok, key}
+      _ -> {:error, "API key not configured for provider #{provider}"}
+    end
+  end
+
+  defp build_headers(api_key) do
+    [{"Authorization", "Bearer #{api_key}"}]
+  end
+
+  # Default HTTP client. Translates the request descriptor into a Req call.
+  # JSON bodies decode to maps; a file-content download returns a raw binary.
+  defp default_http(%{method: method, url: url, headers: headers} = request) do
+    opts =
+      [headers: headers, receive_timeout: 120_000]
+      |> put_body(request)
+
+    result =
+      case method do
+        :get -> Req.get(url, opts)
+        :post -> Req.post(url, opts)
+      end
+
+    case result do
+      {:ok, %Req.Response{status: status, body: body}} -> {:ok, %{status: status, body: body}}
+      {:error, reason} -> {:error, reason}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp put_body(opts, %{multipart: mp}) when is_map(mp), do: Keyword.put(opts, :form_multipart, mp)
+  defp put_body(opts, %{json: json}) when is_map(json), do: Keyword.put(opts, :json, json)
+  defp put_body(opts, _), do: opts
+end

--- a/test/agent/orchestrator/subagent_linger_wake_test.exs
+++ b/test/agent/orchestrator/subagent_linger_wake_test.exs
@@ -1,0 +1,163 @@
+defmodule OptimalSystemAgent.Agent.Orchestrator.SubagentLingerWakeTest do
+  @moduledoc """
+  Cheaper agent wake (#3) — keep a just-finished subagent RESIDENT for a short
+  TTL so a quick follow-up reuses the live Loop with its context already in
+  memory, instead of the expensive terminate-then-restart-and-replay-transcript
+  path.
+
+  Three properties are locked here:
+
+    1. **Default safety.** With `:subagent_linger_ms` unset / 0, a completed
+       subagent's Loop is terminated immediately, exactly as before. Nothing
+       lingers. This is the proof that the feature is inert unless opted in.
+
+    2. **Resident reuse.** With linger enabled, a resume that arrives inside the
+       TTL is served by the SAME live pid — no restart. Pid identity across the
+       resume is the observable proof that no terminate + replay happened (a
+       replay would kill the resident pid and spawn a fresh one under the same
+       id).
+
+    3. **Bounded residency.** With linger enabled and NO resume, the resident
+       pid is terminated once the TTL elapses. A resident Loop is never held
+       forever.
+
+  Uses `OptimalSystemAgent.Test.MockProvider` so completion is deterministic and
+  needs no network.
+  """
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Orchestrator
+  alias OptimalSystemAgent.Test.MockProvider
+
+  setup do
+    prev_provider = Application.get_env(:optimal_system_agent, :default_provider)
+    prev_linger = Application.get_env(:optimal_system_agent, :subagent_linger_ms)
+
+    Application.put_env(:optimal_system_agent, :default_provider, :mock)
+    MockProvider.reset()
+
+    on_exit(fn ->
+      Application.delete_env(:optimal_system_agent, :subagent_linger_ms)
+
+      if prev_provider,
+        do: Application.put_env(:optimal_system_agent, :default_provider, prev_provider),
+        else: Application.delete_env(:optimal_system_agent, :default_provider)
+
+      if prev_linger,
+        do: Application.put_env(:optimal_system_agent, :subagent_linger_ms, prev_linger)
+    end)
+
+    :ok
+  end
+
+  defp uniq(prefix),
+    do: prefix <> "-" <> (:crypto.strong_rand_bytes(6) |> Base.url_encode64(padding: false))
+
+  defp config(subagent_id, parent_id, overrides \\ %{}) do
+    Map.merge(
+      %{
+        task: "say hello",
+        parent_session_id: parent_id,
+        agent_id: subagent_id,
+        role: "tester",
+        tier: :specialist,
+        model: "mock-model-1.0",
+        provider: :mock,
+        working_dir: System.tmp_dir!()
+      },
+      overrides
+    )
+  end
+
+  defp live_pid(id) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, id) do
+      [{pid, _}] -> pid
+      _ -> nil
+    end
+  end
+
+  # Poll until the id has no live Loop registered (termination is async — the
+  # Registry drops the entry via its own monitor after the process dies).
+  defp assert_registry_empty(id, attempts \\ 40)
+
+  defp assert_registry_empty(id, 0),
+    do: assert(Registry.lookup(OptimalSystemAgent.SessionRegistry, id) == [])
+
+  defp assert_registry_empty(id, attempts) do
+    case Registry.lookup(OptimalSystemAgent.SessionRegistry, id) do
+      [] -> :ok
+      _ -> Process.sleep(25) && assert_registry_empty(id, attempts - 1)
+    end
+  end
+
+  defp terminate_leftover(id) do
+    case live_pid(id) do
+      pid when is_pid(pid) ->
+        DynamicSupervisor.terminate_child(OptimalSystemAgent.SessionSupervisor, pid)
+
+      _ ->
+        :ok
+    end
+  end
+
+  describe "default (linger disabled)" do
+    test "a completed subagent's Loop is terminated immediately, exactly as before" do
+      # No :subagent_linger_ms set → default 0.
+      assert Orchestrator.subagent_linger_ms() == 0
+
+      parent_id = uniq("parent")
+      subagent_id = uniq("agent:no-linger")
+
+      assert {:ok, _summary} = Orchestrator.run_subagent(config(subagent_id, parent_id))
+
+      # The child is gone the moment run_subagent returns — nothing resident.
+      assert_registry_empty(subagent_id)
+    end
+  end
+
+  describe "linger enabled — resident reuse" do
+    test "a resume inside the TTL reuses the SAME live pid (no terminate, no replay)" do
+      # Generous TTL so the resume comfortably lands inside the linger window.
+      Application.put_env(:optimal_system_agent, :subagent_linger_ms, 60_000)
+
+      parent_id = uniq("parent")
+      subagent_id = uniq("agent:linger-reuse")
+
+      on_exit(fn -> terminate_leftover(subagent_id) end)
+
+      assert {:ok, _} = Orchestrator.run_subagent(config(subagent_id, parent_id))
+
+      # Instead of being terminated, the Loop is held resident.
+      pid1 = live_pid(subagent_id)
+      assert is_pid(pid1) and Process.alive?(pid1)
+
+      # A follow-up under the SAME id is the fast-wake path: run_subagent routes
+      # it to the resident Loop. If it had gone through terminate + replay, pid1
+      # would be dead and a fresh pid would own the id.
+      assert {:ok, _} =
+               Orchestrator.run_subagent(config(subagent_id, parent_id, %{task: "keep going"}))
+
+      pid2 = live_pid(subagent_id)
+      assert pid2 == pid1
+      assert Process.alive?(pid2)
+    end
+  end
+
+  describe "linger enabled — bounded residency" do
+    test "with no resume, the resident pid is terminated once the TTL elapses" do
+      Application.put_env(:optimal_system_agent, :subagent_linger_ms, 250)
+
+      parent_id = uniq("parent")
+      subagent_id = uniq("agent:linger-ttl")
+
+      assert {:ok, _} = Orchestrator.run_subagent(config(subagent_id, parent_id))
+
+      # Resident right after completion...
+      pid = live_pid(subagent_id)
+      assert is_pid(pid) and Process.alive?(pid)
+
+      # ...and terminated after the TTL lapses with no resume.
+      assert_registry_empty(subagent_id)
+    end
+  end
+end

--- a/test/optimal_system_agent/agent/cost_observations_test.exs
+++ b/test/optimal_system_agent/agent/cost_observations_test.exs
@@ -1,0 +1,51 @@
+defmodule OptimalSystemAgent.Agent.CostObservationsTest do
+  use ExUnit.Case, async: false
+  alias OptimalSystemAgent.Agent.CostObservations
+
+  setup do
+    CostObservations.reset()
+    on_exit(&CostObservations.reset/0)
+    :ok
+  end
+
+  test "nil for an unseen model" do
+    assert CostObservations.avg_cost(:openai, "gpt-5") == nil
+  end
+
+  test "first sample is the value; then EMA moves toward new samples" do
+    CostObservations.record(:openai, "gpt-5", 1.0)
+    assert CostObservations.avg_cost(:openai, "gpt-5") == 1.0
+    CostObservations.record(:openai, "gpt-5", 2.0)
+    v = CostObservations.avg_cost(:openai, "gpt-5")
+    # EMA with alpha 0.3: 1.0 + 0.3*(2.0-1.0) = 1.3
+    assert_in_delta v, 1.3, 1.0e-9
+  end
+
+  test "ignores zero / nil / missing keys (no basis to learn)" do
+    CostObservations.record(:openai, "gpt-5", 0.0)
+    CostObservations.record(:openai, "gpt-5", nil)
+    CostObservations.record(nil, "gpt-5", 1.0)
+    CostObservations.record(:openai, nil, 1.0)
+    assert CostObservations.avg_cost(:openai, "gpt-5") == nil
+  end
+
+  test "telemetry handler folds provider_cost_usd (falls back to estimate)" do
+    CostObservations.handle_telemetry(
+      [:osa, :accounting, :provider_cost],
+      %{provider_cost_usd: 0.5, rate_card_estimate_usd: 0.9},
+      %{provider: :openai, model: "gpt-5"},
+      nil
+    )
+
+    assert CostObservations.avg_cost(:openai, "gpt-5") == 0.5
+
+    CostObservations.handle_telemetry(
+      [:osa, :accounting, :provider_cost],
+      %{provider_cost_usd: 0, rate_card_estimate_usd: 0.2},
+      %{provider: :anthropic, model: "opus"},
+      nil
+    )
+
+    assert CostObservations.avg_cost(:anthropic, "opus") == 0.2
+  end
+end

--- a/test/optimal_system_agent/agent/delegation_router_test.exs
+++ b/test/optimal_system_agent/agent/delegation_router_test.exs
@@ -196,4 +196,45 @@ defmodule OptimalSystemAgent.Agent.DelegationRouterTest do
       refute routed.model_reason =~ "priority:"
     end
   end
+
+  describe "cost-aware routing (#10): loose prefers the cheapest observed model" do
+    alias OptimalSystemAgent.Agent.CostObservations
+
+    setup do
+      CostObservations.reset()
+      on_exit(&CostObservations.reset/0)
+      :ok
+    end
+
+    test "among two capable loose candidates, the cheaper observed one wins" do
+      CostObservations.record(:paid_a, "paid_a-specialist-model", 1.0)
+      CostObservations.record(:paid_b, "paid_b-specialist-model", 0.2)
+
+      routed =
+        DelegationRouter.resolve("do it", %{provider: :paid_a, tier: :specialist, priority: "loose"},
+          candidates: [:paid_a, :paid_b],
+          configured?: fn _ -> true end,
+          model_for: fn tier, provider -> "#{provider}-#{tier}-model" end,
+          tool_call: fn _, _ -> true end,
+          context_window: fn _ -> 200_000 end,
+          vision_capable: fn _, _ -> true end
+        )
+
+      assert routed.provider == :paid_b, "cheaper observed model should be chosen for loose"
+    end
+
+    test "with no observations, order is unchanged (first compatible)" do
+      routed =
+        DelegationRouter.resolve("do it", %{provider: :paid_a, tier: :specialist, priority: "loose"},
+          candidates: [:paid_a, :paid_b],
+          configured?: fn _ -> true end,
+          model_for: fn tier, provider -> "#{provider}-#{tier}-model" end,
+          tool_call: fn _, _ -> true end,
+          context_window: fn _ -> 200_000 end,
+          vision_capable: fn _, _ -> true end
+        )
+
+      assert routed.provider == :paid_a
+    end
+  end
 end

--- a/test/providers/batch_test.exs
+++ b/test/providers/batch_test.exs
@@ -1,0 +1,291 @@
+defmodule OptimalSystemAgent.Providers.BatchTest do
+  @moduledoc """
+  Locks in the OpenAI Batch API foundation (`Providers.Batch`).
+
+  Every test drives an INJECTED http client — no request is ever sent. The
+  properties worth pinning are: submit builds correct JSONL + uploads the file
+  with purpose "batch" + creates the batch with a 24h window; status parses
+  each documented state; results downloads and parses the JSONL output and maps
+  it back to custom_ids; and the error paths (upload fails, batch failed) return
+  `{:error, _}`.
+
+  > #### Nothing here has spoken to OpenAI {: .warning}
+  >
+  > There are no api.openai.com credentials in play. Every assertion is about
+  > what OSA BUILDS and how it PARSES a canned response.
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Providers.Batch
+
+  # A recording http mock: captures every request into the test process mailbox
+  # and replies from a scripted list (one reply per call, in order).
+  defp scripted(replies) do
+    {:ok, agent} = Agent.start_link(fn -> replies end)
+    test = self()
+
+    fn request ->
+      send(test, {:request, request})
+
+      reply =
+        Agent.get_and_update(agent, fn
+          [next | rest] -> {next, rest}
+          [] -> {{:error, "no scripted reply"}, []}
+        end)
+
+      reply
+    end
+  end
+
+  @sample_requests [
+    %{"model" => "gpt-4o", "messages" => [%{"role" => "user", "content" => "one"}]},
+    %{"model" => "gpt-4o", "messages" => [%{"role" => "user", "content" => "two"}]}
+  ]
+
+  describe "submit/2" do
+    test "builds JSONL, uploads with purpose batch, creates a 24h batch, returns the id" do
+      http =
+        scripted([
+          {:ok, %{status: 200, body: %{"id" => "file_abc"}}},
+          {:ok, %{status: 200, body: %{"id" => "batch_xyz", "status" => "validating"}}}
+        ])
+
+      assert {:ok, "batch_xyz"} = Batch.submit(@sample_requests, http: http, api_key: "sk-test")
+
+      # First call: the file upload.
+      assert_receive {:request, upload}
+      assert upload.method == :post
+      assert String.ends_with?(upload.url, "/files")
+      assert {"Authorization", "Bearer sk-test"} in upload.headers
+      assert upload.multipart["purpose"] == "batch"
+
+      {filename, content_type, jsonl} = upload.multipart["file"]
+      assert filename =~ ".jsonl"
+      assert content_type =~ "jsonl"
+
+      # One JSONL line per request, each wrapping the chat body under "body"
+      # with an assigned custom_id and the chat-completions endpoint.
+      lines = String.split(jsonl, "\n", trim: true)
+      assert length(lines) == 2
+
+      first = Jason.decode!(Enum.at(lines, 0))
+      assert first["custom_id"] == "request-0"
+      assert first["method"] == "POST"
+      assert first["url"] == "/v1/chat/completions"
+      assert first["body"]["model"] == "gpt-4o"
+      assert first["body"]["messages"] == [%{"role" => "user", "content" => "one"}]
+
+      assert Jason.decode!(Enum.at(lines, 1))["custom_id"] == "request-1"
+
+      # Second call: the batch create.
+      assert_receive {:request, create}
+      assert create.method == :post
+      assert String.ends_with?(create.url, "/batches")
+      assert create.json["input_file_id"] == "file_abc"
+      assert create.json["endpoint"] == "/v1/chat/completions"
+      assert create.json["completion_window"] == "24h"
+    end
+
+    test "honors a caller-supplied custom_id" do
+      http =
+        scripted([
+          {:ok, %{status: 200, body: %{"id" => "file_abc"}}},
+          {:ok, %{status: 200, body: %{"id" => "batch_xyz"}}}
+        ])
+
+      reqs = [%{"custom_id" => "my-id", "model" => "gpt-4o", "messages" => []}]
+      assert {:ok, "batch_xyz"} = Batch.submit(reqs, http: http, api_key: "sk-test")
+
+      assert_receive {:request, upload}
+      {_f, _c, jsonl} = upload.multipart["file"]
+      line = jsonl |> String.split("\n", trim: true) |> hd() |> Jason.decode!()
+      assert line["custom_id"] == "my-id"
+      # custom_id is not duplicated into the request body.
+      refute Map.has_key?(line["body"], "custom_id")
+    end
+
+    test "returns {:error, _} when the file upload fails" do
+      http =
+        scripted([
+          {:ok, %{status: 401, body: %{"error" => %{"message" => "bad key"}}}}
+        ])
+
+      assert {:error, reason} = Batch.submit(@sample_requests, http: http, api_key: "sk-test")
+      assert reason =~ "upload failed"
+      assert reason =~ "bad key"
+    end
+
+    test "returns {:error, _} when the batch create fails" do
+      http =
+        scripted([
+          {:ok, %{status: 200, body: %{"id" => "file_abc"}}},
+          {:ok, %{status: 400, body: %{"error" => %{"message" => "bad window"}}}}
+        ])
+
+      assert {:error, reason} = Batch.submit(@sample_requests, http: http, api_key: "sk-test")
+      assert reason =~ "create failed"
+    end
+
+    test "rejects a non-openai provider without touching http" do
+      assert {:error, reason} =
+               Batch.submit(@sample_requests, provider: :groq, api_key: "x", http: fn _ -> :boom end)
+
+      assert reason =~ ":openai"
+    end
+  end
+
+  describe "status/2" do
+    for state <- ~w(validating in_progress finalizing completed failed expired cancelling cancelled) do
+      test "parses the #{state} state" do
+        state = unquote(state)
+
+        http =
+          scripted([
+            {:ok, %{status: 200, body: %{"id" => "batch_1", "status" => state}}}
+          ])
+
+        assert {:ok, parsed} = Batch.status("batch_1", http: http, api_key: "sk-test")
+        assert parsed.status == state
+
+        assert_receive {:request, req}
+        assert req.method == :get
+        assert String.ends_with?(req.url, "/batches/batch_1")
+      end
+    end
+
+    test "surfaces output_file_id and error_file_id" do
+      http =
+        scripted([
+          {:ok,
+           %{
+             status: 200,
+             body: %{
+               "id" => "batch_1",
+               "status" => "completed",
+               "output_file_id" => "file_out",
+               "error_file_id" => "file_err"
+             }
+           }}
+        ])
+
+      assert {:ok, parsed} = Batch.status("batch_1", http: http, api_key: "sk-test")
+      assert parsed.output_file_id == "file_out"
+      assert parsed.error_file_id == "file_err"
+    end
+
+    test "returns {:error, _} on an HTTP failure" do
+      http = scripted([{:ok, %{status: 404, body: %{"error" => %{"message" => "no such batch"}}}}])
+      assert {:error, reason} = Batch.status("nope", http: http, api_key: "sk-test")
+      assert reason =~ "status fetch failed"
+    end
+  end
+
+  describe "results/2" do
+    test "downloads the output file and maps rows back to custom_ids" do
+      output_jsonl =
+        [
+          %{
+            "custom_id" => "request-0",
+            "response" => %{
+              "status_code" => 200,
+              "body" => %{"choices" => [%{"message" => %{"content" => "answer one"}}]}
+            },
+            "error" => nil
+          },
+          %{
+            "custom_id" => "request-1",
+            "response" => %{
+              "status_code" => 200,
+              "body" => %{"choices" => [%{"message" => %{"content" => "answer two"}}]}
+            },
+            "error" => nil
+          }
+        ]
+        |> Enum.map(&Jason.encode!/1)
+        |> Enum.join("\n")
+
+      http =
+        scripted([
+          {:ok,
+           %{
+             status: 200,
+             body: %{"id" => "batch_1", "status" => "completed", "output_file_id" => "file_out"}
+           }},
+          {:ok, %{status: 200, body: output_jsonl}}
+        ])
+
+      assert {:ok, rows} = Batch.results("batch_1", http: http, api_key: "sk-test")
+      assert length(rows) == 2
+
+      by_id = Map.new(rows, &{&1.custom_id, &1})
+      assert by_id["request-0"].response["choices"] |> hd() |> get_in(["message", "content"]) ==
+               "answer one"
+
+      assert by_id["request-1"].response["choices"] |> hd() |> get_in(["message", "content"]) ==
+               "answer two"
+
+      assert by_id["request-0"].error == nil
+
+      # The second http call was the file content download.
+      assert_receive {:request, _batch_get}
+      assert_receive {:request, content_get}
+      assert content_get.method == :get
+      assert String.ends_with?(content_get.url, "/files/file_out/content")
+    end
+
+    test "skips a malformed JSONL line rather than failing the whole download" do
+      output = ~s({"custom_id":"request-0","response":{"body":{"ok":true}}}\nNOT JSON\n)
+
+      http =
+        scripted([
+          {:ok,
+           %{
+             status: 200,
+             body: %{"id" => "b", "status" => "completed", "output_file_id" => "file_out"}
+           }},
+          {:ok, %{status: 200, body: output}}
+        ])
+
+      assert {:ok, [row]} = Batch.results("b", http: http, api_key: "sk-test")
+      assert row.custom_id == "request-0"
+      assert row.response == %{"ok" => true}
+    end
+
+    test "returns {:error, {:not_completed, status}} when the batch is still running" do
+      http =
+        scripted([{:ok, %{status: 200, body: %{"id" => "b", "status" => "in_progress"}}}])
+
+      assert {:error, {:not_completed, "in_progress"}} =
+               Batch.results("b", http: http, api_key: "sk-test")
+    end
+
+    test "returns {:error, {:batch_failed, status}} for a terminal failure" do
+      http = scripted([{:ok, %{status: 200, body: %{"id" => "b", "status" => "failed"}}}])
+
+      assert {:error, {:batch_failed, "failed"}} =
+               Batch.results("b", http: http, api_key: "sk-test")
+    end
+
+    test "returns {:error, _} when the output download fails" do
+      http =
+        scripted([
+          {:ok,
+           %{
+             status: 200,
+             body: %{"id" => "b", "status" => "completed", "output_file_id" => "file_out"}
+           }},
+          {:ok, %{status: 500, body: %{"error" => %{"message" => "storage down"}}}}
+        ])
+
+      assert {:error, reason} = Batch.results("b", http: http, api_key: "sk-test")
+      assert reason =~ "download failed"
+    end
+  end
+
+  describe "build_jsonl/1 (unit)" do
+    test "produces one line per request wrapping the body" do
+      jsonl = Batch.build_jsonl(@sample_requests)
+      assert jsonl |> String.split("\n") |> length() == 2
+    end
+  end
+end


### PR DESCRIPTION
The three remaining architecture items, one deployment. Built via parallel worktree agents (#10 I did myself after its agent glitched), all default-safe.

**#10 Cost-aware routing** — new `CostObservations` (self-owning ETS, crash-safe) learns per-{provider,model} cost via an EMA from the accounting cost telemetry (handler attached in Application.start). For `:loose` work the router prefers the cheapest OBSERVED capable model, never routing away from free/local and never overriding capability/tier. **No history → identical to today.**

**#5 Async batch foundation** — `Providers.Batch`: OpenAI Batch API submit/status/results (JSONL upload → /v1/batches → poll → fetch output), ~50% cheaper async. HTTP injectable, `:openai`-only, fully mock-tested. **Deliberately NOT wired into the live loop** (async 24h turnaround needs a submit→poll→resume orchestration — flagged as the follow-up); it's a callable capability behind the door.

**#3 Cheaper wake** — `:subagent_linger_ms` (**default 0 = today's behavior exactly**): when >0, a just-finished subagent lingers resident for the TTL so a quick resume reuses the live Loop (same pid, no transcript replay) instead of terminate+replay. Leak-safe (TTL timer + supervisor reap + fallback-to-terminate).

**Verified:** 103 tests green (orchestrator incl. 62 + linger, cost_observations EMA/guards/telemetry, delegation_router cost tie-break, batch submit/poll/results with mocks). Default paths provably unchanged.

That's all 11 items across the two deployments now done.