### PR TITLE
test: stop the runtime-routes cleanup racing late writers

### DIFF
--- a/test/optimal_system_agent/channels/http/agent_runtime_routes_test.exs
+++ b/test/optimal_system_agent/channels/http/agent_runtime_routes_test.exs
@@ -18,11 +18,18 @@ defmodule OptimalSystemAgent.Channels.HTTP.API.AgentRuntimeRoutesTest do
     Application.put_env(:optimal_system_agent, :agent_runs_dir, dir)
 
     on_exit(fn ->
-      File.rm_rf!(dir)
-
       if previous,
         do: Application.put_env(:optimal_system_agent, :agent_runs_dir, previous),
         else: Application.delete_env(:optimal_system_agent, :agent_runs_dir)
+
+      # A late runtime writer can recreate an entry mid-traversal, making
+      # File.rm_rf!/1 raise :eexist (the CI flake on 2026-08-26). Restore the
+      # env first so nothing new lands here, then remove best-effort with one
+      # retry for the writer that already held the old path.
+      case File.rm_rf(dir) do
+        {:ok, _} -> :ok
+        {:error, _, _} -> File.rm_rf(dir)
+      end
     end)
 
     :ok


### PR DESCRIPTION
The post-merge main run failed 3/3 tests in `agent_runtime_routes_test.exs` on `File.rm_rf!/1: file already exists` in `on_exit` - a cleanup race with a late runtime writer recreating entries mid-traversal. The identical tree was green on PR #176's run, so this is order/timing, not code.

Fix: restore the `agent_runs_dir` env before removing (no new writes land in the dir), and remove best-effort with one retry instead of the bang. Verified: file suite green locally.