### PR TITLE
fix(windows): unbreak OAuth sign-in, the backend daemon, and URL opening

### DIFF
--- a/lib/optimal_system_agent/auth/subscription_store.ex
+++ b/lib/optimal_system_agent/auth/subscription_store.ex
@@ -211,7 +211,25 @@ defmodule OptimalSystemAgent.Auth.SubscriptionStore do
   # can read a bearer token for the operator's paid account — the failure is
   # invisible precisely when it matters. Refusing turns it into "reconnect this
   # provider", which is a 10-second fix with a clear cause.
+  #
+  # Windows is exempt, and must be. It has no POSIX mode bits: Erlang
+  # synthesises `mode` from the read-only attribute alone, so an ordinary file
+  # always reports 0o100666 and `band(mode, 0o077)` is NEVER 0. `File.chmod/2`
+  # cannot clear those bits either, so the 0600-from-birth write below is a
+  # no-op there — meaning OSA rejects, on every read, a store it just wrote
+  # itself. That is not a hardening failure, it is a permanent lockout of every
+  # subscription provider on the platform (`{:unsafe_read,
+  # :insecure_permissions}` on each sign-in). Access on Windows is governed by
+  # NTFS ACLs, which this check cannot see, so defer to them.
   defp check_permissions(file) do
+    if match?({:win32, _}, :os.type()) do
+      :ok
+    else
+      check_posix_permissions(file)
+    end
+  end
+
+  defp check_posix_permissions(file) do
     case File.stat(file) do
       {:ok, %File.Stat{mode: mode}} ->
         # Low 6 bits = group + other. Anything set is a leak.

--- a/lib/optimal_system_agent/cli/doctor.ex
+++ b/lib/optimal_system_agent/cli/doctor.ex
@@ -586,10 +586,20 @@ defmodule OptimalSystemAgent.CLI.Doctor do
   defp executable?(path) do
     case File.stat(path) do
       {:ok, %{access: access}} when access in [:read_write, :read] ->
-        # Check execute permission via the mode bits
-        case File.stat(path) do
-          {:ok, %File.Stat{mode: mode}} -> Bitwise.band(mode, 0o111) != 0
-          _ -> false
+        # Windows has no execute bit. Erlang synthesises `mode` from the
+        # read-only attribute, so every file reports 0o100666 and
+        # `band(mode, 0o111)` is always 0 — which made doctor report a
+        # perfectly good osagent-tui.exe as "found but not executable".
+        # Executability there is decided by the extension (PATHEXT), so a
+        # readable file is as much as this check can honestly assert.
+        if match?({:win32, _}, :os.type()) do
+          true
+        else
+          # Check execute permission via the mode bits
+          case File.stat(path) do
+            {:ok, %File.Stat{mode: mode}} -> Bitwise.band(mode, 0o111) != 0
+            _ -> false
+          end
         end
 
       _ ->

--- a/lib/optimal_system_agent/utils/browser.ex
+++ b/lib/optimal_system_agent/utils/browser.ex
@@ -64,6 +64,17 @@ defmodule OptimalSystemAgent.Utils.Browser do
   @spec command_for({atom(), atom()}, String.t()) :: {String.t(), [String.t()]}
   def command_for({:unix, :darwin}, url), do: {"open", [url]}
   def command_for({:unix, _}, url), do: {"xdg-open", [url]}
-  def command_for({:win32, _}, url), do: {"cmd", ["/c", "start", url]}
+  # NOT `cmd /c start <url>`. `start` parses its first quoted argument as the
+  # WINDOW TITLE, so the URL is consumed as a title and `start` then opens a
+  # window with no target — the user sees a stray Explorer/console window at
+  # the working directory instead of the sign-in page, and the OAuth flow they
+  # were sent to never loads. `&` in a URL (device-flow codes routinely carry
+  # query parameters) is also a `cmd` command separator, which truncates the
+  # URL even once the title slot is filled.
+  #
+  # `rundll32 url.dll,FileProtocolHandler` hands the URL to the default
+  # protocol handler with no shell in the path at all, so neither the title
+  # slot nor `&` can bite. It ships with every supported Windows version.
+  def command_for({:win32, _}, url), do: {"rundll32", ["url.dll,FileProtocolHandler", url]}
   def command_for(_, url), do: {"true", [url]}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -269,9 +269,16 @@ defmodule OptimalSystemAgent.MixProject do
   # Renames the generated release script (bin/osagent → bin/osagent_release)
   # and copies in our wrapper that dispatches subcommands via `eval`.
   defp copy_osagent_wrapper(release) do
-    # The custom wrapper is a POSIX `sh` script Windows cannot execute. On a
-    # Windows build host, skip it entirely and let install.ps1 call the stock
-    # bin\osagent.bat launcher (with serve/setup/doctor as release commands).
+    # The custom wrapper is a POSIX `sh` script Windows cannot execute, so it
+    # is skipped on a Windows build host and install.ps1's launcher drives the
+    # stock bin\osagent.bat instead.
+    #
+    # NOTE: the stock script does NOT understand serve/setup/doctor/
+    # opencomputers — its whole command set is start, start_iex, install, eval,
+    # rpc, remote, restart, stop, pid, version. Anything calling `osagent.bat
+    # serve` gets "ERROR: Unknown command serve" and an immediate exit. The
+    # Windows launcher therefore dispatches those four through `eval`, exactly
+    # as the sh wrapper below does; keep the two in sync when adding a command.
     # The Unix path below is unchanged so Linux/macOS never regress.
     if match?({:win32, _}, :os.type()) do
       release

--- a/priv/rust/tui/src/app/mod.rs
+++ b/priv/rust/tui/src/app/mod.rs
@@ -1714,8 +1714,14 @@ mod modal_overlay_tests {
 pub fn open_in_browser(url: &str) {
     #[cfg(target_os = "macos")]
     let candidates: [&str; 1] = ["open"];
+    // NOT `explorer`. explorer.exe is the file manager: handed a URL it
+    // frequently opens a FOLDER window at the working directory instead of
+    // handing the address to the default browser, so the user is sent to a
+    // file listing and the sign-in page never loads. `rundll32
+    // url.dll,FileProtocolHandler` invokes the registered protocol handler
+    // directly, which is what "open this URL" actually means on Windows.
     #[cfg(target_os = "windows")]
-    let candidates: [&str; 1] = ["explorer"];
+    let candidates: [&str; 1] = ["rundll32"];
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     let candidates: [&str; 3] = ["xdg-open", "gio", "wslview"];
 
@@ -1725,6 +1731,9 @@ pub fn open_in_browser(url: &str) {
             let mut cmd = std::process::Command::new(bin);
             if bin == "gio" {
                 cmd.arg("open");
+            }
+            if bin == "rundll32" {
+                cmd.arg("url.dll,FileProtocolHandler");
             }
             let spawned = cmd
                 .arg(&url)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -327,7 +327,13 @@ if (-not (Test-Path $ReleaseBat)) {
 }
 
 if ($env:OSA_PORT) { $Port = $env:OSA_PORT } else { $Port = 9089 }
-$HealthUrl = "http://localhost:$Port/health"
+# 127.0.0.1, NOT localhost. The backend binds IPv4 only, but Windows resolves
+# "localhost" to ::1 first and the IPv6 attempt STALLS rather than refusing,
+# consuming the whole -TimeoutSec 2 budget in Test-Health below before IPv4 is
+# ever tried. Test-Health therefore returned $false against a perfectly healthy
+# daemon, so every launch tried to start a SECOND backend on the taken port and
+# died with "port 9089 may already be in use".
+$HealthUrl = "http://127.0.0.1:$Port/health"
 
 function Test-Health {
   param([string]$Url)
@@ -346,6 +352,19 @@ function Get-DaemonProcess {
       if ($proc) { return $proc }
     }
   }
+  # Fall back to whoever actually holds the PORT. The pidfile records the
+  # cmd.exe wrapper, but `erl` is its child and outlives it when the wrapper is
+  # killed alone - leaving a backend that owns :$Port and that `osa stop` could
+  # not see. That is the "No OSA backend is running" / "port may already be in
+  # use" deadlock: stop reports nothing to stop, and start cannot bind.
+  try {
+    $owner = (Get-NetTCPConnection -State Listen -LocalPort $Port -ErrorAction SilentlyContinue |
+              Select-Object -First 1).OwningProcess
+    if ($owner) {
+      $proc = Get-Process -Id ([int]$owner) -ErrorAction SilentlyContinue
+      if ($proc) { return $proc }
+    }
+  } catch { }
   return $null
 }
 
@@ -369,7 +388,13 @@ function Start-Daemon {
   # Detached background daemon that SURVIVES this launcher and the TUI.
   $backendLog = Join-Path $LogDir 'backend.log'
   Write-Host "  -> Starting OSA backend on :$Port (background daemon)" -ForegroundColor Cyan
-  $proc = Start-Process -FilePath $ReleaseBat -ArgumentList 'serve' `
+  # The stock release .bat has NO `serve` command (see copy_osagent_wrapper in
+  # mix.exs): it printed "ERROR: Unknown command serve" and exited instantly, so
+  # the daemon never started and Wait-Health's early-exit branch mis-reported it
+  # as a port conflict. Dispatch through `eval`, like the POSIX bin/osagent
+  # wrapper - CLI.serve() also runs migrate!() and seed_workspace(), which a
+  # bare release `start` skips.
+  $proc = Start-Process -FilePath $ReleaseBat -ArgumentList 'eval','OptimalSystemAgent.CLI.serve()' `
     -PassThru -WindowStyle Hidden -RedirectStandardOutput $backendLog
   Set-Content -LiteralPath $PidFile -Value $proc.Id -Encoding ASCII
   return $proc
@@ -1035,7 +1060,11 @@ $overdrive = $false
 # `osa opencomputers ...` owns its own argument vector (a passthrough to the
 # release binary), so it is matched positionally and never enters the verb scan.
 if ($argList.Count -ge 1 -and [string]$argList[0] -eq 'opencomputers') {
-  & $ReleaseBat opencomputers @(Drop-First $argList); exit $LASTEXITCODE
+  # Not a command in the stock release .bat either - build the same Elixir list
+  # the POSIX wrapper builds and hand it to `eval`.
+  $ocQuoted = @(Drop-First $argList) | ForEach-Object { '"' + ([string]$_ -replace '\\', '\\' -replace '"', '\"') + '"' }
+  & $ReleaseBat eval ('OptimalSystemAgent.CLI.opencomputers([' + ($ocQuoted -join ',') + '])')
+  exit $LASTEXITCODE
 }
 
 # Flags that consume the NEXT token as their value. Their argument is never a
@@ -1115,9 +1144,11 @@ switch -Exact ($cmd) {
     }
     exit 0
   }
-  'setup'  { & $ReleaseBat setup;  exit $LASTEXITCODE }
-  'serve'  { & $ReleaseBat serve;  exit $LASTEXITCODE }
-  'doctor' { & $ReleaseBat doctor; exit $LASTEXITCODE }
+  # Dispatched through `eval` because the stock release .bat has no such
+  # commands; these three printed "ERROR: Unknown command <verb>" before.
+  'setup'  { & $ReleaseBat eval 'OptimalSystemAgent.CLI.setup()';  exit $LASTEXITCODE }
+  'serve'  { & $ReleaseBat eval 'OptimalSystemAgent.CLI.serve()';  exit $LASTEXITCODE }
+  'doctor' { & $ReleaseBat eval 'OptimalSystemAgent.CLI.doctor()'; exit $LASTEXITCODE }
   'stop'   { Stop-Daemon; exit 0 }
   'update' {
     # The `update` token was already stripped from $argList by the verb
@@ -1170,7 +1201,7 @@ if ($overdrive) { Warn-Overdrive }
 
 # Launch the TUI. The backend daemon deliberately OUTLIVES this process, so the
 # next `osa` attaches instantly. No cleanup - that is the whole point.
-$env:OSA_URL = "http://localhost:$Port"
+$env:OSA_URL = "http://127.0.0.1:$Port"   # IPv4 literal - see the $HealthUrl note above
 & $TuiBin @argList
 exit $LASTEXITCODE
 '@


### PR DESCRIPTION
## This is a Windows-only report

Everything below is specific to the **Windows** side of things. The Linux/macOS
paths are untouched by this PR, and I've kept the POSIX branches byte-identical
so they cannot regress.

On Windows 11 with the prebuilt **v1.0.145** release (`irm .../install.ps1 | iex`),
OSA currently cannot start its backend, cannot complete any subscription
sign-in, and cannot open a sign-in URL. These are four independent bugs; each
one alone is fatal on the platform.

## What a user sees

```
PS C:\Users\me> osa overdrive
  -> Starting OSA backend on :9089 (background daemon)
  | warming OSA backend...  [x] Backend exited during startup - port 9089 may already be in use.
PS C:\Users\me> osa stop
  No OSA backend is running on :9089.
PS C:\Users\me> osa overdrive
  -> Starting OSA backend on :9089 (background daemon)
  | warming OSA backend...  [x] Backend exited during startup - port 9089 may already be in use.
```

Nothing is on the port. `~/.osa/logs/backend.log` contains the real reason:

```
ERROR: Unknown command serve
```

And once past that, every provider sign-in ends at:

```
xAI sign-in failed: {:unsafe_read, :insecure_permissions}. You can paste an API key instead.
```

## Root causes

### 1. The launcher calls release commands that don't exist on Windows

`copy_osagent_wrapper/1` skips the POSIX `bin/osagent` wrapper on a Windows
build host, on the stated assumption that the stock `bin\osagent.bat` has
"serve/setup/doctor as release commands":

```elixir
# On a Windows build host, skip it entirely and let install.ps1 call the stock
# bin\osagent.bat launcher (with serve/setup/doctor as release commands).
```

It doesn't. The generated script's entire command set is `start`, `start_iex`,
`install`, `eval`, `rpc`, `remote`, `restart`, `stop`, `pid`, `version`.
Confirmed on the shipped release — `serve`, `setup`, `doctor` and
`opencomputers` are absent from **both** `bin/osagent` and `bin\osagent.bat`.

So `Start-Daemon` runs `osagent.bat serve`, which exits instantly, and
`Wait-Health`'s `$rc -eq 2` branch reports that as *"port 9089 may already be in
use"* — pointing users at a port conflict that never existed.

Fixed by dispatching all four through `eval`, exactly as the sh wrapper does.
Note `CLI.serve()` also runs `migrate!()` and `seed_workspace()`, which a bare
release `start` skips — so `eval` is the correct route, not `start`.

### 2. `Test-Health` can never return true

`$HealthUrl` used `localhost`. The backend binds **127.0.0.1 only**, and Windows
resolves `localhost` to `::1` first — and that IPv6 attempt *stalls* rather than
refusing, consuming the whole `-TimeoutSec 2` budget before IPv4 is ever tried.

Measured on the affected machine, backend healthy, three consecutive runs in
fresh `-NoProfile` children (what `osa.cmd` spawns):

| URL | result |
|---|---|
| `http://localhost:9089/health` | FALSE — ~2.1s, every time |
| `http://127.0.0.1:9089/health` | TRUE — ~56ms |
| `http://[::1]:9089/health` | FALSE — nothing bound on IPv6 |

So the launcher never attaches to a healthy daemon. It starts a second one,
which cannot bind, which reproduces the same misleading error on *every* launch.
This is why fixing bug #1 alone is not enough. `$env:OSA_URL` had the same
issue and is also switched to the IPv4 literal.

### 3. `osa stop` cannot stop an orphaned backend

`Get-DaemonProcess` consults only the pidfile, which records the `cmd.exe`
wrapper. `erl` is its child and outlives the wrapper when that is killed alone —
leaving a backend owning `:9089` that `stop` reports as "No OSA backend is
running" while `start` cannot bind. Added a fallback to the process actually
holding the port.

### 4. POSIX mode bits don't exist on Windows

Erlang synthesises `File.Stat.mode` from the read-only attribute alone, so an
ordinary file **always** reports `0o100666`. Two checks assume otherwise:

**`SubscriptionStore.check_permissions/1`** requires `band(mode, 0o077) == 0`.
Never true on Windows — and `File.chmod/2` can't clear those bits either, so the
0600-from-birth write is a no-op there. OSA rejects, on every read, a credential
file **it just wrote itself**. Every subscription provider is permanently
unusable.

Verified against a real xAI device-code credential on the affected machine:

```
os_type={:win32, :nt}
erlang_reported_mode=0o100666
band(mode, 0o077)=0o66      <- nonzero, so the old code refuses, always
READ_OK providers=["xai"]   <- with this patch
```

The device flow had **succeeded** and the token was live against `api.x.ai`
(12 models returned) the entire time. Only the read gate rejected it. Windows
access is governed by NTFS ACLs, which this check cannot see, so it now defers
to them.

**`Doctor.executable?/1`** requires `band(mode, 0o111) != 0`, likewise never
true, so `osa doctor` reports a working `osagent-tui.exe` as "found but not
executable".

### 5. `explorer.exe` is not a browser

```rust
#[cfg(target_os = "windows")]
let candidates: [&str; 1] = ["explorer"];
```

`explorer.exe` is the file manager. Handed a URL it commonly opens **a folder
window at the working directory** instead of passing the address to the default
browser — so a user sent to an OAuth page gets a file listing and the sign-in
never loads. This was reported to me as "it opens a folder pathway and not the
actual URL for the auth".

Replaced with `rundll32 url.dll,FileProtocolHandler`, which invokes the
registered protocol handler directly, involves no shell, and ships with every
supported Windows version.

`Utils.Browser` has the same class of bug — `cmd /c start <url>` consumes the
URL as `start`'s **window-title** argument, and `&` in a URL is a `cmd`
separator — so it's fixed the same way.

## Verification

All of this was verified on the affected machine against the installed
v1.0.145 release:

- `osagent.bat eval "OptimalSystemAgent.CLI.serve()"` via `Start-Process` →
  healthy in ~3.6s, prints `OSA serving on :9089`
- `osa doctor` → runs (previously "Unknown command doctor"), reports
  `✓ Provider … xai (grok-4.6)`
- `osa stop` → stops an orphaned backend and frees the port
- Patched `SubscriptionStore` compiled against the shipped release and hot-
  swapped in → `READ_OK providers=["xai"]`, sign-in completes
- `Invoke-RestMethod https://api.x.ai/v1/models` with the stored OAuth token →
  200, 12 models

I could not rebuild the Rust TUI here, so the `mod.rs` change is the only one
not exercised end-to-end on this machine; the reasoning and the reported symptom
match precisely, but it's worth a maintainer confirming.

Happy to split this into separate PRs per bug if you'd prefer smaller reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0158cRHtuJ1yi1u3AhuWV5UM
