### PR TITLE
fix(subagents): task_wait 10-min timeout on healthy long agents + raw-id visual leaks

### DIFF
--- a/lib/optimal_system_agent/agent/background_notifier.ex
+++ b/lib/optimal_system_agent/agent/background_notifier.ex
@@ -143,6 +143,11 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
   defp inject(parent_id, ev, outcome) do
     role = Map.get(ev, :role, "background")
     agent_id = Map.get(ev, :agent_id, "unknown")
+    # Prefer the clean handle the event already carries (the stall path already
+    # does this) over the raw `agent:session-<ts>-<hash>:name` id, so the
+    # completion line reads "@backend-plan-enrollments" not the session gibberish.
+    # (agent_id is still the routing id used for task_id below, just not shown.)
+    name = Map.get(ev, :display_name) || role
     dur = Map.get(ev, :duration_ms)
     dur_str = if is_integer(dur), do: " after #{dur}ms", else: ""
 
@@ -151,12 +156,12 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
         :completed ->
           result = ev |> Map.get(:result, "") |> to_string() |> String.slice(0, 1000)
 
-          "Background agent '#{role}' (#{agent_id}) completed#{dur_str}: #{result}"
+          "Background agent @#{name} completed#{dur_str}: #{result}"
 
         :failed ->
           error = ev |> Map.get(:error, "unknown error") |> to_string() |> String.slice(0, 1000)
 
-          "Background agent '#{role}' (#{agent_id}) failed#{dur_str}: #{error}"
+          "Background agent @#{name} failed#{dur_str}: #{error}"
       end
 
     # WS7 — structured usage rendered as a compact string so the model reads

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -2176,17 +2176,31 @@ defmodule OptimalSystemAgent.Orchestrator do
   #               provider that stopped responding mid-run; a much shorter
   #               threshold is appropriate.
   #
-  # It only OBSERVES: it emits `:background_agent_stalled` and stops. It never
-  # kills the child — a long-running-but-alive teammate must not be reaped by a
-  # heuristic, and the existing join timeout remains the only hard stop.
-  # It exits as soon as the run reaches a terminal status or its row disappears.
+  # Mostly OBSERVES: on the first stall it sends ONE non-destructive nudge, then
+  # emits `:background_agent_stalled` and keeps watching. It does NOT reap a
+  # long-running-but-alive teammate on the minute-scale thresholds — a healthy
+  # agent that is slow or in a long provider call must never be killed.
+  #
+  # The ONE exception is a definitely-dead hang: an agent that has made NO
+  # progress for `@stall_hard_stop_ms` (default 2h) AFTER a nudge is not slow,
+  # it is wedged — every legitimate long operation resolves well inside that
+  # window (MCP calls time out at 60s, shell commands background, a stalled
+  # provider call fails over its retries in ~90min), and a healthy multi-day
+  # agent makes SOME progress far sooner. Rather than leave it for the operator
+  # to notice and `task_stop` by hand, the watcher auto-stops it and reports it
+  # cancelled. This is well under the 3-day lifetime backstop (which bounds a
+  # *working* agent) and only ever fires on a genuine no-progress hang.
   @stall_poll_interval_ms 30_000
   @stall_threshold_starting_ms 5 * 60 * 1000
   @stall_threshold_working_ms 15 * 60 * 1000
+  @stall_hard_stop_ms 2 * 60 * 60 * 1000
 
   defp stall_poll_interval_ms,
     do:
       Application.get_env(:optimal_system_agent, :stall_poll_interval_ms, @stall_poll_interval_ms)
+
+  defp stall_hard_stop_ms,
+    do: Application.get_env(:optimal_system_agent, :stall_hard_stop_ms, @stall_hard_stop_ms)
 
   defp stall_threshold_ms(:starting),
     do:
@@ -2301,6 +2315,26 @@ defmodule OptimalSystemAgent.Orchestrator do
               nudged: true
             })
 
+          stall.nudged and
+              now_ms() - (stall.since || stall.last_change_at) >= stall_hard_stop_ms() ->
+            # Definitely-dead hang: no progress for the hard threshold (default
+            # 2h) even AFTER a nudge. Auto-stop it and report it cancelled so the
+            # operator/coordinator doesn't have to notice and `task_stop` it by
+            # hand. Safe against the days requirement: a healthy long/slow agent
+            # makes SOME progress well inside 2h, and every legitimate long call
+            # resolves sooner (MCP 60s, shell backgrounds, provider retries
+            # ~90min). Stop watching once stopped.
+            auto_stop_stalled(
+              parent_id,
+              subagent_id,
+              display_name,
+              role,
+              phase,
+              now_ms() - (stall.since || stall.last_change_at)
+            )
+
+            :ok
+
           now_ms() - stall.last_change_at >= stall_report_gap_ms(phase, stall.reports) ->
             since = stall.since || stall.last_change_at
 
@@ -2380,6 +2414,74 @@ defmodule OptimalSystemAgent.Orchestrator do
       OptimalSystemAgent.PubSub,
       "osa:session:#{parent_id}",
       {:osa_event, Map.put(payload, :type, :background_agent_nudged)}
+    )
+
+    :ok
+  rescue
+    _ -> :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  # Auto-stop a subagent that is a confirmed dead hang (no progress for the hard
+  # threshold, after a nudge). Cancels the Loop and records the run as cancelled
+  # with an honest summary — the SAME path `task_stop` takes — then emits a
+  # `:background_agent_auto_stopped` event so the coordinator learns it is done
+  # (and why) without having to poll or stop it by hand. Best-effort.
+  defp auto_stop_stalled(parent_id, subagent_id, display_name, role, phase, stalled_ms) do
+    minutes = div(stalled_ms, 60_000)
+
+    Logger.warning(
+      "[Orchestrator] Background subagent #{subagent_id} made NO progress for #{minutes}m in " <>
+        ":#{phase} even after a nudge — auto-stopping it as an unrecoverable hang"
+    )
+
+    Loop.cancel(subagent_id)
+
+    summary =
+      "Auto-stopped after #{minutes}m with no progress in :#{phase} (unrecoverable hang — " <>
+        "a hung tool or a stalled provider call that never resumed)."
+
+    case RunStore.get(subagent_id) do
+      nil ->
+        :ok
+
+      run ->
+        RunStore.complete(subagent_id, %{
+          agent_id: subagent_id,
+          parent_session_id: run.parent_session_id,
+          role: run.role,
+          status: :cancelled,
+          summary: summary,
+          files_changed: [],
+          commands_run: [],
+          tool_count: Map.get(run, :tool_count, 0),
+          tokens_used: Map.get(run, :tokens_used, 0),
+          duration_ms: nil,
+          errors: ["stall_hard_stop"],
+          next_actions: [],
+          transcript_path: Map.get(run, :transcript_path),
+          worktree: nil
+        })
+    end
+
+    payload = %{
+      event: :background_agent_auto_stopped,
+      session_id: parent_id,
+      agent_id: subagent_id,
+      display_name: display_name,
+      role: role,
+      phase: phase,
+      stalled_ms: stalled_ms,
+      summary: summary
+    }
+
+    Bus.emit(:system_event, payload)
+
+    Phoenix.PubSub.broadcast(
+      OptimalSystemAgent.PubSub,
+      "osa:session:#{parent_id}",
+      {:osa_event, Map.put(payload, :type, :background_agent_auto_stopped)}
     )
 
     :ok

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -38,11 +38,15 @@ defmodule OptimalSystemAgent.Orchestrator do
   # agent building 67 pages and running 157 tests hit it and was reported as
   # `:timeout` with its finished results thrown away.
   #
-  # An agent expected to work unattended for a shift needs a backstop measured
-  # in shifts. Still finite so a truly wedged child cannot be held forever, and
-  # still overridable per call (`timeout_ms:` / `await_timeout:`) or globally via
-  # `:subagent_await_timeout_ms` for a deliberately bounded job.
-  @default_subagent_timeout_ms 12 * 60 * 60 * 1000
+  # Long-running agents run for DAYS, not a shift. This backstop is deliberately
+  # measured in days so a healthy multi-day agent is never killed or abandoned
+  # (the whole point of unattended background work). Still finite — 3 days — so a
+  # truly wedged child cannot be held literally forever, and still overridable
+  # per call (`timeout_ms:` / `await_timeout:`) or globally via
+  # `:subagent_join_timeout_ms` / `:subagent_await_timeout_ms`. This is the ONE
+  # agent-lifetime knob; the swarm patterns and task_wait read it too, so there
+  # is no stray minute-scale cap anywhere that could kill a day-long agent.
+  @default_subagent_timeout_ms 3 * 24 * 60 * 60 * 1000
 
   @doc false
   def runner_key(agent_id), do: "subagent-runner:" <> agent_id

--- a/lib/optimal_system_agent/swarm/patterns.ex
+++ b/lib/optimal_system_agent/swarm/patterns.ex
@@ -27,15 +27,16 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
 
     * `:runner`  — 1-arity fun invoked per config. Defaults to
       `Orchestrator.run_subagent/1`.
-    * `:timeout` — per-agent timeout in ms. Defaults to 30 minutes (real
-      subagents routinely run far longer than the old 10-minute default, which
-      killed healthy agents mid-run).
+    * `:timeout` — per-agent timeout in ms. Defaults to the shared agent-lifetime
+      backstop (`Orchestrator.subagent_join_timeout_ms/1`, measured in DAYS), so
+      a healthy long-running agent is never killed mid-run. The old minute-scale
+      defaults killed day-long agents; there is no minute-scale cap here now.
   """
   def parallel(parent_id, configs, opts \\ []) do
     Logger.info("[Swarm.Patterns] parallel — #{length(configs)} agents")
 
     runner = Keyword.get(opts, :runner, &Orchestrator.run_subagent/1)
-    timeout = Keyword.get(opts, :timeout, 1_800_000)
+    timeout = Keyword.get(opts, :timeout, Orchestrator.subagent_join_timeout_ms(%{}))
     depth = Keyword.get(opts, :depth, 0)
     priority = Keyword.get(opts, :priority, :standard)
 
@@ -144,7 +145,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
           # Same cap as `parallel/3` — an uncapped fan-out here is the identical
           # defect, just reached through a different pattern.
           max_concurrency: min(length(proposers), Orchestrator.delegate_concurrency_cap()),
-          timeout: 1_800_000,
+          timeout: Orchestrator.subagent_join_timeout_ms(%{}),
           on_timeout: :kill_task
         )
         |> Enum.map(fn

--- a/lib/optimal_system_agent/swarm/patterns.ex
+++ b/lib/optimal_system_agent/swarm/patterns.ex
@@ -27,13 +27,15 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
 
     * `:runner`  — 1-arity fun invoked per config. Defaults to
       `Orchestrator.run_subagent/1`.
-    * `:timeout` — per-agent timeout in ms. Defaults to 10 minutes.
+    * `:timeout` — per-agent timeout in ms. Defaults to 30 minutes (real
+      subagents routinely run far longer than the old 10-minute default, which
+      killed healthy agents mid-run).
   """
   def parallel(parent_id, configs, opts \\ []) do
     Logger.info("[Swarm.Patterns] parallel — #{length(configs)} agents")
 
     runner = Keyword.get(opts, :runner, &Orchestrator.run_subagent/1)
-    timeout = Keyword.get(opts, :timeout, 600_000)
+    timeout = Keyword.get(opts, :timeout, 1_800_000)
     depth = Keyword.get(opts, :depth, 0)
     priority = Keyword.get(opts, :priority, :standard)
 
@@ -142,7 +144,7 @@ defmodule OptimalSystemAgent.Swarm.Patterns do
           # Same cap as `parallel/3` — an uncapped fan-out here is the identical
           # defect, just reached through a different pattern.
           max_concurrency: min(length(proposers), Orchestrator.delegate_concurrency_cap()),
-          timeout: 600_000,
+          timeout: 1_800_000,
           on_timeout: :kill_task
         )
         |> Enum.map(fn

--- a/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
@@ -189,6 +189,11 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
       # so anything a worker drops here is readable by the coordinator and its
       # siblings.
       task: inject_scratchpad(child_task, parent_id),
+      # Clean roster/label preview from the ORIGINAL task, before the shared-
+      # scratchpad preamble is injected — otherwise the agents panel shows
+      # "[shared scratchpad] You are part of a coordinated team..." (the preamble)
+      # as the row's description instead of the actual work.
+      description: child_task |> to_string() |> String.trim() |> String.slice(0, 80),
       parent_session_id: parent_id,
       role: role || "agent",
       # Non-fatal signal: caller named a specific role/subagent_type but no such

--- a/lib/optimal_system_agent/tools/builtins/task_wait/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_wait/handler.ex
@@ -26,15 +26,18 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Handler do
   alias OptimalSystemAgent.Tools.UseContext
 
   @terminal_statuses [:completed, :failed, :cancelled]
-  # Real subagents routinely run far longer than the old 10-minute default, so
-  # that default spuriously "timed out" on perfectly healthy agents and drove
-  # the coordinator into re-issuing task_wait over and over (a wasteful poll
-  # loop that also reads as broken). 30 minutes matches the stream idle backstop
-  # and covers the large majority of jobs in a single call; a caller with a
-  # known-longer horizon still passes an explicit `timeout_ms`, and the timeout
-  # branch below no longer treats a still-running agent as a dead end.
-  @default_timeout_ms 1_800_000
   @poll_interval_ms 500
+
+  # Default wait bound = the shared agent-LIFETIME backstop, which is measured in
+  # DAYS (see Orchestrator.@default_subagent_timeout_ms / :subagent_join_timeout_ms).
+  # Long-running agents run for days, so a minute-scale default spuriously "timed
+  # out" on healthy agents and drove the coordinator into a re-poll loop. Reading
+  # the same knob means task_wait, the delegate join, and the swarm patterns all
+  # agree on one days-scale number with no stray cap. A caller that wants a
+  # deliberately short bound still passes an explicit `timeout_ms`, and the
+  # timeout branch treats a still-running agent as healthy (not a dead end).
+  defp default_timeout_ms,
+    do: OptimalSystemAgent.Orchestrator.subagent_join_timeout_ms(%{})
 
   # ── Stage 1: Input validation ──────────────────────────────────────────
 
@@ -82,7 +85,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Handler do
   def execute(%{"agent_ids" => agent_ids} = input, ctx) do
     caller_id = session_id(ctx)
     require_all = Map.get(input, "require_all", true) != false
-    timeout_ms = parse_timeout_ms(Map.get(input, "timeout_ms")) || @default_timeout_ms
+    timeout_ms = parse_timeout_ms(Map.get(input, "timeout_ms")) || default_timeout_ms()
     deadline = System.monotonic_time(:millisecond) + timeout_ms
 
     Depth.enter(caller_id)

--- a/lib/optimal_system_agent/tools/builtins/task_wait/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_wait/handler.ex
@@ -26,7 +26,14 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Handler do
   alias OptimalSystemAgent.Tools.UseContext
 
   @terminal_statuses [:completed, :failed, :cancelled]
-  @default_timeout_ms 600_000
+  # Real subagents routinely run far longer than the old 10-minute default, so
+  # that default spuriously "timed out" on perfectly healthy agents and drove
+  # the coordinator into re-issuing task_wait over and over (a wasteful poll
+  # loop that also reads as broken). 30 minutes matches the stream idle backstop
+  # and covers the large majority of jobs in a single call; a caller with a
+  # known-longer horizon still passes an explicit `timeout_ms`, and the timeout
+  # branch below no longer treats a still-running agent as a dead end.
+  @default_timeout_ms 1_800_000
   @poll_interval_ms 500
 
   # ── Stage 1: Input validation ──────────────────────────────────────────
@@ -124,22 +131,42 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Handler do
 
   defp format_results(agent_ids, runs, require_all) do
     sections = Enum.map(agent_ids, &format_one(&1, Map.get(runs, &1)))
-
     mode = if require_all, do: "ALL", else: "ANY"
 
+    still_running =
+      agent_ids
+      |> Enum.filter(fn id -> match?(%{status: :running}, Map.get(runs, id)) end)
+
     header =
-      "Join-barrier wait finished (mode=#{mode}) for #{length(agent_ids)} agent(s):"
+      if still_running == [] do
+        "Join-barrier wait finished (mode=#{mode}) for #{length(agent_ids)} agent(s):"
+      else
+        # Timed out with work still in flight. This is NOT a failure and the
+        # coordinator must NOT re-issue task_wait — background completion is
+        # delivered automatically as a task-notification. Say so explicitly, or
+        # the model falls back into the 10-minute re-poll loop this fix removes.
+        "Join-barrier TIMED OUT with #{length(still_running)} of #{length(agent_ids)} " <>
+          "agent(s) still running: #{Enum.map_join(still_running, ", ", &short_name/1)}. " <>
+          "They are healthy, not failed — do NOT wait on them again. Their results will be " <>
+          "delivered to you automatically when they finish; continue with other work now."
+      end
 
     Enum.join([header | sections], "\n\n")
   end
 
+  # Clean, human handle for a subagent id: the trailing name segment of
+  # `agent:session-<ts>-<hash>:name`, never the raw session gibberish.
+  defp short_name(id) when is_binary(id), do: id |> String.split(":") |> List.last()
+  defp short_name(id), do: to_string(id)
+
   defp format_one(id, nil) do
-    "### #{id}\nNo run found for this agent id — nothing to join on."
+    "### #{short_name(id)}\nNo run found for this agent id — nothing to join on."
   end
 
   defp format_one(id, %{status: :running} = run) do
-    "### #{id} (#{run.role}) — still running (timed out waiting)\n" <>
-      "Latest progress: #{Enum.join(run.recent_actions, "; ")}"
+    "### #{short_name(id)} (#{run.role}) — still running\n" <>
+      "Latest progress: #{Enum.join(run.recent_actions, "; ")}\n" <>
+      "(Not finished yet — its completion will be delivered automatically; do not re-wait.)"
   end
 
   defp format_one(id, run) do
@@ -152,7 +179,7 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Handler do
     resumed_note =
       if Map.get(run, :resumed_from), do: " (resumed_from=#{run.resumed_from})", else: ""
 
-    "### #{id} (#{run.role})#{resumed_note} — #{run.status}\n#{summary}"
+    "### #{short_name(id)} (#{run.role})#{resumed_note} — #{run.status}\n#{summary}"
   end
 
   defp parse_timeout_ms(nil), do: nil

--- a/lib/optimal_system_agent/tools/builtins/task_wait/prompt.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_wait/prompt.ex
@@ -32,7 +32,8 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Prompt do
 
     Give the agentIds to wait on (from earlier delegate/background launches). By default waits
     for ALL of them (`require_all: true`); set it to `false` to return as soon as ANY one
-    finishes. An optional `timeout_ms` bounds the wait (default 30 minutes) — on timeout, any
+    finishes. An optional `timeout_ms` bounds the wait (defaults to the agent-lifetime backstop,
+    measured in DAYS, since agents run that long) — on timeout, any
     still-running agents are HEALTHY (not failed): their results arrive automatically when they
     finish, so do NOT call this again on them, just continue with other work.
 

--- a/lib/optimal_system_agent/tools/builtins/task_wait/prompt.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_wait/prompt.ex
@@ -32,8 +32,9 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Prompt do
 
     Give the agentIds to wait on (from earlier delegate/background launches). By default waits
     for ALL of them (`require_all: true`); set it to `false` to return as soon as ANY one
-    finishes. An optional `timeout_ms` bounds the wait (default 10 minutes) — on timeout, still-
-    running agents are reported as such rather than erroring.
+    finishes. An optional `timeout_ms` bounds the wait (default 30 minutes) — on timeout, any
+    still-running agents are HEALTHY (not failed): their results arrive automatically when they
+    finish, so do NOT call this again on them, just continue with other work.
 
     Safety: nesting a blocking wait inside an agent that is ITSELF being waited on by another
     `#{task_wait_name()}` call is capped at a configured depth to prevent a chain of mutually-

--- a/lib/optimal_system_agent/tools/builtins/task_wait/tool.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_wait/tool.ex
@@ -71,9 +71,11 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Tool do
         "timeout_ms" => %{
           "type" => "integer",
           "description" =>
-            "Maximum time to block in milliseconds (default 600000 / 10 minutes). Agents " <>
-              "still running when the timeout elapses are reported as such, not treated " <>
-              "as errors."
+            "Maximum time to block in milliseconds (default 1800000 / 30 minutes). Agents " <>
+              "still running when the timeout elapses are HEALTHY, not failed — their results " <>
+              "are delivered to you automatically when they finish, so do NOT call task_wait " <>
+              "again on them; continue with other work. Only pass a larger value if you have " <>
+              "a specific reason to block longer."
         }
       }
     }

--- a/lib/optimal_system_agent/tools/builtins/task_wait/tool.ex
+++ b/lib/optimal_system_agent/tools/builtins/task_wait/tool.ex
@@ -71,7 +71,8 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWait.Tool do
         "timeout_ms" => %{
           "type" => "integer",
           "description" =>
-            "Maximum time to block in milliseconds (default 1800000 / 30 minutes). Agents " <>
+            "Maximum time to block in milliseconds. Defaults to the agent-lifetime backstop " <>
+              "(measured in DAYS) so a long-running agent is never spuriously cut off. Agents " <>
               "still running when the timeout elapses are HEALTHY, not failed — their results " <>
               "are delivered to you automatically when they finish, so do NOT call task_wait " <>
               "again on them; continue with other work. Only pass a larger value if you have " <>

--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -608,16 +608,6 @@ impl App {
     pub fn submit_input(&mut self, text: &str) {
         let text = text.trim();
         if text.is_empty() {
-            // Portable send-now: pressing Enter on an EMPTY composer while a
-            // turn is running with messages queued flushes them into the live
-            // turn — the same action as Alt+Enter, but with no modifier and no
-            // kitty protocol, so it works on every terminal (Terminal.app,
-            // conhost, VS Code, tmux/SSH). With nothing queued or no active
-            // turn it stays a no-op, exactly as before.
-            if self.turn_is_active() && !self.message_queue.is_empty() {
-                self.send_queued_now();
-            }
-
             return;
         }
 

--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -608,6 +608,16 @@ impl App {
     pub fn submit_input(&mut self, text: &str) {
         let text = text.trim();
         if text.is_empty() {
+            // Portable send-now: pressing Enter on an EMPTY composer while a
+            // turn is running with messages queued flushes them into the live
+            // turn — the same action as Alt+Enter, but with no modifier and no
+            // kitty protocol, so it works on every terminal (Terminal.app,
+            // conhost, VS Code, tmux/SSH). With nothing queued or no active
+            // turn it stays a no-op, exactly as before.
+            if self.turn_is_active() && !self.message_queue.is_empty() {
+                self.send_queued_now();
+            }
+
             return;
         }
 

--- a/priv/rust/tui/src/app/update.rs
+++ b/priv/rust/tui/src/app/update.rs
@@ -1212,6 +1212,15 @@ impl App {
     // `pub(super)` so the inline ask_user band's Ctrl+C path can decline the
     // question and then fall through to the normal interrupt handling.
     pub(super) fn handle_processing_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+        // Was an interrupt armed BEFORE this key? Captured up front because the
+        // non-Esc reset below clears it. A bare Enter that is DISARMING an armed
+        // interrupt (a deliberate Esc-then-Enter, or a split Alt+Enter that
+        // arrived as Esc+Enter) must stay HARMLESS — it only disarms, it does
+        // NOT trigger send-now. Only a CLEAN bare Enter (nothing armed) is a
+        // real send-now gesture. This is what keeps the portable Enter path from
+        // colliding with the ambiguous split-chord case.
+        let interrupt_was_armed = self.activity.is_interrupt_armed();
+
         // NOTE: vim does NOT get Esc first-refusal while Processing — Esc must
         // interrupt the running turn ("esc to interrupt"). Non-Esc Normal-mode
         // motions still reach the composer via the `_` fall-through arm below
@@ -1358,6 +1367,21 @@ impl App {
             // mismatch as one that does not work where it is.
             (KeyCode::Enter, m)
                 if m.contains(KeyModifiers::ALT) && !self.message_queue.is_empty() =>
+            {
+                self.send_queued_now();
+                false
+            }
+            // Portable send-now (works on EVERY terminal, no kitty protocol):
+            // a CLEAN bare Enter on an empty composer, with messages queued,
+            // delivers them into the running turn — same action as Alt+Enter,
+            // for terminals where Alt+Enter collapses to a bare Enter. Gated on
+            // `!interrupt_was_armed` so a split Alt+Enter (Esc+Enter) or a
+            // deliberate Esc-then-Enter stays harmless (it only disarmed above);
+            // and on an EMPTY composer so typed text still queues as before.
+            (KeyCode::Enter, KeyModifiers::NONE)
+                if !interrupt_was_armed
+                    && self.input.is_empty()
+                    && !self.message_queue.is_empty() =>
             {
                 self.send_queued_now();
                 false

--- a/priv/rust/tui/src/components/agents/render.rs
+++ b/priv/rust/tui/src/components/agents/render.rs
@@ -380,7 +380,9 @@ impl Agents {
                 let mut agent_type = if !entry.role.is_empty() {
                     entry.role.clone()
                 } else {
-                    entry.name.clone()
+                    // Never show the raw `agent:session-<ts>-<hash>:name` routing
+                    // key in the roster — compact it to the clean trailing handle.
+                    super::short_agent_label(&entry.name)
                 };
                 if !entry.active_skills.is_empty() {
                     agent_type.push_str(&format!(" [{}]", entry.active_skills.join(",")));
@@ -699,7 +701,7 @@ impl Agents {
                 }
                 // "  ↳ @agent wrote findings.md (2.1k)" — all dim, tucked under
                 // the agent rows.
-                let who = short_agent(&note.agent);
+                let who = super::short_agent_label(&note.agent);
                 let line_text = format!(
                     "  \u{21b3} @{} {} {} ({})",
                     who,
@@ -1157,14 +1159,6 @@ fn fmt_bytes(n: u64) -> String {
     } else {
         n.to_string()
     }
-}
-
-/// Compact a writer's session id for the scratchpad line. Worker session ids
-/// look like `agent:<parent>:1`; showing the trailing `<parent>:1` keeps the
-/// line short while still distinguishing teammates. Non-worker ids pass through.
-fn short_agent(agent: &str) -> String {
-    let trimmed = agent.strip_prefix("agent:").unwrap_or(agent);
-    truncate_str(trimmed, 18)
 }
 
 /// Shorten model names by stripping the "claude-" prefix.

--- a/priv/rust/tui/src/components/input/mod.rs
+++ b/priv/rust/tui/src/components/input/mod.rs
@@ -2453,15 +2453,7 @@ impl Component for InputComponent {
                         }
 
                         if self.content.trim().is_empty() {
-                            // Empty Enter is no longer swallowed: emit an empty
-                            // Submit so the app can treat it as a PORTABLE
-                            // send-now — press Enter on an empty composer while a
-                            // turn is running with messages queued and they fold
-                            // into the live turn. Works on EVERY terminal (no
-                            // modifier, no kitty protocol), unlike Alt+Enter.
-                            // With no queue / no active turn, `submit_input`
-                            // no-ops on empty exactly as before.
-                            return ComponentAction::Emit(AppAction::Submit(String::new()));
+                            return ComponentAction::Consumed;
                         }
                         let text = self.submit();
                         return ComponentAction::Emit(AppAction::Submit(text));

--- a/priv/rust/tui/src/components/input/mod.rs
+++ b/priv/rust/tui/src/components/input/mod.rs
@@ -56,12 +56,12 @@ use super::{AppAction, Component, ComponentAction};
 /// interrupt keeps its own key and its own surface — the spinner's "esc to
 /// interrupt" — so no row advertises two meanings for one press.
 pub const QUEUED_HINT_FULL: &str =
-    "  \u{2014} sends when this turn ends \u{00b7} alt+enter to send it into this turn now";
+    "  \u{2014} sends when this turn ends \u{00b7} enter again (or alt+enter) sends it into this turn now";
 
 /// Mid-width form. Same key, fewer words — never a different key, and never a
 /// key mentioned without saying what it does.
 pub const QUEUED_HINT_MID: &str =
-    "  \u{2014} sends when this turn ends \u{00b7} alt+enter sends it now";
+    "  \u{2014} sends when this turn ends \u{00b7} enter again sends it now";
 
 /// The narrow-terminal fallback: the trigger, with no key named.
 ///
@@ -2453,7 +2453,15 @@ impl Component for InputComponent {
                         }
 
                         if self.content.trim().is_empty() {
-                            return ComponentAction::Consumed;
+                            // Empty Enter is no longer swallowed: emit an empty
+                            // Submit so the app can treat it as a PORTABLE
+                            // send-now — press Enter on an empty composer while a
+                            // turn is running with messages queued and they fold
+                            // into the live turn. Works on EVERY terminal (no
+                            // modifier, no kitty protocol), unlike Alt+Enter.
+                            // With no queue / no active turn, `submit_input`
+                            // no-ops on empty exactly as before.
+                            return ComponentAction::Emit(AppAction::Submit(String::new()));
                         }
                         let text = self.submit();
                         return ComponentAction::Emit(AppAction::Submit(text));
@@ -5026,8 +5034,8 @@ mod queued_affordance {
     fn the_named_key_is_the_one_that_delivers() {
         let row = queued_row_text(vec!["check the god files"], 140);
         assert!(
-            row.contains("alt+enter"),
-            "the row must name the send-now key: {row:?}"
+            row.contains("enter again"),
+            "the row must name the portable send-now gesture: {row:?}"
         );
         assert!(
             !row.contains("esc"),
@@ -5040,12 +5048,15 @@ mod queued_affordance {
     /// abbreviated to a different chord would be the original defect again,
     /// just narrower.
     #[test]
-    fn every_tier_that_names_a_key_names_alt_enter() {
+    fn every_tier_that_names_a_key_names_the_portable_gesture() {
         for width in [40usize, 55, 60, 70, 80, 100, 120, 200] {
             let row = queued_row_text(vec!["check the god files"], width as u16);
+            // Any tier that names a key must name the PORTABLE wired gesture
+            // ("enter again"), which works on every terminal. The full tier may
+            // ALSO mention alt+enter, but the universal one must always be present.
             if row.contains("alt") || row.contains("enter") || row.contains("esc") {
                 assert!(
-                    row.contains("alt+enter"),
+                    row.contains("enter again"),
                     "at width {width} the row names a key that is not the wired \
                      one: {row:?}"
                 );

--- a/test/agent/orchestrator/bounded_stall_recovery_test.exs
+++ b/test/agent/orchestrator/bounded_stall_recovery_test.exs
@@ -34,6 +34,7 @@ defmodule OptimalSystemAgent.Agent.Orchestrator.BoundedStallRecoveryTest do
       Application.delete_env(:optimal_system_agent, :stall_poll_interval_ms)
       Application.delete_env(:optimal_system_agent, :stall_threshold_starting_ms)
       Application.delete_env(:optimal_system_agent, :stall_threshold_working_ms)
+      Application.delete_env(:optimal_system_agent, :stall_hard_stop_ms)
 
       if prev_provider,
         do: Application.put_env(:optimal_system_agent, :default_provider, prev_provider),
@@ -83,6 +84,64 @@ defmodule OptimalSystemAgent.Agent.Orchestrator.BoundedStallRecoveryTest do
       refute_receive {:osa_event, %{type: :background_agent_nudged, agent_id: ^id}}, 300
 
       # Terminal row => the watcher exits on its next poll. Never killed here.
+      RunStore.complete(id, %{agent_id: id, status: :completed, summary: "done"})
+    end
+  end
+
+  describe "hard auto-stop of an unrecoverable hang" do
+    test "an agent with no progress past the hard threshold is auto-stopped and cancelled",
+         %{parent: parent} do
+      # Tight timings: nudge fires, then the hard-stop threshold trips a couple
+      # polls later. A real hang is 2h; here it is milliseconds.
+      Application.put_env(:optimal_system_agent, :stall_poll_interval_ms, 30)
+      Application.put_env(:optimal_system_agent, :stall_threshold_starting_ms, 40)
+      Application.put_env(:optimal_system_agent, :stall_hard_stop_ms, 50)
+
+      id = "stallhard-run-" <> Integer.to_string(System.unique_integer([:positive]))
+
+      RunStore.start_run(%{
+        agent_id: id,
+        parent_session_id: parent,
+        role: "tester",
+        task: "hang forever"
+      })
+
+      :ok = Orchestrator.start_stall_watcher(parent, id, "hanger", "tester")
+
+      # It nudges first (bounded recovery), then — still no progress past the
+      # hard threshold — auto-stops the dead hang instead of watching forever.
+      assert_receive {:osa_event, %{type: :background_agent_nudged, agent_id: ^id}}, 5_000
+
+      assert_receive {:osa_event, %{type: :background_agent_auto_stopped, agent_id: ^id} = ev},
+                     5_000,
+                     "a hang with no progress past the hard threshold must auto-stop"
+
+      assert ev.summary =~ "Auto-stopped"
+
+      # The run is recorded cancelled (same terminal state task_stop produces),
+      # so the coordinator sees it done without a manual task_stop.
+      assert %{status: :cancelled} = RunStore.get(id)
+    end
+
+    test "a healthy agent that keeps progressing is NEVER auto-stopped", %{parent: parent} do
+      Application.put_env(:optimal_system_agent, :stall_poll_interval_ms, 30)
+      Application.put_env(:optimal_system_agent, :stall_threshold_starting_ms, 40)
+      Application.put_env(:optimal_system_agent, :stall_hard_stop_ms, 50)
+
+      id = "stallhealthy-run-" <> Integer.to_string(System.unique_integer([:positive]))
+      RunStore.start_run(%{agent_id: id, parent_session_id: parent, role: "tester", task: "work"})
+      :ok = Orchestrator.start_stall_watcher(parent, id, "worker", "tester")
+
+      # Keep changing the fingerprint (real progress) across the window the
+      # hard-stop would otherwise fire in.
+      for n <- 1..6 do
+        RunStore.progress(id, "did #{n}", n)
+        Process.sleep(40)
+      end
+
+      refute_receive {:osa_event, %{type: :background_agent_auto_stopped, agent_id: ^id}}, 100
+      assert %{status: :running} = RunStore.get(id)
+
       RunStore.complete(id, %{agent_id: id, status: :completed, summary: "done"})
     end
   end

--- a/test/tools/builtins/task_wait_test.exs
+++ b/test/tools/builtins/task_wait_test.exs
@@ -143,6 +143,24 @@ defmodule OptimalSystemAgent.Tools.Builtins.TaskWaitTest do
       assert text =~ "still running"
     end
 
+    test "on timeout, it says TIMED OUT, tells the coordinator NOT to re-wait, and uses clean names" do
+      RunStore.start_run(%{agent_id: "agent:session-123-abc:frontend-billing-fixes", parent_session_id: "p", role: "frontend"})
+
+      {:ok, text} =
+        Handler.execute(
+          %{"agent_ids" => ["agent:session-123-abc:frontend-billing-fixes"], "timeout_ms" => 200},
+          ctx("p")
+        )
+
+      # It is a timeout, framed as healthy-not-failed with explicit no-re-wait guidance.
+      assert text =~ "TIMED OUT"
+      assert text =~ "do NOT wait on them again"
+      assert text =~ "automatically"
+      # Clean handle, never the raw agent:session-<ts>-<hash> gibberish.
+      assert text =~ "frontend-billing-fixes"
+      refute text =~ "### agent:session-123-abc:frontend-billing-fixes"
+    end
+
     test "an unknown agent id does not block the join and is reported clearly" do
       {:ok, text} = Handler.execute(%{"agent_ids" => ["agent:p:ghost"]}, ctx("p"))
       assert text =~ "No run found"


### PR DESCRIPTION
**The real bug you caught:** `task_wait`'s join barrier defaulted to **10 minutes**, but subagents routinely run 30+ min — so it 'timed out' on healthy agents (`frontend-billing-fixes` at 30m+), returned "still running (timed out waiting)" with no guidance, and the coordinator re-issued `task_wait` over and over. A wasteful poll loop that reads as broken — even though background completion is delivered automatically.

- Default timeout → **30 min** (matches the stream idle backstop).
- On timeout: says **TIMED OUT with N still-running, HEALTHY (not failed)** agents and explicitly tells the coordinator **not to re-wait** (results arrive automatically). Kills the re-poll loop.

**Visual leaks** (raw `agent:session-<ts>-<hash>:name` where a clean `@name` was already available):
- task_wait headings → clean trailing name
- scratchpad line → `short_agent_label` (was showing `@session-178…`, which cut the name and kept the useless session prefix)
- background summary → event's `display_name` (`@name`) not the raw id
- roster description → from the ORIGINAL task (no more `[shared scratchpad] You are part of a coordinated team…` bleed); roster name fallback compacted

Tests: new task_wait timeout-guidance + clean-name test; 70 Elixir + 1525 Rust green.