### PR TITLE
feat: /models — local model manager (CLI + TUI catalog), hardware fit, auto num_ctx

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -354,6 +354,23 @@ config :optimal_system_agent,
         else:
           Application.compile_env(:optimal_system_agent, :ollama_url, "http://localhost:11434")
       ),
+  # Context window ceiling for LOCAL models. `auto` (default) picks the largest
+  # window whose KV cache still fits in VRAM beside the weights — never below
+  # 32k, never above the model's trained window. A number pins it.
+  ollama_num_ctx:
+    (case System.get_env("OLLAMA_NUM_CTX") do
+       nil ->
+         :auto
+
+       "auto" ->
+         :auto
+
+       s ->
+         case Integer.parse(s) do
+           {n, _} when n >= 2048 -> n
+           _ -> :auto
+         end
+     end),
   ollama_model:
     System.get_env("OLLAMA_MODEL") ||
       Application.compile_env(:optimal_system_agent, :ollama_model, "glm-5.2:cloud"),

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -371,6 +371,15 @@ config :optimal_system_agent,
            _ -> :auto
          end
      end),
+  # The daemon's KV cache quantisation (OLLAMA_KV_CACHE_TYPE on the Ollama
+  # service: f16 | q8_0 | q4_0). OSA cannot read the daemon's env, so mirror
+  # the value here; it scales the KV-cache term of every fit / auto-window
+  # calculation (q8_0 halves it, q4_0 quarters it).
+  ollama_kv_cache_type:
+    (case System.get_env("OLLAMA_KV_CACHE_TYPE") do
+       nil -> "f16"
+       s -> String.downcase(String.trim(s))
+     end),
   ollama_model:
     System.get_env("OLLAMA_MODEL") ||
       Application.compile_env(:optimal_system_agent, :ollama_model, "glm-5.2:cloud"),

--- a/lib/optimal_system_agent/agent/context.ex
+++ b/lib/optimal_system_agent/agent/context.ex
@@ -424,15 +424,26 @@ defmodule OptimalSystemAgent.Agent.Context do
   #                    which have no native tool channel at all.
   @doc false
   @spec static_base_variant(atom(), boolean()) :: :lite | :native_tools | :full
-  def static_base_variant(_provider, true), do: :lite
+  # A small window gets the SMALLEST base the transport can carry. MEASURED
+  # with the lean template: :full 17,215 · :lite 13,201 · :native_tools 8,950.
+  # `:lite` used to win here unconditionally, which handed a 32k-window local
+  # model a prefix 4.2k tokens LARGER than the native-schema one — on the
+  # model that could least afford it — for no capability gain: on a native
+  # transport the tool descriptions ride in the request as schemas either
+  # way, and `tool_search` still reaches everything the 10-tool budget
+  # leaves out. `:lite` remains the answer for prompt-text transports, where
+  # the inlined core-tool prose is the only copy the model gets.
+  def static_base_variant(provider, true) do
+    if native_base?(provider), do: :native_tools, else: :lite
+  end
 
   def static_base_variant(provider, _lite?) do
-    if Soul.dedupe_native_tool_prompt?() and
-         OptimalSystemAgent.Providers.Registry.native_tool_schemas?(provider) do
-      :native_tools
-    else
-      :full
-    end
+    if native_base?(provider), do: :native_tools, else: :full
+  end
+
+  defp native_base?(provider) do
+    Soul.dedupe_native_tool_prompt?() and
+      OptimalSystemAgent.Providers.Registry.native_tool_schemas?(provider)
   end
 
   # ---------------------------------------------------------------------------

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -892,15 +892,12 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
         if m.params, do: IO.puts("  #{@dim}Parameters:#{@reset}   #{m.params}")
 
         if m.context_length do
-          used =
-            if m.installed,
-              do: " · OSA uses #{format_context_window(LocalModels.num_ctx_ceiling(m.tag))} here",
-              else: ""
-
           IO.puts(
-            "  #{@dim}Context:#{@reset}      #{format_context_window(m.context_length)} tokens trained#{used}"
+            "  #{@dim}Context:#{@reset}      #{format_context_window(m.context_length)} tokens trained"
           )
         end
+
+        if m.installed, do: models_osa_profile(m.tag)
 
         IO.puts(
           "  #{@dim}Capabilities:#{@reset} #{if m.capabilities == [], do: "?", else: Enum.join(m.capabilities, ", ")}"
@@ -952,6 +949,54 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
             "  #{@dim}(GPU not in the bandwidth table — speed estimates use a conservative default)#{@reset}"
           )
         end
+    end
+  end
+
+  # How OSA will actually drive this model: the window it allocates, which
+  # prompt variant that selects (and its size), where compaction fires, and
+  # how many tools ride in the request. This is the "does it work on a small
+  # window" answer, in numbers, before the first turn.
+  defp models_osa_profile(tag) do
+    alias OptimalSystemAgent.Agent.Context
+    alias OptimalSystemAgent.Agent.Loop.CompactionThresholds
+    alias OptimalSystemAgent.Soul
+
+    window = ProviderRegistry.effective_context_window(tag, :ollama)
+    small? = Context.small_window?(tag, :ollama)
+    variant = Context.static_base_variant(:ollama, small?)
+    static = Soul.static_token_count(variant)
+    compact = CompactionThresholds.compact_at(window)
+    tools = if small?, do: "10 core tools + tool_search", else: "all tools"
+
+    IO.puts("")
+    IO.puts("  #{@bold}OSA on this model#{@reset}")
+
+    IO.puts(
+      "  #{@dim}Window:#{@reset}       #{format_context_window(window)} tokens (auto — largest that fits VRAM)"
+    )
+
+    IO.puts(
+      "  #{@dim}Prompt:#{@reset}       #{variant} variant, #{format_context_window(static)} tokens#{operator_prompt_note(tag)}"
+    )
+
+    IO.puts(
+      "  #{@dim}Compaction:#{@reset}   at #{format_context_window(compact)} tokens (#{div(compact * 100, max(window, 1))}%)"
+    )
+
+    IO.puts("  #{@dim}Tools:#{@reset}        #{tools}")
+
+    IO.puts(
+      "  #{@dim}Free for chat:#{@reset} ~#{format_context_window(max(compact - static, 0))} tokens before the first compaction"
+    )
+  end
+
+  defp operator_prompt_note(tag) do
+    case PromptOverrides.effective(tag) do
+      {_, %{mode: mode, text: text}} ->
+        " + your #{mode} prompt (~#{format_context_window(OptimalSystemAgent.Agent.Context.estimate_tokens(text))})"
+
+      nil ->
+        ""
     end
   end
 

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -891,11 +891,16 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
         if m.family, do: IO.puts("  #{@dim}Family:#{@reset}       #{m.family}")
         if m.params, do: IO.puts("  #{@dim}Parameters:#{@reset}   #{m.params}")
 
-        if m.context_length,
-          do:
-            IO.puts(
-              "  #{@dim}Context:#{@reset}      #{format_context_window(m.context_length)} tokens"
-            )
+        if m.context_length do
+          used =
+            if m.installed,
+              do: " · OSA uses #{format_context_window(LocalModels.num_ctx_ceiling(m.tag))} here",
+              else: ""
+
+          IO.puts(
+            "  #{@dim}Context:#{@reset}      #{format_context_window(m.context_length)} tokens trained#{used}"
+          )
+        end
 
         IO.puts(
           "  #{@dim}Capabilities:#{@reset} #{if m.capabilities == [], do: "?", else: Enum.join(m.capabilities, ", ")}"
@@ -1139,9 +1144,13 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
       "  #{@dim}Bandwidth:#{@reset}  #{hw.bandwidth_gbps} GB/s#{if hw.bandwidth_known, do: "", else: " (default — GPU not in table)"}"
     )
 
-    IO.puts(
-      "  #{@dim}Fit context:#{@reset} #{format_context_window(LocalModels.context_for_fit())} tokens (OLLAMA_NUM_CTX)"
-    )
+    ctx_mode =
+      case Application.get_env(:optimal_system_agent, :ollama_num_ctx) do
+        n when is_integer(n) -> "pinned to #{format_context_window(n)} (OLLAMA_NUM_CTX)"
+        _ -> "auto — largest window that fits VRAM per model (OLLAMA_NUM_CTX=<n> to pin)"
+      end
+
+    IO.puts("  #{@dim}Context:#{@reset}    #{ctx_mode}")
   end
 
   defp models_search(q) do

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -11,6 +11,8 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
 
   alias OptimalSystemAgent.Agent.{Compactor, ContextDiscovery, Loop, SessionPersistence, Tasks}
   alias OptimalSystemAgent.Agent.PromptOverrides
+  alias OptimalSystemAgent.LocalModels
+  alias OptimalSystemAgent.LocalModels.{Fit, Hardware}
   alias OptimalSystemAgent.Budget
   alias OptimalSystemAgent.Channels.CLI.{MessageQueue, Renderer, Session, TaskDisplay}
   alias OptimalSystemAgent.ContextRefs.Parser, as: ContextRefsParser
@@ -38,6 +40,8 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     "model" => {"Show or switch the current model (list = local Ollama models)", :cmd_model},
     "system" =>
       {"Inject into or replace the system prompt for the current model (persists)", :cmd_system},
+    "models" =>
+      {"Local models: what fits this machine, install, remove, load, unload, bench", :cmd_models},
     "uncensored" =>
       {"Hop the current model to its unfiltered twin (off to return)", :cmd_uncensored},
     "status" => {"Show session status", :cmd_status},
@@ -704,6 +708,496 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     IO.puts(
       "  #{@dim}Add --all after the verb to target every model. Use \\n for newlines inline. Saved in #{PromptOverrides.path()}#{@reset}"
     )
+  end
+
+  # ── /models — local model manager ─────────────────────────────────────────
+  #
+  #   /models                    installed + catalog, each with a fit verdict
+  #   /models info <model>       capabilities, size per quant, fit, est./measured tok/s
+  #   /models install <model>    pull (catalog id, hf.co/… tag, or any Ollama tag), then benchmark
+  #   /models install <model> <quant>
+  #   /models use <model>        switch this session AND make it the default
+  #   /models remove <model>
+  #   /models load | unload <model>
+  #   /models bench <model>      measure tok/s
+  #   /models alias <model> <short-name>
+  #   /models hardware           what was detected
+  #   /models search <words>     Hugging Face GGUF search
+  def cmd_models(args, session_id) do
+    IO.puts("")
+
+    {verb, rest} =
+      case String.split(String.trim(args), ~r/\s+/, parts: 2) do
+        [""] -> {"", ""}
+        [v] -> {String.downcase(v), ""}
+        [v, r] -> {String.downcase(v), String.trim(r)}
+      end
+
+    case {verb, rest} do
+      {"", _} ->
+        models_overview(session_id)
+
+      {v, _} when v in ["list", "ls"] ->
+        models_overview(session_id)
+
+      {v, ""}
+      when v in [
+             "info",
+             "show",
+             "install",
+             "pull",
+             "use",
+             "remove",
+             "rm",
+             "delete",
+             "load",
+             "unload",
+             "bench",
+             "alias",
+             "search"
+           ] ->
+        models_usage()
+
+      {v, ref} when v in ["info", "show"] ->
+        models_info(ref)
+
+      {v, ref} when v in ["install", "pull", "get"] ->
+        models_install(ref, session_id)
+
+      {"use", ref} ->
+        models_use(ref, session_id)
+
+      {v, ref} when v in ["remove", "rm", "delete"] ->
+        models_remove(ref)
+
+      {"load", ref} ->
+        models_simple(LocalModels.load(ref), "Loaded #{ref} into VRAM (kept resident)")
+
+      {"unload", ref} ->
+        models_simple(LocalModels.unload(ref), "Unloaded #{ref} from VRAM")
+
+      {"bench", ref} ->
+        models_bench(ref)
+
+      {"alias", ref} ->
+        models_alias(ref)
+
+      {v, _} when v in ["hardware", "hw", "specs"] ->
+        models_hardware()
+
+      {"search", q} ->
+        models_search(q)
+
+      _ ->
+        models_usage()
+    end
+
+    IO.puts("")
+    session_id
+  rescue
+    e ->
+      IO.puts("  #{@yellow}error: /models failed: #{Exception.message(e)}#{@reset}\n")
+      session_id
+  end
+
+  defp models_overview(session_id) do
+    ov = LocalModels.overview()
+    {_prov, current} = session_provider_model(session_id)
+
+    IO.puts(
+      "  #{@bold}This machine#{@reset}  #{@dim}#{Hardware.summary(ov.hardware)} · fit at #{format_context_window(ov.ctx)} ctx#{@reset}"
+    )
+
+    if ov.error do
+      IO.puts("  #{@yellow}Ollama: #{ov.error}#{@reset}")
+    end
+
+    IO.puts("")
+    IO.puts("  #{@bold}Installed#{@reset}")
+
+    if ov.installed == [] do
+      IO.puts("  #{@dim}nothing local yet — pick one below with /models install <id>#{@reset}")
+    else
+      Enum.each(ov.installed, fn r ->
+        mark =
+          cond do
+            r.tag == current -> "#{@green}●#{@reset}"
+            r.loaded -> "#{@cyan}●#{@reset}"
+            true -> "#{@dim}○#{@reset}"
+          end
+
+        IO.puts("  #{mark} #{@bold}#{r.tag}#{@reset}")
+        IO.puts("      #{@dim}#{models_line(r)}#{@reset}")
+      end)
+
+      IO.puts(
+        "  #{@dim}● current   #{@cyan}●#{@reset}#{@dim} loaded in VRAM   ○ on disk#{@reset}"
+      )
+    end
+
+    IO.puts("")
+
+    IO.puts(
+      "  #{@bold}Available#{@reset}  #{@dim}(curated abliterated / uncensored GGUFs — /models install <id>)#{@reset}"
+    )
+
+    Enum.each(ov.catalog, fn r ->
+      IO.puts("  #{fit_badge(r.fit)} #{@bold}#{r.entry.id}#{@reset}  #{@dim}#{r.name}#{@reset}")
+      IO.puts("      #{@dim}#{models_line(r)}#{@reset}")
+    end)
+
+    IO.puts("")
+
+    IO.puts(
+      "  #{@dim}/models info <id> for detail · /models install <id> · /models use <id> · /models hardware#{@reset}"
+    )
+  end
+
+  defp models_line(r) do
+    size = if r.size_bytes > 0, do: gb(r.size_bytes), else: "?"
+    exact = if r.fit && !r.fit.weights_exact && !r.installed, do: "~", else: ""
+    caps = if r.capabilities == [], do: "", else: " · " <> Enum.join(r.capabilities, ", ")
+
+    speed =
+      cond do
+        r.measured_tps -> " · #{r.measured_tps} tok/s measured"
+        r.fit && r.fit.est_tps -> " · ~#{round(r.fit.est_tps)} tok/s est."
+        true -> ""
+      end
+
+    "#{exact}#{size} #{r.quant || ""} · #{r.params || "?"} · #{r.fit && Fit.label(r.fit.verdict)}#{speed}#{caps}"
+  end
+
+  defp fit_badge(nil), do: "#{@dim}?#{@reset}"
+  defp fit_badge(%{verdict: :fits}), do: "#{@green}✓#{@reset}"
+  defp fit_badge(%{verdict: :partial}), do: "#{@yellow}⚠#{@reset}"
+  defp fit_badge(%{verdict: :cpu}), do: "#{@yellow}⚠#{@reset}"
+  defp fit_badge(%{verdict: :no}), do: "#{@red}✗#{@reset}"
+
+  defp gb(bytes), do: "#{Float.round(bytes / 1.0e9, 1)} GB"
+
+  defp models_info(ref) do
+    IO.puts("  #{@dim}Looking up #{ref}…#{@reset}")
+
+    case LocalModels.inspect_model(ref) do
+      {:error, e} ->
+        IO.puts("  #{@yellow}#{e}#{@reset}")
+
+      {:ok, m} ->
+        hw = Hardware.detect()
+        IO.puts("  #{@bold}#{m.name}#{@reset}")
+        IO.puts("  #{@dim}Tag:#{@reset}          #{m.tag}")
+        IO.puts("  #{@dim}Installed:#{@reset}    #{if m.installed, do: "yes", else: "no"}")
+        if m.family, do: IO.puts("  #{@dim}Family:#{@reset}       #{m.family}")
+        if m.params, do: IO.puts("  #{@dim}Parameters:#{@reset}   #{m.params}")
+
+        if m.context_length,
+          do:
+            IO.puts(
+              "  #{@dim}Context:#{@reset}      #{format_context_window(m.context_length)} tokens"
+            )
+
+        IO.puts(
+          "  #{@dim}Capabilities:#{@reset} #{if m.capabilities == [], do: "?", else: Enum.join(m.capabilities, ", ")}"
+        )
+
+        if m.entry && m.entry.blurb != "", do: IO.puts("  #{@dim}#{m.entry.blurb}#{@reset}")
+        IO.puts("")
+        IO.puts("  #{@bold}On this machine#{@reset}  #{@dim}#{Hardware.summary(hw)}#{@reset}")
+
+        if m.quants != [] do
+          Enum.each(trim_quants(m.quants), fn q ->
+            chosen = if q.quant == String.upcase(m.quant || ""), do: "#{@bold}", else: ""
+            est = if q.fit.est_tps, do: "~#{round(q.fit.est_tps)} tok/s", else: "—"
+            approx = if q.exact, do: "", else: "~"
+
+            IO.puts(
+              "  #{fit_badge(q.fit)} #{chosen}#{String.pad_trailing(q.quant, 8)}#{@reset} #{approx}#{String.pad_leading(gb(q.bytes), 9)}  #{String.pad_trailing(Fit.label(q.fit.verdict), 22)} #{est}"
+            )
+          end)
+
+          IO.puts(
+            "  #{@dim}bold = recommended · /models install #{(m.entry && m.entry.id) || m.tag} <quant> to pick another#{@reset}"
+          )
+        else
+          f = m.fit
+
+          IO.puts(
+            "  #{fit_badge(f)} #{Fit.label(f.verdict)} — weights #{gb(f.weights_bytes)} + KV #{gb(f.kv_bytes)} @ #{format_context_window(f.ctx)} ctx"
+          )
+
+          cond do
+            m.measured ->
+              IO.puts(
+                "  #{@dim}Speed:#{@reset}        #{m.measured["decode_tps"]} tok/s measured#{if m.measured["prompt_tps"], do: " (prompt #{m.measured["prompt_tps"]} tok/s)"}"
+              )
+
+            f.est_tps ->
+              IO.puts(
+                "  #{@dim}Speed:#{@reset}        ~#{round(f.est_tps)} tok/s estimated · /models bench #{m.tag} to measure"
+              )
+
+            true ->
+              :ok
+          end
+        end
+
+        if !hw.bandwidth_known and hw.gpu do
+          IO.puts(
+            "  #{@dim}(GPU not in the bandwidth table — speed estimates use a conservative default)#{@reset}"
+          )
+        end
+    end
+  end
+
+  # A repo like bartowski's 70B ships 29 quants. Show the ones worth choosing
+  # between: everything that runs, capped at 10 from the largest down, plus
+  # the smallest one that does not — so the cliff is visible.
+  defp trim_quants(quants) when length(quants) <= 10, do: quants
+
+  defp trim_quants(quants) do
+    {runs, no} = Enum.split_with(quants, &(&1.fit.verdict != :no))
+    kept = runs |> Enum.sort_by(& &1.bytes, :desc) |> Enum.take(10) |> Enum.sort_by(& &1.bytes)
+    kept ++ Enum.take(no, 1)
+  end
+
+  defp models_install(ref, session_id) do
+    {ref, quant} =
+      case String.split(ref, ~r/\s+/, parts: 2) do
+        [r, q] -> {r, q}
+        [r] -> {r, nil}
+      end
+
+    IO.puts("  #{@dim}Checking #{ref}…#{@reset}")
+
+    with {:ok, m} <- LocalModels.inspect_model(ref),
+         :ok <- models_confirm_fit(m, quant) do
+      tag =
+        if quant && m.entry,
+          do: OptimalSystemAgent.LocalModels.Catalog.tag(m.entry, quant),
+          else: m.tag
+
+      IO.puts("  #{@dim}Pulling #{tag} (#{gb(m.size_bytes)})…#{@reset}")
+
+      progress = fn %{status: status, completed: c, total: t} ->
+        if t > 0 do
+          pct = div(c * 100, t)
+
+          IO.write(
+            "\r  #{@dim}#{String.slice(status, 0, 30)}#{@reset} #{String.pad_leading("#{pct}%", 4)}  #{gb(c)} / #{gb(t)}      "
+          )
+        else
+          IO.write("\r  #{@dim}#{status}#{@reset}                                        ")
+        end
+      end
+
+      case LocalModels.install(tag, on_progress: progress, quant: quant) do
+        {:ok, %{tag: tag, bench: bench}} ->
+          IO.write("\r")
+          IO.puts("  #{@green}✓#{@reset} Installed #{@bold}#{tag}#{@reset}")
+
+          if bench do
+            IO.puts(
+              "  #{@dim}Measured:#{@reset} #{bench.decode_tps} tok/s decode#{if bench.prompt_tps, do: ", #{bench.prompt_tps} tok/s prompt"}"
+            )
+          end
+
+          IO.puts("  #{@dim}/models use #{tag} to switch to it#{@reset}")
+
+        {:error, e} ->
+          IO.write("\r")
+          IO.puts("  #{@yellow}Pull failed: #{e}#{@reset}")
+      end
+    else
+      {:error, e} -> IO.puts("  #{@yellow}#{e}#{@reset}")
+      :abort -> :ok
+    end
+
+    _ = session_id
+  end
+
+  # Refuse a pull that cannot run; warn (but continue) on partial offload.
+  defp models_confirm_fit(%{fit: nil}, _quant), do: :ok
+
+  defp models_confirm_fit(%{fit: fit, quants: quants} = m, quant) do
+    fit =
+      case quant && Enum.find(quants, &(&1.quant == String.upcase(quant))) do
+        %{fit: f} -> f
+        _ -> fit
+      end
+
+    case fit.verdict do
+      :no ->
+        IO.puts(
+          "  #{@red}✗ #{m.name} won't fit: needs #{gb(fit.total_bytes)} (weights #{gb(fit.weights_bytes)} + KV), this machine has #{gb(fit.budget_bytes)} usable.#{@reset}"
+        )
+
+        IO.puts(
+          "  #{@dim}Try a smaller quant (/models info #{(m.entry && m.entry.id) || m.tag}) or a smaller model.#{@reset}"
+        )
+
+        :abort
+
+      :partial ->
+        IO.puts(
+          "  #{@yellow}⚠ Partial offload: only #{round(fit.gpu_share * 100)}% of the weights fit in VRAM; expect ~#{round(fit.est_tps || 0)} tok/s. Pulling anyway.#{@reset}"
+        )
+
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp models_use(ref, session_id) do
+    case LocalModels.resolve(ref) do
+      {:installed, tag} ->
+        case swap_to(:ollama, tag, session_id) do
+          :ok ->
+            case LocalModels.set_default(tag) do
+              :ok ->
+                IO.puts("  #{@dim}Saved as default for new sessions.#{@reset}")
+
+              {:error, e} ->
+                IO.puts("  #{@yellow}Switched, but could not save default: #{e}#{@reset}")
+            end
+
+          _ ->
+            :ok
+        end
+
+      {:catalog, entry, _} ->
+        IO.puts(
+          "  #{@yellow}#{entry.name} is not installed. /models install #{entry.id}#{@reset}"
+        )
+
+      _ ->
+        IO.puts("  #{@yellow}#{ref} is not installed. /models to see what is.#{@reset}")
+    end
+  end
+
+  defp models_remove(ref) do
+    case LocalModels.resolve(ref) do
+      {:installed, tag} -> models_simple(LocalModels.remove(tag), "Removed #{tag}")
+      _ -> IO.puts("  #{@yellow}#{ref} is not installed.#{@reset}")
+    end
+  end
+
+  defp models_bench(ref) do
+    case LocalModels.resolve(ref) do
+      {:installed, tag} ->
+        IO.puts("  #{@dim}Benchmarking #{tag} (64 tokens)…#{@reset}")
+
+        case LocalModels.bench(tag) do
+          {:ok, b} ->
+            IO.puts(
+              "  #{@green}✓#{@reset} #{@bold}#{b.decode_tps} tok/s#{@reset} decode#{if b.prompt_tps, do: " · #{b.prompt_tps} tok/s prompt"} · load #{b.load_ms} ms"
+            )
+
+          {:error, e} ->
+            IO.puts("  #{@yellow}#{e}#{@reset}")
+        end
+
+      _ ->
+        IO.puts("  #{@yellow}#{ref} is not installed.#{@reset}")
+    end
+  end
+
+  defp models_alias(rest) do
+    case String.split(rest, ~r/\s+/, parts: 2) do
+      [from, to] ->
+        case LocalModels.resolve(from) do
+          {:installed, tag} ->
+            models_simple(
+              LocalModels.alias_tag(tag, to),
+              "#{to} → #{tag} (same weights, no extra disk)"
+            )
+
+          _ ->
+            IO.puts("  #{@yellow}#{from} is not installed.#{@reset}")
+        end
+
+      _ ->
+        IO.puts("  #{@yellow}usage: /models alias <model> <short-name>#{@reset}")
+    end
+  end
+
+  defp models_hardware do
+    hw = Hardware.refresh()
+    IO.puts("  #{@bold}Hardware#{@reset}")
+
+    IO.puts(
+      "  #{@dim}GPU:#{@reset}        #{hw.gpu || "none"}#{if hw.gpu, do: " (#{hw.backend})"}"
+    )
+
+    IO.puts("  #{@dim}VRAM:#{@reset}       #{gb(hw.vram_bytes)}")
+    IO.puts("  #{@dim}RAM:#{@reset}        #{gb(hw.ram_bytes)}")
+    IO.puts("  #{@dim}CPU:#{@reset}        #{hw.cpu || "?"} · #{hw.cores} threads")
+
+    IO.puts(
+      "  #{@dim}Bandwidth:#{@reset}  #{hw.bandwidth_gbps} GB/s#{if hw.bandwidth_known, do: "", else: " (default — GPU not in table)"}"
+    )
+
+    IO.puts(
+      "  #{@dim}Fit context:#{@reset} #{format_context_window(LocalModels.context_for_fit())} tokens (OLLAMA_NUM_CTX)"
+    )
+  end
+
+  defp models_search(q) do
+    IO.puts("  #{@dim}Searching Hugging Face for “#{q}” GGUFs…#{@reset}")
+
+    case OptimalSystemAgent.LocalModels.HuggingFace.search(q, limit: 15) do
+      {:ok, []} ->
+        IO.puts("  #{@dim}nothing found#{@reset}")
+
+      {:ok, list} ->
+        Enum.each(list, fn r ->
+          IO.puts("  #{@dim}•#{@reset} #{r.id} #{@dim}(#{r.downloads} downloads)#{@reset}")
+        end)
+
+        IO.puts(
+          "  #{@dim}/models info hf.co/<repo> to size one · /models install hf.co/<repo>:<quant>#{@reset}"
+        )
+
+      {:error, e} ->
+        IO.puts("  #{@yellow}#{e}#{@reset}")
+    end
+  end
+
+  defp models_simple(:ok, msg), do: IO.puts("  #{@green}✓#{@reset} #{msg}")
+  defp models_simple({:error, e}, _), do: IO.puts("  #{@yellow}#{e}#{@reset}")
+
+  defp models_usage do
+    IO.puts("  #{@bold}/models#{@reset} — local models on this machine")
+    IO.puts("")
+
+    IO.puts(
+      "  #{@cyan}/models#{@reset}                      installed + curated catalog, with fit for this hardware"
+    )
+
+    IO.puts(
+      "  #{@cyan}/models info#{@reset} <model>         capabilities, size per quant, est./measured tok/s"
+    )
+
+    IO.puts(
+      "  #{@cyan}/models install#{@reset} <model> [q]  pull it (catalog id, hf.co/repo:quant, or Ollama tag), then benchmark"
+    )
+
+    IO.puts(
+      "  #{@cyan}/models use#{@reset} <model>          switch this session and make it the default"
+    )
+
+    IO.puts("  #{@cyan}/models remove#{@reset} <model>       delete from disk")
+
+    IO.puts(
+      "  #{@cyan}/models load#{@reset} | #{@cyan}unload#{@reset} <model> keep in VRAM / evict now"
+    )
+
+    IO.puts("  #{@cyan}/models bench#{@reset} <model>        measure tok/s")
+    IO.puts("  #{@cyan}/models alias#{@reset} <model> <name> short tag for a long hf.co/… name")
+    IO.puts("  #{@cyan}/models search#{@reset} <words>       find GGUFs on Hugging Face")
+    IO.puts("  #{@cyan}/models hardware#{@reset}             what was detected")
   end
 
   defp uncensored_list do

--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -785,6 +785,9 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
       {v, _} when v in ["hardware", "hw", "specs"] ->
         models_hardware()
 
+      {v, arg} when v in ["ctx", "context", "window"] ->
+        models_ctx(arg, session_id)
+
       {"search", q} ->
         models_search(q)
 
@@ -1198,6 +1201,127 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     IO.puts("  #{@dim}Context:#{@reset}    #{ctx_mode}")
   end
 
+  # /models ctx            show the window for the current model and why
+  # /models ctx auto       largest window whose KV cache fits VRAM (default)
+  # /models ctx max        the model's full trained window, fit or not
+  # /models ctx <n>        pin a number (e.g. 131072 or 128k)
+  # Persists as OLLAMA_NUM_CTX in ~/.osa/.env and applies to the next turn.
+  defp models_ctx(arg, session_id) do
+    {_provider, model} = session_provider_model(session_id)
+    trained = trained_window(model)
+
+    choice =
+      case String.downcase(String.trim(arg)) do
+        "" ->
+          :show
+
+        "auto" ->
+          :auto
+
+        "max" when is_integer(trained) ->
+          trained
+
+        "max" ->
+          {:error, "trained window unknown for #{model} — pin a number instead"}
+
+        s ->
+          case Integer.parse(String.replace(s, ~r/[_,]/, "")) do
+            {n, ""} when n >= 2048 -> n
+            {n, "k"} when n >= 2 -> n * 1024
+            _ -> {:error, "usage: /models ctx auto | max | <tokens>"}
+          end
+      end
+
+    case choice do
+      {:error, msg} ->
+        IO.puts("  #{@yellow}#{msg}#{@reset}")
+
+      :show ->
+        models_ctx_report(model, trained)
+
+      value ->
+        env_value = if value == :auto, do: "auto", else: Integer.to_string(value)
+        Application.put_env(:optimal_system_agent, :ollama_num_ctx, value)
+        LocalModels.forget_auto_num_ctx(model)
+
+        try do
+          OptimalSystemAgent.CLI.Setup.save_env("OLLAMA_NUM_CTX", env_value)
+        rescue
+          _ -> :ok
+        end
+
+        IO.puts(
+          "  #{@green}✓#{@reset} Context window: #{env_value} #{@dim}(saved as OLLAMA_NUM_CTX; applies from the next message)#{@reset}"
+        )
+
+        models_ctx_report(model, trained)
+    end
+  end
+
+  defp models_ctx_report(model, trained) do
+    window = ProviderRegistry.effective_context_window(model, :ollama)
+    mode = Application.get_env(:optimal_system_agent, :ollama_num_ctx)
+    kv_type = Application.get_env(:optimal_system_agent, :ollama_kv_cache_type, "f16")
+
+    IO.puts("")
+    IO.puts("  #{@bold}Context window · #{model}#{@reset}")
+
+    IO.puts(
+      "  #{@dim}In use:#{@reset}     #{format_context_window(window)} tokens (#{if is_integer(mode), do: "pinned", else: "auto"})"
+    )
+
+    if trained,
+      do: IO.puts("  #{@dim}Trained:#{@reset}    #{format_context_window(trained)} tokens")
+
+    IO.puts("  #{@dim}KV cache:#{@reset}   #{kv_type} on the daemon (OLLAMA_KV_CACHE_TYPE)")
+
+    case LocalModels.inspect_model(model) do
+      {:ok, %{installed: true, fit: %{} = f}} ->
+        per_token = div(round(f.kv_bytes / Fit.kv_cache_scale()), max(f.ctx, 1))
+        spec = %{weights_bytes: f.weights_bytes, kv_bytes_per_token: per_token}
+        hw = Hardware.detect()
+        at = Fit.assess(spec, hw, window)
+
+        IO.puts(
+          "  #{@dim}Fit:#{@reset}        #{fit_badge(at)} #{Fit.label(at.verdict)} — weights #{gb(at.weights_bytes)} + KV #{gb(at.kv_bytes)} of #{gb(at.budget_bytes)} usable"
+        )
+
+        if at.verdict in [:partial, :no] do
+          IO.puts(
+            "  #{@yellow}⚠ At this window the KV cache does not fit VRAM: expect ~#{round(at.est_tps || 0)} tok/s (spills to RAM).#{@reset}"
+          )
+
+          IO.puts(
+            "  #{@dim}Fix: quantise the daemon's KV cache — OLLAMA_FLASH_ATTENTION=1 OLLAMA_KV_CACHE_TYPE=q8_0 (½) or q4_0 (¼) on the Ollama service,#{@reset}"
+          )
+
+          IO.puts(
+            "  #{@dim}then set the same OLLAMA_KV_CACHE_TYPE in ~/.osa/.env so OSA sizes it right.#{@reset}"
+          )
+        end
+
+        if is_integer(trained) and window < trained do
+          f16 = per_token * trained
+
+          IO.puts(
+            "  #{@dim}Full #{format_context_window(trained)} needs KV #{gb(f16)} at f16 · #{gb(div(f16, 2))} at q8_0 · #{gb(div(f16, 4))} at q4_0.#{@reset}"
+          )
+        end
+
+      _ ->
+        :ok
+    end
+
+    IO.puts("  #{@dim}/models ctx auto · max · <tokens>#{@reset}")
+  end
+
+  defp trained_window(model) do
+    case OptimalSystemAgent.LocalModels.OllamaAdmin.show(model) do
+      {:ok, %{context_length: n}} when is_integer(n) and n > 0 -> n
+      _ -> nil
+    end
+  end
+
   defp models_search(q) do
     IO.puts("  #{@dim}Searching Hugging Face for “#{q}” GGUFs…#{@reset}")
 
@@ -1252,6 +1376,10 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     IO.puts("  #{@cyan}/models alias#{@reset} <model> <name> short tag for a long hf.co/… name")
     IO.puts("  #{@cyan}/models search#{@reset} <words>       find GGUFs on Hugging Face")
     IO.puts("  #{@cyan}/models hardware#{@reset}             what was detected")
+
+    IO.puts(
+      "  #{@cyan}/models ctx#{@reset} auto|max|<n>      context window for the current model (persists)"
+    )
   end
 
   defp uncensored_list do

--- a/lib/optimal_system_agent/channels/http.ex
+++ b/lib/optimal_system_agent/channels/http.ex
@@ -272,6 +272,76 @@ defmodule OptimalSystemAgent.Channels.HTTP do
     |> send_resp(200, body)
   end
 
+  # ── Local model manager (the TUI's catalog screen; CLI twin is /models) ──
+  #
+  # Same gate as the onboarding routes: a bearer once setup is complete, open
+  # before it so the first-run picker can install a model. Every handler
+  # delegates to `LocalModels`, which never raises on a daemon that is down.
+
+  get "/models/local" do
+    local_models_reply(conn, fn ->
+      ov = OptimalSystemAgent.LocalModels.overview()
+
+      {:ok,
+       %{
+         hardware:
+           Map.put(
+             ov.hardware,
+             :summary,
+             OptimalSystemAgent.LocalModels.Hardware.summary(ov.hardware)
+           ),
+         ctx: ov.ctx,
+         installed: OptimalSystemAgent.LocalModels.to_json(ov.installed),
+         catalog: OptimalSystemAgent.LocalModels.to_json(ov.catalog),
+         error: ov.error
+       }}
+    end)
+  end
+
+  get "/models/local/info" do
+    conn = Plug.Conn.fetch_query_params(conn)
+    ref = conn.query_params["ref"] || ""
+
+    local_models_reply(conn, fn ->
+      with {:ok, m} <- OptimalSystemAgent.LocalModels.inspect_model(ref) do
+        {:ok, OptimalSystemAgent.LocalModels.to_json(m)}
+      end
+    end)
+  end
+
+  post "/models/local/install" do
+    with_json_body(conn, fn params ->
+      local_models_reply(conn, fn ->
+        with ref when is_binary(ref) and ref != "" <-
+               params["ref"] || {:error, "ref is required"},
+             {:ok, id} <- OptimalSystemAgent.LocalModels.Installer.start(ref, params["quant"]) do
+          {:ok, %{job_id: id}}
+        end
+      end)
+    end)
+  end
+
+  get "/models/local/install/:id" do
+    local_models_reply(conn, fn ->
+      case OptimalSystemAgent.LocalModels.Installer.status(id) do
+        nil -> {:error, "no such job"}
+        job -> {:ok, OptimalSystemAgent.LocalModels.to_json(job)}
+      end
+    end)
+  end
+
+  post "/models/local/remove" do
+    with_json_body(conn, fn params ->
+      local_models_reply(conn, fn ->
+        with tag when is_binary(tag) and tag != "" <-
+               params["tag"] || {:error, "tag is required"},
+             :ok <- OptimalSystemAgent.LocalModels.remove(tag) do
+          {:ok, %{removed: tag}}
+        end
+      end)
+    end)
+  end
+
   get "/onboarding/models" do
     conn = Plug.Conn.fetch_query_params(conn)
     provider = conn.query_params["provider"] || "ollama_local"
@@ -611,6 +681,53 @@ defmodule OptimalSystemAgent.Channels.HTTP do
       end
     else
       :ok
+    end
+  end
+
+  # Shared tail of the /models/local routes: gate, run, encode.
+  defp local_models_reply(conn, fun) do
+    case verify_bearer_when_required(conn) do
+      :unauthorized ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(401, Jason.encode!(%{error: "unauthorized"}))
+
+      :ok ->
+        {status, body} =
+          try do
+            case fun.() do
+              {:ok, data} -> {200, data}
+              {:error, reason} -> {400, %{error: to_string(reason)}}
+            end
+          rescue
+            e -> {500, %{error: Exception.message(e)}}
+          catch
+            :exit, reason -> {500, %{error: inspect(reason)}}
+          end
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(status, Jason.encode!(body))
+    end
+  end
+
+  defp with_json_body(conn, fun) do
+    case Plug.Conn.read_body(conn) do
+      {:ok, raw, conn} ->
+        case Jason.decode(raw) do
+          {:ok, %{} = params} ->
+            fun.(params)
+
+          _ ->
+            conn
+            |> put_resp_content_type("application/json")
+            |> send_resp(400, Jason.encode!(%{error: "invalid JSON body"}))
+        end
+
+      _ ->
+        conn
+        |> put_resp_content_type("application/json")
+        |> send_resp(400, Jason.encode!(%{error: "could not read body"}))
     end
   end
 

--- a/lib/optimal_system_agent/local_models.ex
+++ b/lib/optimal_system_agent/local_models.ex
@@ -142,6 +142,31 @@ defmodule OptimalSystemAgent.LocalModels do
     %{hardware: hw, ctx: ctx, installed: installed_rows, catalog: catalog_rows, error: error}
   end
 
+  @doc "One-line summary of a row for pickers: fit · speed · capabilities."
+  @spec note(row()) :: String.t()
+  def note(row) do
+    fit =
+      case row.fit && row.fit.verdict do
+        :fits -> "✓ fits in VRAM"
+        :partial -> "⚠ partial offload"
+        :cpu -> "⚠ CPU only"
+        :no -> "✗ won't fit"
+        _ -> nil
+      end
+
+    speed =
+      cond do
+        row.measured_tps -> "#{row.measured_tps} tok/s measured"
+        row.fit && row.fit.est_tps -> "~#{round(row.fit.est_tps)} tok/s est."
+        true -> nil
+      end
+
+    caps = if row.capabilities == [], do: nil, else: Enum.join(row.capabilities, ", ")
+    size = if row.size_bytes > 0, do: "#{Float.round(row.size_bytes / 1.0e9, 1)} GB"
+
+    [fit, speed, size, caps] |> Enum.reject(&is_nil/1) |> Enum.join(" · ")
+  end
+
   # ── inspect one ─────────────────────────────────────────────────────────
 
   @doc """

--- a/lib/optimal_system_agent/local_models.ex
+++ b/lib/optimal_system_agent/local_models.ex
@@ -462,6 +462,10 @@ defmodule OptimalSystemAgent.LocalModels do
       MapSet.member?(installed, ref <> ":latest") ->
         {:installed, ref <> ":latest"}
 
+      String.ends_with?(ref, ":latest") and
+          MapSet.member?(installed, String.trim_trailing(ref, ":latest")) ->
+        {:installed, ref}
+
       entry = Catalog.find(ref) ->
         {_, quant} = Catalog.split_tag(ref)
         quant = if Catalog.hf_tag?(ref) or String.contains?(ref, "/"), do: quant, else: nil
@@ -500,10 +504,18 @@ defmodule OptimalSystemAgent.LocalModels do
     end
   end
 
+  # `superqwen-abliterated` and `superqwen-abliterated:latest` are the same
+  # tag to Ollama; config.json usually carries the short form.
   defp installed_size(tag) do
     case OllamaAdmin.installed() do
-      {:ok, list} -> Enum.find_value(list, 0, &(&1.name == tag && &1.size_bytes))
-      _ -> 0
+      {:ok, list} ->
+        Enum.find_value(list, 0, fn m ->
+          (m.name == tag or m.name == tag <> ":latest" or m.name <> ":latest" == tag) and
+            m.size_bytes
+        end)
+
+      _ ->
+        0
     end
   end
 

--- a/lib/optimal_system_agent/local_models.ex
+++ b/lib/optimal_system_agent/local_models.ex
@@ -15,6 +15,9 @@ defmodule OptimalSystemAgent.LocalModels do
   alias OptimalSystemAgent.LocalModels.{Catalog, Fit, Hardware, HuggingFace, OllamaAdmin}
   alias OptimalSystemAgent.System.{AtomicFile, JsonStore}
 
+  @floor_ctx 32_768
+  @ctx_buckets [32_768, 49_152, 65_536, 98_304, 131_072, 196_608, 262_144]
+
   @type row :: %{
           tag: String.t(),
           name: String.t(),
@@ -166,6 +169,38 @@ defmodule OptimalSystemAgent.LocalModels do
 
     [fit, speed, size, caps] |> Enum.reject(&is_nil/1) |> Enum.join(" · ")
   end
+
+  @doc "JSON-safe shape of a row / inspect result / fit for the HTTP API."
+  @spec to_json(term()) :: term()
+  def to_json(%{} = map) do
+    map
+    |> Map.drop([:entry, :model_info])
+    |> Map.new(fn
+      {:fit, fit} -> {:fit, to_json(fit)}
+      {:quants, qs} when is_list(qs) -> {:quants, Enum.map(qs, &to_json/1)}
+      {:hardware, hw} -> {:hardware, hw}
+      {k, v} when is_atom(v) and not is_boolean(v) and not is_nil(v) -> {k, Atom.to_string(v)}
+      {k, v} -> {k, v}
+    end)
+    |> then(fn m ->
+      case Map.get(map, :entry) do
+        %{id: id, blurb: blurb, tags: tags, repo: repo, quants: quants} ->
+          Map.merge(m, %{
+            catalog_id: id,
+            blurb: blurb,
+            tags: tags,
+            repo: repo,
+            catalog_quants: quants
+          })
+
+        _ ->
+          m
+      end
+    end)
+  end
+
+  def to_json(list) when is_list(list), do: Enum.map(list, &to_json/1)
+  def to_json(other), do: other
 
   # ── inspect one ─────────────────────────────────────────────────────────
 
@@ -480,7 +515,77 @@ defmodule OptimalSystemAgent.LocalModels do
 
   @doc false
   def context_for_fit do
-    Application.get_env(:optimal_system_agent, :ollama_num_ctx) || 32_768
+    case Application.get_env(:optimal_system_agent, :ollama_num_ctx) do
+      n when is_integer(n) -> n
+      _ -> @floor_ctx
+    end
+  end
+
+  # ── context window ceiling ─────────────────────────────────────────────
+
+  @doc """
+  The `num_ctx` ceiling for a local model. `OLLAMA_NUM_CTX=<n>` pins it;
+  `auto` (the default) returns the largest bucket whose KV cache fits in
+  VRAM beside the weights on THIS machine, floored at 32k. Cached per model.
+  """
+  @spec num_ctx_ceiling(String.t() | nil) :: pos_integer()
+  def num_ctx_ceiling(model) do
+    case Application.get_env(:optimal_system_agent, :ollama_num_ctx) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> auto_num_ctx(model)
+    end
+  end
+
+  @doc false
+  def auto_num_ctx(model) when is_binary(model) do
+    key = {__MODULE__, :auto_ctx, model}
+
+    case :persistent_term.get(key, nil) do
+      nil ->
+        ctx = compute_auto_num_ctx(model)
+        :persistent_term.put(key, ctx)
+        ctx
+
+      ctx ->
+        ctx
+    end
+  end
+
+  def auto_num_ctx(_), do: @floor_ctx
+
+  @doc false
+  def forget_auto_num_ctx(model), do: :persistent_term.erase({__MODULE__, :auto_ctx, model})
+
+  defp compute_auto_num_ctx(model) do
+    with {:ok, d} <- OllamaAdmin.show(model),
+         size when size > 0 <- installed_size(model) do
+      spec = %{
+        weights_bytes: size,
+        quant: d.quant,
+        family: d.family,
+        kv_bytes_per_token: d.kv_bytes_per_token
+      }
+
+      auto_ctx_for(spec, Hardware.detect(), d.context_length)
+    else
+      _ -> @floor_ctx
+    end
+  rescue
+    _ -> @floor_ctx
+  catch
+    :exit, _ -> @floor_ctx
+  end
+
+  @doc "Pure: largest bucket that fully fits, floored at 32k, capped at the trained window."
+  @spec auto_ctx_for(Fit.spec(), Hardware.t(), pos_integer() | nil) :: pos_integer()
+  def auto_ctx_for(spec, hw, trained) do
+    cap = if is_integer(trained) and trained > 0, do: trained, else: List.last(@ctx_buckets)
+
+    @ctx_buckets
+    |> Enum.filter(&(&1 <= cap))
+    |> Enum.filter(&(Fit.assess(spec, hw, &1).verdict == :fits))
+    |> Enum.max(fn -> @floor_ctx end)
+    |> max(@floor_ctx)
   end
 
   defp bench_path do

--- a/lib/optimal_system_agent/local_models.ex
+++ b/lib/optimal_system_agent/local_models.ex
@@ -1,0 +1,475 @@
+defmodule OptimalSystemAgent.LocalModels do
+  @moduledoc """
+  Local model management for `/models`: what is installed and loaded, what the
+  curated catalog offers, whether each one fits THIS machine and how fast it
+  should decode, and the lifecycle verbs — install (pull + benchmark), remove,
+  load, unload, alias, set as default.
+
+  Composes `LocalModels.Hardware` (what the box has), `LocalModels.Fit` (does
+  it fit / est. tok/s), `LocalModels.OllamaAdmin` (the daemon),
+  `LocalModels.HuggingFace` (exact GGUF sizes) and `LocalModels.Catalog`.
+  """
+
+  require Logger
+
+  alias OptimalSystemAgent.LocalModels.{Catalog, Fit, Hardware, HuggingFace, OllamaAdmin}
+  alias OptimalSystemAgent.System.{AtomicFile, JsonStore}
+
+  @type row :: %{
+          tag: String.t(),
+          name: String.t(),
+          installed: boolean(),
+          loaded: boolean(),
+          remote: boolean(),
+          size_bytes: non_neg_integer(),
+          params: String.t() | nil,
+          quant: String.t() | nil,
+          capabilities: [String.t()],
+          fit: Fit.t() | nil,
+          measured_tps: float() | nil,
+          entry: Catalog.entry() | nil
+        }
+
+  # ── overview ────────────────────────────────────────────────────────────
+
+  @doc """
+  Everything the picker needs in one call: hardware, installed local models
+  (with what is resident), and the catalog — each with a fit verdict.
+  Never raises; a daemon that is down yields `installed: []` and an error.
+  """
+  @spec overview() :: %{
+          hardware: Hardware.t(),
+          ctx: pos_integer(),
+          installed: [row()],
+          catalog: [row()],
+          error: String.t() | nil
+        }
+  def overview do
+    hw = Hardware.detect()
+    ctx = context_for_fit()
+    bench = read_bench()
+
+    {installed, error} =
+      case OllamaAdmin.installed() do
+        {:ok, list} -> {list, nil}
+        {:error, e} -> {[], e}
+      end
+
+    loaded =
+      case OllamaAdmin.loaded() do
+        {:ok, list} -> MapSet.new(list, & &1.name)
+        _ -> MapSet.new()
+      end
+
+    # An alias (`ollama cp hf.co/… superqwen-abliterated`) shares the digest
+    # of the tag it was copied from, so it inherits that tag's catalog entry,
+    # capabilities and quant.
+    by_digest =
+      installed
+      |> Enum.reject(& &1.remote)
+      |> Enum.reduce(%{}, fn m, acc ->
+        case Catalog.entry_for_tag(m.name) do
+          nil -> acc
+          entry -> Map.put_new(acc, m.digest, {entry, m.quant})
+        end
+      end)
+
+    installed_rows =
+      installed
+      |> Enum.reject(& &1.remote)
+      |> Enum.map(fn m ->
+        {entry, quant} =
+          case {Catalog.entry_for_tag(m.name), Map.get(by_digest, m.digest)} do
+            {nil, {entry, q}} -> {entry, m.quant || q}
+            {entry, _} -> {entry, m.quant || (entry && entry.quant)}
+          end
+
+        spec = %{
+          weights_bytes: m.size_bytes,
+          params_b: entry && entry.params_b,
+          active_params_b: entry && entry.active_params_b,
+          quant: quant,
+          family: (entry && entry.family) || m.family
+        }
+
+        %{
+          tag: m.name,
+          name: (entry && entry.name) || m.name,
+          installed: true,
+          loaded: MapSet.member?(loaded, m.name),
+          remote: false,
+          size_bytes: m.size_bytes,
+          params: m.params,
+          quant: quant,
+          capabilities: (entry && entry.capabilities) || [],
+          fit: Fit.assess(spec, hw, ctx),
+          measured_tps: get_in(bench, [m.name, "decode_tps"]),
+          entry: entry
+        }
+      end)
+
+    installed_tags = MapSet.new(installed, & &1.name)
+
+    catalog_rows =
+      Catalog.all()
+      |> Enum.reject(fn e ->
+        Enum.any?(e.quants, &MapSet.member?(installed_tags, Catalog.tag(e, &1)))
+      end)
+      |> Enum.map(fn e ->
+        spec = %{
+          params_b: e.params_b,
+          active_params_b: e.active_params_b,
+          quant: e.quant,
+          family: e.family
+        }
+
+        %{
+          tag: Catalog.tag(e),
+          name: e.name,
+          installed: false,
+          loaded: false,
+          remote: false,
+          size_bytes: elem(Fit.weights_bytes(spec), 0),
+          params: "#{e.params_b}B",
+          quant: e.quant,
+          capabilities: e.capabilities,
+          fit: Fit.assess(spec, hw, ctx),
+          measured_tps: nil,
+          entry: e
+        }
+      end)
+
+    %{hardware: hw, ctx: ctx, installed: installed_rows, catalog: catalog_rows, error: error}
+  end
+
+  # ── inspect one ─────────────────────────────────────────────────────────
+
+  @doc """
+  Full detail for one model — installed tag, catalog id, or `hf.co/…` tag.
+  For a catalog/HF model that is not installed, sizes come from the Hub
+  (exact) and the fit is per available quant.
+  """
+  @spec inspect_model(String.t(), keyword()) :: {:ok, map()} | {:error, String.t()}
+  def inspect_model(ref, opts \\ []) do
+    hw = Hardware.detect()
+    ctx = context_for_fit()
+
+    case resolve(ref) do
+      {:installed, tag} -> inspect_installed(tag, hw, ctx)
+      {:catalog, entry, quant} -> inspect_catalog(entry, quant, hw, ctx, opts)
+      {:hf, repo, quant} -> inspect_hf(repo, quant, hw, ctx, opts)
+      :unknown -> {:error, "unknown model: #{ref} — try /models to see what's available"}
+    end
+  end
+
+  defp inspect_installed(tag, hw, ctx) do
+    with {:ok, d} <- OllamaAdmin.show(tag) do
+      entry = Catalog.entry_for_tag(tag)
+      size = installed_size(tag)
+
+      spec = %{
+        weights_bytes: size,
+        params_b: params_b_of(d, entry),
+        active_params_b: entry && entry.active_params_b,
+        quant: d.quant,
+        family: (entry && entry.family) || d.family,
+        kv_bytes_per_token: d.kv_bytes_per_token
+      }
+
+      {:ok,
+       %{
+         tag: tag,
+         name: (entry && entry.name) || tag,
+         installed: true,
+         capabilities: d.capabilities,
+         family: d.family,
+         params: d.params,
+         quant: d.quant,
+         context_length: d.context_length,
+         size_bytes: size,
+         fit: Fit.assess(spec, hw, ctx),
+         measured: read_bench()[tag],
+         quants: [],
+         entry: entry
+       }}
+    end
+  end
+
+  defp inspect_catalog(entry, quant, hw, ctx, opts) do
+    quants = fit_per_quant(entry.repo, entry, hw, ctx, opts)
+
+    # Recommend for THIS machine — the largest quant that fully fits — when
+    # the Hub told us the real sizes; the catalog's quant is the offline guess.
+    chosen =
+      cond do
+        is_binary(quant) -> quant
+        Enum.any?(quants, & &1.exact) -> pick_quant(quants)
+        true -> entry.quant
+      end
+
+    {:ok,
+     %{
+       tag: Catalog.tag(entry, chosen),
+       name: entry.name,
+       installed: false,
+       capabilities: entry.capabilities,
+       family: entry.family,
+       params: "#{entry.params_b}B",
+       quant: chosen,
+       context_length: entry.context,
+       size_bytes: Enum.find_value(quants, 0, &(&1.quant == String.upcase(chosen) && &1.bytes)),
+       fit: Enum.find_value(quants, &(&1.quant == String.upcase(chosen) && &1.fit)),
+       measured: nil,
+       quants: quants,
+       entry: entry
+     }}
+  end
+
+  defp inspect_hf(repo, quant, hw, ctx, opts) do
+    with {:ok, hf} <- HuggingFace.repo(repo, opts) do
+      if hf.quants == [] do
+        {:error, "#{repo} has no GGUF files"}
+      else
+        quants = fit_per_quant(repo, nil, hw, ctx, opts)
+        chosen = quant || pick_quant(quants)
+
+        {:ok,
+         %{
+           tag: "hf.co/#{repo}:#{chosen}",
+           name: repo,
+           installed: false,
+           capabilities: if(hf.mmproj_bytes > 0, do: ["vision"], else: []),
+           family: nil,
+           params: nil,
+           quant: chosen,
+           context_length: nil,
+           size_bytes:
+             Enum.find_value(quants, 0, &(&1.quant == String.upcase(chosen) && &1.bytes)),
+           fit: Enum.find_value(quants, &(&1.quant == String.upcase(chosen) && &1.fit)),
+           measured: nil,
+           quants: quants,
+           entry: nil
+         }}
+      end
+    end
+  end
+
+  # Every quant the repo ships, sized exactly from the Hub when reachable,
+  # else estimated from params — each with its own fit.
+  defp fit_per_quant(repo, entry, hw, ctx, opts) do
+    params = entry && entry.params_b
+    active = entry && entry.active_params_b
+    family = entry && entry.family
+
+    case HuggingFace.repo(repo, opts) do
+      {:ok, hf} when hf.quants != [] ->
+        Enum.map(hf.quants, fn q ->
+          spec = %{
+            weights_bytes: q.bytes + hf.mmproj_bytes,
+            params_b: params,
+            active_params_b: active,
+            quant: q.quant,
+            family: family
+          }
+
+          %{quant: q.quant, bytes: q.bytes, exact: true, fit: Fit.assess(spec, hw, ctx)}
+        end)
+
+      _ when is_map(entry) ->
+        Enum.map(entry.quants, fn q ->
+          spec = %{params_b: params, active_params_b: active, quant: q, family: family}
+          {bytes, _} = Fit.weights_bytes(spec)
+          %{quant: String.upcase(q), bytes: bytes, exact: false, fit: Fit.assess(spec, hw, ctx)}
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  # Largest quant that fully fits; else the smallest available.
+  defp pick_quant(quants) do
+    fitting = Enum.filter(quants, &(&1.fit.verdict == :fits))
+
+    case fitting do
+      [] -> quants |> Enum.min_by(& &1.bytes, fn -> %{quant: "Q4_K_M"} end) |> Map.get(:quant)
+      list -> list |> Enum.max_by(& &1.bytes) |> Map.get(:quant)
+    end
+  end
+
+  # ── lifecycle ───────────────────────────────────────────────────────────
+
+  @doc """
+  Pull `ref` (catalog id, `hf.co/…` tag, or plain Ollama tag) at `quant`,
+  streaming progress, then benchmark it and remember the measured speed.
+  Returns the installed tag and the benchmark.
+  """
+  @spec install(String.t(), keyword()) ::
+          {:ok, %{tag: String.t(), bench: map() | nil}} | {:error, String.t()}
+  def install(ref, opts \\ []) do
+    on_progress = Keyword.get(opts, :on_progress, fn _ -> :ok end)
+    quant = Keyword.get(opts, :quant)
+
+    tag =
+      case resolve(ref) do
+        {:installed, tag} -> tag
+        {:catalog, entry, q} -> Catalog.tag(entry, quant || q)
+        {:hf, repo, q} -> "hf.co/#{repo}:#{quant || q || "Q4_K_M"}"
+        :unknown -> ref
+      end
+
+    with :ok <- OllamaAdmin.pull(tag, on_progress) do
+      bench =
+        if Keyword.get(opts, :bench, true) do
+          case bench(tag) do
+            {:ok, b} -> b
+            _ -> nil
+          end
+        end
+
+      {:ok, %{tag: tag, bench: bench}}
+    end
+  end
+
+  @doc "Measure decode speed and remember it for the picker."
+  @spec bench(String.t()) :: {:ok, map()} | {:error, String.t()}
+  def bench(tag) do
+    with {:ok, b} <- OllamaAdmin.bench(tag) do
+      write_bench(
+        Map.put(read_bench(), tag, %{
+          "decode_tps" => b.decode_tps,
+          "prompt_tps" => b.prompt_tps,
+          "load_ms" => b.load_ms,
+          "measured_at" =>
+            DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+        })
+      )
+
+      {:ok, b}
+    end
+  end
+
+  @spec remove(String.t()) :: :ok | {:error, String.t()}
+  def remove(tag) do
+    with :ok <- OllamaAdmin.delete(tag) do
+      write_bench(Map.delete(read_bench(), tag))
+      :ok
+    end
+  end
+
+  defdelegate load(tag), to: OllamaAdmin
+  defdelegate unload(tag), to: OllamaAdmin
+  defdelegate alias_tag(from, to), to: OllamaAdmin, as: :copy
+
+  @doc "Make `tag` the default for new sessions (config.json + OLLAMA_MODEL)."
+  @spec set_default(String.t()) :: :ok | {:error, String.t()}
+  def set_default(tag) when is_binary(tag) do
+    path = Path.join(osa_home(), "config.json")
+
+    with {:ok, existing} <- read_config(path),
+         updated = Map.merge(existing, %{"provider" => "ollama", "model" => tag}),
+         {:ok, json} <- Jason.encode(updated, pretty: true),
+         :ok <- File.mkdir_p(Path.dirname(path)),
+         :ok <- AtomicFile.write(path, json <> "\n", mode: 0o600) do
+      try do
+        OptimalSystemAgent.CLI.Setup.save_env("OLLAMA_MODEL", tag)
+      rescue
+        _ -> :ok
+      end
+
+      Application.put_env(:optimal_system_agent, :ollama_model, tag)
+      :ok
+    else
+      {:error, :corrupt} -> {:error, JsonStore.corrupt_message("model selection", path)}
+      {:error, reason} -> {:error, inspect(reason)}
+    end
+  end
+
+  # ── resolution ──────────────────────────────────────────────────────────
+
+  @doc false
+  def resolve(ref) when is_binary(ref) do
+    ref = String.trim(ref)
+    installed = installed_tags()
+
+    cond do
+      ref == "" ->
+        :unknown
+
+      MapSet.member?(installed, ref) ->
+        {:installed, ref}
+
+      MapSet.member?(installed, ref <> ":latest") ->
+        {:installed, ref <> ":latest"}
+
+      entry = Catalog.find(ref) ->
+        {_, quant} = Catalog.split_tag(ref)
+        quant = if Catalog.hf_tag?(ref) or String.contains?(ref, "/"), do: quant, else: nil
+        {:catalog, entry, quant}
+
+      Catalog.hf_tag?(ref) or (String.contains?(ref, "/") and not String.contains?(ref, " ")) ->
+        {repo, quant} = Catalog.split_tag(ref)
+        {:hf, repo, quant}
+
+      true ->
+        :unknown
+    end
+  end
+
+  defp installed_tags do
+    case OllamaAdmin.installed() do
+      {:ok, list} -> MapSet.new(list, & &1.name)
+      _ -> MapSet.new()
+    end
+  end
+
+  defp installed_size(tag) do
+    case OllamaAdmin.installed() do
+      {:ok, list} -> Enum.find_value(list, 0, &(&1.name == tag && &1.size_bytes))
+      _ -> 0
+    end
+  end
+
+  defp params_b_of(%{params_count: n}, _entry) when is_integer(n) and n > 0, do: n / 1.0e9
+  defp params_b_of(_, %{params_b: p}), do: p
+  defp params_b_of(_, _), do: nil
+
+  # ── persistence ─────────────────────────────────────────────────────────
+
+  @doc false
+  def context_for_fit do
+    Application.get_env(:optimal_system_agent, :ollama_num_ctx) || 32_768
+  end
+
+  defp bench_path do
+    Application.get_env(:optimal_system_agent, :local_bench_path) ||
+      Path.join([osa_home(), "cache", "local_bench.json"])
+  end
+
+  @doc false
+  def read_bench do
+    with {:ok, raw} <- File.read(bench_path()),
+         {:ok, map} when is_map(map) <- Jason.decode(raw) do
+      map
+    else
+      _ -> %{}
+    end
+  end
+
+  defp write_bench(map) do
+    File.mkdir_p!(Path.dirname(bench_path()))
+    File.write(bench_path(), Jason.encode!(map, pretty: true))
+  rescue
+    _ -> :ok
+  end
+
+  defp read_config(path) do
+    if File.exists?(path), do: JsonStore.read_map_for_write(path), else: {:ok, %{}}
+  end
+
+  defp osa_home do
+    (Application.get_env(:optimal_system_agent, :bootstrap_dir) ||
+       System.get_env("OSA_HOME") || Path.join(System.user_home!(), ".osa"))
+    |> Path.expand()
+  end
+end

--- a/lib/optimal_system_agent/local_models.ex
+++ b/lib/optimal_system_agent/local_models.ex
@@ -103,7 +103,7 @@ defmodule OptimalSystemAgent.LocalModels do
           quant: quant,
           capabilities: (entry && entry.capabilities) || [],
           fit: Fit.assess(spec, hw, ctx),
-          measured_tps: get_in(bench, [m.name, "decode_tps"]),
+          measured_tps: measured_for(m, bench, installed),
           entry: entry
         }
       end)
@@ -405,7 +405,14 @@ defmodule OptimalSystemAgent.LocalModels do
       entry = Catalog.find(ref) ->
         {_, quant} = Catalog.split_tag(ref)
         quant = if Catalog.hf_tag?(ref) or String.contains?(ref, "/"), do: quant, else: nil
-        {:catalog, entry, quant}
+
+        # A catalog id whose model is already pulled (at any quant) IS that
+        # installed tag — `/models info <id>` after `/models install <id>`
+        # must describe what is on disk, and `/models use <id>` must work.
+        case Enum.find(entry.quants, &MapSet.member?(installed, Catalog.tag(entry, &1))) do
+          nil -> {:catalog, entry, quant}
+          q -> {:installed, Catalog.tag(entry, q)}
+        end
 
       Catalog.hf_tag?(ref) or (String.contains?(ref, "/") and not String.contains?(ref, " ")) ->
         {repo, quant} = Catalog.split_tag(ref)
@@ -414,6 +421,16 @@ defmodule OptimalSystemAgent.LocalModels do
       true ->
         :unknown
     end
+  end
+
+  # A benchmark is keyed by tag, but an alias shares its source's digest and
+  # therefore its speed.
+  defp measured_for(m, bench, installed) do
+    get_in(bench, [m.name, "decode_tps"]) ||
+      Enum.find_value(installed, fn other ->
+        other.digest == m.digest and other.name != m.name and
+          get_in(bench, [other.name, "decode_tps"])
+      end)
   end
 
   defp installed_tags do

--- a/lib/optimal_system_agent/local_models/catalog.ex
+++ b/lib/optimal_system_agent/local_models/catalog.ex
@@ -1,0 +1,117 @@
+defmodule OptimalSystemAgent.LocalModels.Catalog do
+  @moduledoc """
+  The curated list of local GGUF models OSA offers in `/models`
+  (`priv/models/local_catalog.json`).
+
+  An entry names a Hugging Face repo and the quants it ships; the Ollama tag
+  for a pull is `hf.co/<repo>:<quant>`. Users can add their own entries in
+  `~/.osa/local_catalog.json` (same shape) — those are merged on top, and an
+  entry with the same `id` overrides the shipped one.
+  """
+
+  @type entry :: %{
+          id: String.t(),
+          name: String.t(),
+          repo: String.t(),
+          family: String.t() | nil,
+          params_b: number(),
+          active_params_b: number() | nil,
+          quant: String.t(),
+          quants: [String.t()],
+          capabilities: [String.t()],
+          context: non_neg_integer() | nil,
+          tags: [String.t()],
+          blurb: String.t(),
+          source: :shipped | :user
+        }
+
+  @spec all() :: [entry()]
+  def all do
+    shipped = load(shipped_path(), :shipped)
+    user = load(user_path(), :user)
+
+    (shipped ++ user)
+    |> Enum.reduce(%{}, fn e, acc -> Map.put(acc, e.id, e) end)
+    |> Map.values()
+    |> Enum.sort_by(&{&1.params_b, &1.name})
+  end
+
+  @doc "Find by catalog id, exact repo, or the `hf.co/<repo>:<quant>` tag."
+  @spec find(String.t()) :: entry() | nil
+  def find(ref) when is_binary(ref) do
+    ref = String.trim(ref)
+    {repo, _quant} = split_tag(ref)
+
+    Enum.find(all(), fn e ->
+      e.id == ref or e.repo == ref or String.downcase(e.repo) == String.downcase(repo)
+    end)
+  end
+
+  @doc "Ollama tag for a catalog entry at `quant` (default: the entry's recommended quant)."
+  @spec tag(entry(), String.t() | nil) :: String.t()
+  def tag(entry, quant \\ nil), do: "hf.co/#{entry.repo}:#{quant || entry.quant}"
+
+  @doc "`{repo, quant}` from `hf.co/<repo>:<quant>`, `<repo>:<quant>`, or a bare repo."
+  @spec split_tag(String.t()) :: {String.t(), String.t() | nil}
+  def split_tag(ref) do
+    ref = String.replace_prefix(ref, "hf.co/", "") |> String.replace_prefix("huggingface.co/", "")
+
+    case String.split(ref, ":", parts: 2) do
+      [repo, quant] -> {repo, quant}
+      [repo] -> {repo, nil}
+    end
+  end
+
+  @doc "True when a tag is a Hugging Face pull (`hf.co/…`)."
+  @spec hf_tag?(String.t()) :: boolean()
+  def hf_tag?(tag), do: String.starts_with?(tag, ["hf.co/", "huggingface.co/"])
+
+  @doc "The catalog entry an INSTALLED tag came from, if any."
+  @spec entry_for_tag(String.t()) :: entry() | nil
+  def entry_for_tag(tag) when is_binary(tag) do
+    if hf_tag?(tag), do: find(tag), else: nil
+  end
+
+  defp shipped_path,
+    do: Path.join(:code.priv_dir(:optimal_system_agent), "models/local_catalog.json")
+
+  defp user_path do
+    Application.get_env(:optimal_system_agent, :local_catalog_user_path) ||
+      Path.join(
+        System.get_env("OSA_HOME") || Path.join(System.user_home!(), ".osa"),
+        "local_catalog.json"
+      )
+  end
+
+  defp load(path, source) do
+    with {:ok, raw} <- File.read(path),
+         {:ok, %{"models" => models}} when is_list(models) <- Jason.decode(raw) do
+      models |> Enum.map(&normalize(&1, source)) |> Enum.reject(&is_nil/1)
+    else
+      _ -> []
+    end
+  end
+
+  defp normalize(%{"repo" => repo} = m, source) when is_binary(repo) do
+    %{
+      id: m["id"] || repo |> String.split("/") |> List.last() |> String.downcase(),
+      name: m["name"] || repo,
+      repo: repo,
+      family: m["family"],
+      params_b: num(m["params_b"]) || 0,
+      active_params_b: num(m["active_params_b"]),
+      quant: m["quant"] || List.first(m["quants"] || []) || "Q4_K_M",
+      quants: m["quants"] || [m["quant"] || "Q4_K_M"],
+      capabilities: m["capabilities"] || [],
+      context: m["context"],
+      tags: m["tags"] || [],
+      blurb: m["blurb"] || "",
+      source: source
+    }
+  end
+
+  defp normalize(_, _), do: nil
+
+  defp num(n) when is_number(n), do: n
+  defp num(_), do: nil
+end

--- a/lib/optimal_system_agent/local_models/fit.ex
+++ b/lib/optimal_system_agent/local_models/fit.ex
@@ -148,6 +148,23 @@ defmodule OptimalSystemAgent.LocalModels.Fit do
   @hybrid_families ~w(qwen35 qwen3.5 qwen36 qwen3.6 qwen3.8 gemma4 lfm2 deepseek)
   defp hybrid_family?(family), do: Enum.any?(@hybrid_families, &String.starts_with?(family, &1))
 
+  @doc """
+  How much of the f16 KV cache the daemon actually allocates, from
+  `:ollama_kv_cache_type` (mirrors `OLLAMA_KV_CACHE_TYPE` on the Ollama
+  service): f16 → 1.0, q8_0 → 0.5, q4_0 → 0.25.
+  """
+  @spec kv_cache_scale() :: float()
+  def kv_cache_scale do
+    case Application.get_env(:optimal_system_agent, :ollama_kv_cache_type, "f16") do
+      "q8_0" -> 0.5
+      "q4_0" -> 0.25
+      "q4_1" -> 0.28
+      "q5_0" -> 0.34
+      "q5_1" -> 0.38
+      _ -> 1.0
+    end
+  end
+
   @doc "From GGUF `model_info` (Ollama `/api/show`): exact KV bytes per token, or nil."
   @spec kv_from_model_info(map()) :: non_neg_integer() | nil
   def kv_from_model_info(info) when is_map(info) do
@@ -182,7 +199,7 @@ defmodule OptimalSystemAgent.LocalModels.Fit do
   @spec assess(spec(), Hardware.t(), pos_integer()) :: t()
   def assess(spec, hw, ctx) when is_integer(ctx) and ctx > 0 do
     {weights, exact} = weights_bytes(spec)
-    kv = kv_bytes_per_token(spec) * ctx
+    kv = round(kv_bytes_per_token(spec) * ctx * kv_cache_scale())
     total = weights + kv + @overhead
 
     vram_budget = round(hw.vram_bytes * @vram_usable)

--- a/lib/optimal_system_agent/local_models/fit.ex
+++ b/lib/optimal_system_agent/local_models/fit.ex
@@ -1,0 +1,257 @@
+defmodule OptimalSystemAgent.LocalModels.Fit do
+  @moduledoc """
+  Will a model run on this hardware, and roughly how fast?
+
+  Pure arithmetic over a model spec and a `Hardware.t()`:
+
+    * **weights** — the GGUF bytes (exact when known from HF / the daemon,
+      else `params × bytes-per-param(quant)`)
+    * **KV cache** — per-token bytes × context length
+    * **overhead** — ~1 GiB for the runtime, compute buffers, the projector
+
+  Verdicts:
+
+    * `:fits`    — everything sits in VRAM (or unified memory)
+    * `:partial` — weights spill into system RAM; runs, but decode drops to
+                   CPU bandwidth for the spilled share
+    * `:cpu`     — no GPU; runs from RAM at CPU speed
+    * `:no`      — does not fit in VRAM + RAM at all
+
+  The tokens/sec number is an ESTIMATE from memory bandwidth — decode streams
+  the active weights once per token — with a ~65% efficiency factor that
+  matches what llama.cpp actually achieves on consumer cards. `Bench` replaces
+  it with a measured figure once the model is installed.
+  """
+
+  alias OptimalSystemAgent.LocalModels.Hardware
+
+  @type spec :: %{
+          optional(:weights_bytes) => non_neg_integer() | nil,
+          optional(:params_b) => number() | nil,
+          optional(:active_params_b) => number() | nil,
+          optional(:quant) => String.t() | nil,
+          optional(:kv_bytes_per_token) => non_neg_integer() | nil
+        }
+
+  @type verdict :: :fits | :partial | :cpu | :no
+
+  @type t :: %{
+          verdict: verdict(),
+          weights_bytes: non_neg_integer(),
+          kv_bytes: non_neg_integer(),
+          total_bytes: non_neg_integer(),
+          budget_bytes: non_neg_integer(),
+          gpu_share: float(),
+          est_tps: float() | nil,
+          ctx: pos_integer(),
+          weights_exact: boolean()
+        }
+
+  @overhead 1024 * 1024 * 1024
+  # Measured: SuperQwen 3.8 27B Q4_K_M on an RTX 5090 Laptop (896 GB/s,
+  # 17.2 GB) decodes at 25.6 tok/s = 49% of the bandwidth-bound ceiling.
+  @efficiency 0.5
+  # A MoE streams only its active experts, but the router, shared experts and
+  # attention still cost — measured throughput is roughly half the naive
+  # active/total scaling predicts.
+  @moe_efficiency 0.5
+  # Leave headroom for the display / compositor and driver allocations.
+  @vram_usable 0.92
+  @ram_usable 0.70
+
+  # Bytes per parameter by quant. GGUF K-quants mix block sizes, so these are
+  # measured whole-file averages, not the nominal bit width.
+  @bytes_per_param %{
+    "IQ1_S" => 0.22,
+    "IQ1_M" => 0.24,
+    "IQ2_XXS" => 0.27,
+    "IQ2_XS" => 0.30,
+    "IQ2_S" => 0.31,
+    "IQ2_M" => 0.34,
+    "Q2_K" => 0.40,
+    "Q2_K_L" => 0.42,
+    "IQ3_XXS" => 0.39,
+    "IQ3_XS" => 0.42,
+    "IQ3_S" => 0.44,
+    "IQ3_M" => 0.46,
+    "Q3_K" => 0.49,
+    "Q3_K_S" => 0.44,
+    "Q3_K_M" => 0.49,
+    "Q3_K_L" => 0.53,
+    "IQ4_XS" => 0.54,
+    "Q4_0" => 0.57,
+    "Q4_K_S" => 0.58,
+    "Q4_K" => 0.61,
+    "Q4_K_M" => 0.61,
+    "Q4_K_L" => 0.63,
+    "Q5_0" => 0.69,
+    "Q5_K_S" => 0.70,
+    "Q5_K" => 0.72,
+    "Q5_K_M" => 0.72,
+    "Q5_K_L" => 0.74,
+    "Q6_K" => 0.83,
+    "Q8_0" => 1.07,
+    "MXFP4" => 0.55,
+    "F16" => 2.0,
+    "BF16" => 2.0,
+    "F32" => 4.0
+  }
+
+  @doc "Bytes per parameter for a quant label (case-insensitive); Q4_K_M when unknown."
+  @spec bytes_per_param(String.t() | nil) :: float()
+  def bytes_per_param(nil), do: @bytes_per_param["Q4_K_M"]
+
+  def bytes_per_param(quant) do
+    Map.get(@bytes_per_param, String.upcase(quant), @bytes_per_param["Q4_K_M"])
+  end
+
+  @doc "Bytes the weights take: exact when the spec carries them, else estimated."
+  @spec weights_bytes(spec()) :: {non_neg_integer(), boolean()}
+  def weights_bytes(%{weights_bytes: bytes}) when is_integer(bytes) and bytes > 0,
+    do: {bytes, true}
+
+  def weights_bytes(%{params_b: params} = spec) when is_number(params) and params > 0 do
+    {round(params * 1.0e9 * bytes_per_param(Map.get(spec, :quant))), false}
+  end
+
+  def weights_bytes(_), do: {0, false}
+
+  @doc """
+  KV-cache bytes per token. Exact from GGUF metadata when the spec has it.
+
+  Otherwise a rule of thumb. Hybrid architectures (Qwen 3.5/3.6, Gemma 4,
+  the linear-attention + sliding-window families) keep a full KV cache on
+  only a fraction of their layers — measured 64 KB/token on Qwen 3.5 27B —
+  so they get ~64 KB. Classic GQA transformers (Llama 3, Qwen 3, Mistral;
+  8 KV heads × 128 dims, f16) get ~128 KB/token under 20B params, ~256 KB
+  above, ~320 KB above 60B.
+  """
+  @spec kv_bytes_per_token(spec()) :: non_neg_integer()
+  def kv_bytes_per_token(%{kv_bytes_per_token: n}) when is_integer(n) and n > 0, do: n
+
+  def kv_bytes_per_token(spec) do
+    family = spec |> Map.get(:family) |> to_string() |> String.downcase()
+
+    cond do
+      hybrid_family?(family) ->
+        64 * 1024
+
+      true ->
+        case Map.get(spec, :params_b) do
+          p when is_number(p) and p >= 60 -> 320 * 1024
+          p when is_number(p) and p >= 20 -> 256 * 1024
+          _ -> 128 * 1024
+        end
+    end
+  end
+
+  @hybrid_families ~w(qwen35 qwen3.5 qwen36 qwen3.6 qwen3.8 gemma4 lfm2 deepseek)
+  defp hybrid_family?(family), do: Enum.any?(@hybrid_families, &String.starts_with?(family, &1))
+
+  @doc "From GGUF `model_info` (Ollama `/api/show`): exact KV bytes per token, or nil."
+  @spec kv_from_model_info(map()) :: non_neg_integer() | nil
+  def kv_from_model_info(info) when is_map(info) do
+    arch = info["general.architecture"]
+
+    with true <- is_binary(arch),
+         layers when is_integer(layers) <- info["#{arch}.block_count"],
+         heads when is_integer(heads) and heads > 0 <- info["#{arch}.attention.head_count"],
+         emb when is_integer(emb) <- info["#{arch}.embedding_length"] do
+      kv_heads = info["#{arch}.attention.head_count_kv"] || heads
+      key_len = info["#{arch}.attention.key_length"] || div(emb, heads)
+      value_len = info["#{arch}.attention.value_length"] || key_len
+
+      # Hybrid models (Qwen 3.5+: gated DeltaNet on 3 of every 4 layers) only
+      # keep a KV cache on the full-attention layers.
+      kv_layers =
+        case info["#{arch}.full_attention_interval"] do
+          i when is_integer(i) and i > 1 -> div(layers, i)
+          _ -> layers
+        end
+
+      # K and V, f16.
+      kv_layers * kv_heads * (key_len + value_len) * 2
+    else
+      _ -> nil
+    end
+  end
+
+  def kv_from_model_info(_), do: nil
+
+  @doc "Assess `spec` on `hw` at `ctx` tokens of context."
+  @spec assess(spec(), Hardware.t(), pos_integer()) :: t()
+  def assess(spec, hw, ctx) when is_integer(ctx) and ctx > 0 do
+    {weights, exact} = weights_bytes(spec)
+    kv = kv_bytes_per_token(spec) * ctx
+    total = weights + kv + @overhead
+
+    vram_budget = round(hw.vram_bytes * @vram_usable)
+    ram_budget = round(hw.ram_bytes * @ram_usable)
+
+    {verdict, gpu_share, budget} =
+      cond do
+        weights == 0 ->
+          {:no, 0.0, vram_budget}
+
+        hw.backend == :cpu ->
+          if total <= ram_budget, do: {:cpu, 0.0, ram_budget}, else: {:no, 0.0, ram_budget}
+
+        total <= vram_budget ->
+          {:fits, 1.0, vram_budget}
+
+        total <= vram_budget + ram_budget ->
+          # KV and overhead stay on the GPU; weights spill.
+          on_gpu = max(vram_budget - kv - @overhead, 0)
+          {:partial, min(on_gpu / weights, 1.0), vram_budget}
+
+        true ->
+          {:no, 0.0, vram_budget}
+      end
+
+    %{
+      verdict: verdict,
+      weights_bytes: weights,
+      kv_bytes: kv,
+      total_bytes: total,
+      budget_bytes: budget,
+      gpu_share: Float.round(gpu_share * 1.0, 2),
+      est_tps: estimate_tps(spec, weights, gpu_share, verdict, hw),
+      ctx: ctx,
+      weights_exact: exact
+    }
+  end
+
+  # tokens/s ≈ bandwidth ÷ bytes streamed per token. For a MoE only the
+  # active experts stream, so scale by active/total params. A partial offload
+  # is a harmonic blend: the GPU share at GPU bandwidth, the rest at CPU.
+  defp estimate_tps(_spec, _w, _share, :no, _hw), do: nil
+  defp estimate_tps(_spec, 0, _share, _v, _hw), do: nil
+
+  defp estimate_tps(spec, weights, share, verdict, hw) do
+    active_bytes = weights * active_fraction(spec)
+    cpu_bw = Hardware.cpu_bandwidth_gbps() * 1.0e9 * @efficiency
+    gpu_bw = hw.bandwidth_gbps * 1.0e9 * @efficiency
+
+    seconds_per_token =
+      case verdict do
+        :cpu -> active_bytes / cpu_bw
+        :fits -> active_bytes / gpu_bw
+        :partial -> active_bytes * share / gpu_bw + active_bytes * (1 - share) / cpu_bw
+      end
+
+    Float.round(1 / seconds_per_token, 1)
+  end
+
+  defp active_fraction(%{active_params_b: a, params_b: p})
+       when is_number(a) and is_number(p) and p > 0 and a > 0 and a < p,
+       do: a / p / @moe_efficiency
+
+  defp active_fraction(_), do: 1.0
+
+  @doc "Human label for a verdict."
+  @spec label(verdict()) :: String.t()
+  def label(:fits), do: "fits in VRAM"
+  def label(:partial), do: "partial offload (slow)"
+  def label(:cpu), do: "CPU only"
+  def label(:no), do: "won't fit"
+end

--- a/lib/optimal_system_agent/local_models/hardware.ex
+++ b/lib/optimal_system_agent/local_models/hardware.ex
@@ -1,0 +1,312 @@
+defmodule OptimalSystemAgent.LocalModels.Hardware do
+  @moduledoc """
+  What this machine can run a local model on.
+
+  Detected once and cached in `:persistent_term` (call `refresh/0` to redo):
+  GPU name + VRAM, system RAM, CPU, and the accelerator backend. The numbers
+  feed `LocalModels.Fit` — will the weights fit, how fast will decode be.
+
+  Every probe is best-effort and degrades to "unknown" (nil / 0) rather than
+  raising; a machine with no `nvidia-smi` is a CPU box, not an error.
+  """
+
+  @type t :: %{
+          backend: :cuda | :rocm | :metal | :cpu,
+          gpu: String.t() | nil,
+          vram_bytes: non_neg_integer(),
+          ram_bytes: non_neg_integer(),
+          cpu: String.t() | nil,
+          cores: pos_integer(),
+          os: :linux | :macos | :windows | :other,
+          # Memory bandwidth the decode loop is bound by, in GB/s. From a
+          # lookup on the GPU name; a guess is flagged so the UI can say "est."
+          bandwidth_gbps: number(),
+          bandwidth_known: boolean()
+        }
+
+  @key {__MODULE__, :detected}
+
+  @spec detect() :: t()
+  def detect do
+    case :persistent_term.get(@key, nil) do
+      nil -> refresh()
+      hw -> hw
+    end
+  end
+
+  @spec refresh() :: t()
+  def refresh do
+    hw = probe()
+    :persistent_term.put(@key, hw)
+    hw
+  end
+
+  @doc "Build the record from raw probe results (test seam — no shelling out)."
+  @spec from_probe(map()) :: t()
+  def from_probe(raw) do
+    os = Map.get(raw, :os, :linux)
+    ram = Map.get(raw, :ram_bytes, 0)
+    {gpu, vram, backend} = pick_gpu(raw, os, ram)
+    {bw, known} = bandwidth_for(gpu, backend, os)
+
+    %{
+      backend: backend,
+      gpu: gpu,
+      vram_bytes: vram,
+      ram_bytes: ram,
+      cpu: Map.get(raw, :cpu),
+      cores: Map.get(raw, :cores, System.schedulers_online()),
+      os: os,
+      bandwidth_gbps: bw,
+      bandwidth_known: known
+    }
+  end
+
+  @doc "One-line summary for status lines: `RTX 5090 Laptop · 24 GB VRAM · 64 GB RAM`."
+  @spec summary(t()) :: String.t()
+  def summary(hw) do
+    gpu =
+      case hw.gpu do
+        nil -> "no GPU (#{hw.cpu || "cpu"})"
+        name -> "#{shorten_gpu(name)} · #{gb(hw.vram_bytes)} GB VRAM"
+      end
+
+    "#{gpu} · #{gb(hw.ram_bytes)} GB RAM"
+  end
+
+  @doc false
+  def shorten_gpu(name) do
+    name
+    |> String.replace(~r/^NVIDIA (GeForce )?/, "")
+    |> String.replace(~r/ GPU$/, "")
+    |> String.replace("Apple ", "")
+  end
+
+  defp gb(bytes), do: Float.round(bytes / 1024 / 1024 / 1024, 0) |> trunc()
+
+  # ── probing ─────────────────────────────────────────────────────────────
+
+  defp probe do
+    os = host_os()
+
+    from_probe(%{
+      os: os,
+      ram_bytes: ram_bytes(os),
+      cpu: cpu_name(os),
+      cores: System.schedulers_online(),
+      nvidia: nvidia_smi(),
+      amd_vram: amd_vram(os),
+      apple_chip: apple_chip(os)
+    })
+  end
+
+  defp pick_gpu(raw, os, ram) do
+    cond do
+      match?({name, vram} when is_binary(name) and vram > 0, Map.get(raw, :nvidia)) ->
+        {name, vram} = raw.nvidia
+        {name, vram, :cuda}
+
+      is_integer(Map.get(raw, :amd_vram)) and raw.amd_vram > 0 ->
+        {"AMD GPU", raw.amd_vram, :rocm}
+
+      os == :macos and is_binary(Map.get(raw, :apple_chip)) ->
+        # Unified memory: Metal lets a process use roughly 3/4 of RAM by default.
+        {raw.apple_chip, div(ram * 3, 4), :metal}
+
+      true ->
+        {nil, 0, :cpu}
+    end
+  end
+
+  defp host_os do
+    case :os.type() do
+      {:unix, :darwin} -> :macos
+      {:unix, _} -> :linux
+      {:win32, _} -> :windows
+      _ -> :other
+    end
+  end
+
+  defp nvidia_smi do
+    case run("nvidia-smi", ["--query-gpu=name,memory.total", "--format=csv,noheader,nounits"]) do
+      {:ok, out} ->
+        # Multi-GPU: take the largest card. Fit against one device is the
+        # honest answer — Ollama splits across cards, but bandwidth does not add.
+        out
+        |> String.split("\n", trim: true)
+        |> Enum.map(fn line ->
+          case String.split(line, ",") do
+            [name, mib | _] ->
+              {String.trim(name), (mib |> String.trim() |> to_int()) * 1024 * 1024}
+
+            _ ->
+              nil
+          end
+        end)
+        |> Enum.reject(&is_nil/1)
+        |> Enum.max_by(&elem(&1, 1), fn -> nil end)
+
+      _ ->
+        nil
+    end
+  end
+
+  defp amd_vram(:linux) do
+    Path.wildcard("/sys/class/drm/card*/device/mem_info_vram_total")
+    |> Enum.map(fn p ->
+      case File.read(p) do
+        {:ok, s} -> to_int(String.trim(s))
+        _ -> 0
+      end
+    end)
+    |> Enum.max(fn -> 0 end)
+  end
+
+  defp amd_vram(_), do: 0
+
+  defp apple_chip(:macos) do
+    case run("sysctl", ["-n", "machdep.cpu.brand_string"]) do
+      {:ok, s} -> String.trim(s)
+      _ -> nil
+    end
+  end
+
+  defp apple_chip(_), do: nil
+
+  defp ram_bytes(:linux) do
+    case File.read("/proc/meminfo") do
+      {:ok, s} ->
+        case Regex.run(~r/MemTotal:\s+(\d+) kB/, s) do
+          [_, kb] -> to_int(kb) * 1024
+          _ -> 0
+        end
+
+      _ ->
+        0
+    end
+  end
+
+  defp ram_bytes(:macos) do
+    case run("sysctl", ["-n", "hw.memsize"]) do
+      {:ok, s} -> to_int(String.trim(s))
+      _ -> 0
+    end
+  end
+
+  defp ram_bytes(_), do: 0
+
+  defp cpu_name(:linux) do
+    case File.read("/proc/cpuinfo") do
+      {:ok, s} ->
+        case Regex.run(~r/model name\s*:\s*(.+)/, s) do
+          [_, name] -> String.trim(name)
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp cpu_name(:macos), do: apple_chip(:macos)
+  defp cpu_name(_), do: nil
+
+  defp run(cmd, args) do
+    case System.find_executable(cmd) do
+      nil ->
+        :error
+
+      path ->
+        case System.cmd(path, args, stderr_to_stdout: true) do
+          {out, 0} -> {:ok, out}
+          _ -> :error
+        end
+    end
+  rescue
+    _ -> :error
+  end
+
+  defp to_int(s) do
+    case Integer.parse(s) do
+      {n, _} -> n
+      :error -> 0
+    end
+  end
+
+  # ── bandwidth table ─────────────────────────────────────────────────────
+  #
+  # Decode is memory-bandwidth-bound: every generated token streams the active
+  # weights once. GB/s per part, most specific pattern first. Not exhaustive —
+  # an unmatched GPU gets a conservative default and `bandwidth_known: false`.
+  @gpu_bandwidth [
+    {"5090 laptop", 896},
+    {"5080 laptop", 896},
+    {"5070 ti laptop", 672},
+    {"5070 laptop", 384},
+    {"5060 laptop", 384},
+    {"5090", 1792},
+    {"5080", 960},
+    {"5070 ti", 896},
+    {"5070", 672},
+    {"5060 ti", 448},
+    {"5060", 448},
+    {"4090 laptop", 576},
+    {"4080 laptop", 432},
+    {"4070 laptop", 256},
+    {"4060 laptop", 256},
+    {"4090", 1008},
+    {"4080", 717},
+    {"4070 ti", 504},
+    {"4070", 504},
+    {"4060 ti", 288},
+    {"4060", 272},
+    {"3090", 936},
+    {"3080", 760},
+    {"3070", 448},
+    {"3060", 360},
+    {"h200", 4800},
+    {"h100", 3350},
+    {"a100", 1935},
+    {"l40", 864},
+    {"a6000", 768},
+    {"rtx 6000", 960},
+    {"a10", 600},
+    {"7900 xtx", 960},
+    {"7900", 800},
+    {"m4 max", 546},
+    {"m4 pro", 273},
+    {"m4", 120},
+    {"m3 ultra", 819},
+    {"m3 max", 400},
+    {"m3 pro", 150},
+    {"m3", 100},
+    {"m2 ultra", 800},
+    {"m2 max", 400},
+    {"m2 pro", 200},
+    {"m2", 100},
+    {"m1 ultra", 800},
+    {"m1 max", 400},
+    {"m1 pro", 200},
+    {"m1", 68}
+  ]
+
+  @default_gpu_bandwidth 450
+  # Dual-channel DDR5 on a desktop/laptop; what CPU-offloaded layers get.
+  @cpu_bandwidth 60
+
+  @doc false
+  def cpu_bandwidth_gbps, do: @cpu_bandwidth
+
+  @doc false
+  @spec bandwidth_for(String.t() | nil, atom(), atom()) :: {number(), boolean()}
+  def bandwidth_for(nil, _backend, _os), do: {@cpu_bandwidth, true}
+
+  def bandwidth_for(gpu, _backend, _os) do
+    name = String.downcase(gpu)
+
+    case Enum.find(@gpu_bandwidth, fn {pat, _} -> String.contains?(name, pat) end) do
+      {_, bw} -> {bw, true}
+      nil -> {@default_gpu_bandwidth, false}
+    end
+  end
+end

--- a/lib/optimal_system_agent/local_models/hugging_face.ex
+++ b/lib/optimal_system_agent/local_models/hugging_face.ex
@@ -1,0 +1,175 @@
+defmodule OptimalSystemAgent.LocalModels.HuggingFace do
+  @moduledoc """
+  The little bit of the Hugging Face Hub API OSA needs to size a GGUF before
+  pulling it: the repo's file list with byte sizes, and a search.
+
+  Responses are cached on disk (`~/.osa/cache/hf/`) for a day — file sizes
+  do not change, and the picker should not hit the network on every open.
+  """
+
+  @api "https://huggingface.co/api/models"
+  @cache_ttl_s 24 * 3600
+
+  @type quant_file :: %{quant: String.t(), bytes: non_neg_integer(), files: [String.t()]}
+
+  @type repo :: %{
+          id: String.t(),
+          downloads: non_neg_integer(),
+          tags: [String.t()],
+          quants: [quant_file()],
+          mmproj_bytes: non_neg_integer()
+        }
+
+  @doc """
+  Repo metadata with every GGUF quant and its total size (split parts summed;
+  the vision projector reported separately).
+  """
+  @spec repo(String.t(), keyword()) :: {:ok, repo()} | {:error, String.t()}
+  def repo(repo_id, opts \\ []) when is_binary(repo_id) do
+    with_cache("repo-" <> safe(repo_id), opts, fn ->
+      case Req.get(
+             [
+               url: "#{@api}/#{repo_id}",
+               params: [blobs: true],
+               receive_timeout: 20_000,
+               retry: false
+             ] ++
+               Keyword.get(opts, :req_opts, [])
+           ) do
+        {:ok, %{status: 200, body: body}} when is_map(body) -> {:ok, parse_repo(body)}
+        {:ok, %{status: 404}} -> {:error, "no such repo on Hugging Face: #{repo_id}"}
+        {:ok, %{status: s}} -> {:error, "Hugging Face returned HTTP #{s}"}
+        {:error, reason} -> {:error, "Hugging Face unreachable: #{inspect(reason)}"}
+      end
+    end)
+  end
+
+  @doc "Search the Hub for GGUF repos; `[%{id, downloads, likes}]` by downloads."
+  @spec search(String.t(), keyword()) :: {:ok, [map()]} | {:error, String.t()}
+  def search(query, opts \\ []) when is_binary(query) do
+    limit = Keyword.get(opts, :limit, 25)
+
+    case Req.get(
+           [
+             url: @api,
+             params: [search: query <> " GGUF", sort: "downloads", direction: -1, limit: limit],
+             receive_timeout: 20_000,
+             retry: false
+           ] ++ Keyword.get(opts, :req_opts, [])
+         ) do
+      {:ok, %{status: 200, body: list}} when is_list(list) ->
+        {:ok,
+         list
+         |> Enum.filter(&String.contains?(String.downcase(&1["id"] || ""), "gguf"))
+         |> Enum.map(&%{id: &1["id"], downloads: &1["downloads"] || 0, likes: &1["likes"] || 0})}
+
+      {:ok, %{status: s}} ->
+        {:error, "Hugging Face returned HTTP #{s}"}
+
+      {:error, reason} ->
+        {:error, "Hugging Face unreachable: #{inspect(reason)}"}
+    end
+  end
+
+  @doc "Parse an `/api/models/<id>?blobs=true` body (test seam)."
+  @spec parse_repo(map()) :: repo()
+  def parse_repo(body) do
+    files =
+      (body["siblings"] || [])
+      |> Enum.map(&{&1["rfilename"] || "", &1["size"] || 0})
+      |> Enum.filter(fn {name, _} -> String.ends_with?(String.downcase(name), ".gguf") end)
+
+    {mmproj, weights} =
+      Enum.split_with(files, fn {n, _} -> String.contains?(String.downcase(n), "mmproj") end)
+
+    quants =
+      weights
+      |> Enum.group_by(fn {name, _} -> quant_of(name) end)
+      |> Enum.reject(fn {q, _} -> is_nil(q) end)
+      |> Enum.map(fn {q, fs} ->
+        %{
+          quant: q,
+          bytes: Enum.sum(Enum.map(fs, &elem(&1, 1))),
+          files: Enum.map(fs, &elem(&1, 0))
+        }
+      end)
+      |> Enum.sort_by(& &1.bytes)
+
+    %{
+      id: body["id"] || body["modelId"] || "",
+      downloads: body["downloads"] || 0,
+      tags: body["tags"] || [],
+      quants: quants,
+      mmproj_bytes: mmproj |> Enum.map(&elem(&1, 1)) |> Enum.max(fn -> 0 end)
+    }
+  end
+
+  @doc "The quant label in a GGUF filename, e.g. `Q4_K_M`, `IQ4_XS`, `Q8_0`; nil if none."
+  @spec quant_of(String.t()) :: String.t() | nil
+  def quant_of(filename) do
+    base = filename |> Path.basename() |> String.upcase()
+
+    case Regex.run(
+           ~r/(?:^|[-._])(IQ\d_[A-Z]+|Q\d_K_[SML]|Q\d_K|Q\d_\d|MXFP4|BF16|F16|F32)(?:[-._]|$)/,
+           base
+         ) do
+      [_, q] -> q
+      _ -> nil
+    end
+  end
+
+  @doc "Pick the file group for `quant` (case-insensitive) from a parsed repo."
+  @spec quant(repo(), String.t()) :: quant_file() | nil
+  def quant(%{quants: quants}, wanted) do
+    w = String.upcase(wanted)
+    Enum.find(quants, &(&1.quant == w))
+  end
+
+  # ── cache ───────────────────────────────────────────────────────────────
+
+  defp with_cache(key, opts, fun) do
+    path = Path.join(cache_dir(), key <> ".json")
+
+    fresh? =
+      case File.stat(path, time: :posix) do
+        {:ok, %{mtime: m}} -> System.os_time(:second) - m < @cache_ttl_s
+        _ -> false
+      end
+
+    with false <- Keyword.get(opts, :refresh, false) == false and fresh? and read_cache(path),
+         {:ok, value} <- fun.() do
+      write_cache(path, value)
+      {:ok, value}
+    else
+      {:ok, cached} -> {:ok, cached}
+      {:error, _} = e -> e
+    end
+  end
+
+  defp read_cache(path) do
+    with {:ok, raw} <- File.read(path),
+         {:ok, map} <- Jason.decode(raw, keys: :atoms) do
+      {:ok, map}
+    else
+      _ -> false
+    end
+  end
+
+  defp write_cache(path, value) do
+    File.mkdir_p!(Path.dirname(path))
+    File.write(path, Jason.encode!(value))
+  rescue
+    _ -> :ok
+  end
+
+  defp cache_dir do
+    Application.get_env(:optimal_system_agent, :hf_cache_dir) ||
+      Path.join([
+        System.get_env("OSA_HOME") || Path.join(System.user_home!(), ".osa"),
+        "cache",
+        "hf"
+      ])
+  end
+
+  defp safe(id), do: String.replace(id, ~r/[^A-Za-z0-9._-]/, "_")
+end

--- a/lib/optimal_system_agent/local_models/installer.ex
+++ b/lib/optimal_system_agent/local_models/installer.ex
@@ -1,0 +1,133 @@
+defmodule OptimalSystemAgent.LocalModels.Installer do
+  @moduledoc """
+  Background install jobs for `LocalModels` with pollable progress — the
+  HTTP/TUI side of `/models install`.
+
+  A pull takes minutes; an HTTP request cannot. `start/2` kicks off
+  `LocalModels.install/2` in a task and returns a job id; `status/1` reports
+  where it is (`:pulling` with bytes, `:benchmarking`, `:done` with the
+  measured speed, or `:error`). Jobs live in a public ETS table created on
+  first use, so nothing in the supervision tree needs to know about them.
+  One job per tag at a time.
+  """
+
+  alias OptimalSystemAgent.LocalModels
+
+  @table :osa_local_model_jobs
+
+  @type status :: %{
+          id: String.t(),
+          ref: String.t(),
+          tag: String.t() | nil,
+          state: :pulling | :benchmarking | :done | :error,
+          status: String.t(),
+          completed: non_neg_integer(),
+          total: non_neg_integer(),
+          bench: map() | nil,
+          error: String.t() | nil,
+          started_at: integer(),
+          updated_at: integer()
+        }
+
+  @doc """
+  Start pulling `ref` (catalog id / hf.co tag / Ollama tag) at `quant`.
+  `run: false` (tests) records the job without spawning the task.
+  """
+  @spec start(String.t(), String.t() | nil, keyword()) :: {:ok, String.t()} | {:error, String.t()}
+  def start(ref, quant \\ nil, opts \\ []) when is_binary(ref) do
+    ensure_table()
+
+    if Enum.any?(list(), &(&1.ref == ref and &1.state in [:pulling, :benchmarking])) do
+      {:error, "already installing #{ref}"}
+    else
+      id = "job-" <> Base.url_encode64(:crypto.strong_rand_bytes(6), padding: false)
+      now = System.system_time(:millisecond)
+
+      put(%{
+        id: id,
+        ref: ref,
+        tag: nil,
+        state: :pulling,
+        status: "starting",
+        completed: 0,
+        total: 0,
+        bench: nil,
+        error: nil,
+        started_at: now,
+        updated_at: now
+      })
+
+      if Keyword.get(opts, :run, true), do: Task.start(fn -> run(id, ref, quant) end)
+      {:ok, id}
+    end
+  end
+
+  @doc "Current state of a job, or nil."
+  @spec status(String.t()) :: status() | nil
+  def status(id) when is_binary(id) do
+    ensure_table()
+
+    case :ets.lookup(@table, id) do
+      [{^id, job}] -> job
+      _ -> nil
+    end
+  end
+
+  @doc "Every job this node has seen (finished ones stay until `forget/1`)."
+  @spec list() :: [status()]
+  def list do
+    ensure_table()
+    @table |> :ets.tab2list() |> Enum.map(&elem(&1, 1)) |> Enum.sort_by(& &1.started_at, :desc)
+  end
+
+  @spec forget(String.t()) :: :ok
+  def forget(id) do
+    ensure_table()
+    :ets.delete(@table, id)
+    :ok
+  end
+
+  # Test seam: run the job body synchronously with an injectable installer.
+  @doc false
+  def run(id, ref, quant, install_fun \\ &LocalModels.install/2) do
+    on_progress = fn %{status: status, completed: c, total: t} ->
+      update(id, fn job ->
+        state = if status == "success", do: :benchmarking, else: :pulling
+        %{job | state: state, status: status, completed: c, total: t}
+      end)
+    end
+
+    case install_fun.(ref, on_progress: on_progress, quant: quant) do
+      {:ok, %{tag: tag, bench: bench}} ->
+        update(id, &%{&1 | state: :done, status: "done", tag: tag, bench: bench})
+
+      {:error, reason} ->
+        update(id, &%{&1 | state: :error, status: "failed", error: to_string(reason)})
+    end
+  rescue
+    e -> update(id, &%{&1 | state: :error, status: "failed", error: Exception.message(e)})
+  end
+
+  defp update(id, fun) do
+    case status(id) do
+      nil -> :ok
+      job -> put(fun.(%{job | updated_at: System.system_time(:millisecond)}))
+    end
+  end
+
+  defp put(job), do: :ets.insert(@table, {job.id, job})
+
+  defp ensure_table do
+    case :ets.whereis(@table) do
+      :undefined ->
+        try do
+          :ets.new(@table, [:named_table, :public, :set, read_concurrency: true])
+        rescue
+          ArgumentError -> @table
+        end
+
+      _ ->
+        @table
+    end
+  end
+end

--- a/lib/optimal_system_agent/local_models/ollama_admin.ex
+++ b/lib/optimal_system_agent/local_models/ollama_admin.ex
@@ -1,0 +1,320 @@
+defmodule OptimalSystemAgent.LocalModels.OllamaAdmin do
+  @moduledoc """
+  Management side of the local Ollama daemon: what is installed, what is
+  loaded in VRAM, pull / delete / alias, load / unload, and a short decode
+  benchmark. The chat side lives in `Providers.Ollama`; this module never
+  generates a reply.
+
+  Every call goes to `Providers.Ollama.local_daemon_url/0` — the daemon on
+  THIS machine, regardless of what `OLLAMA_URL` says.
+  """
+
+  alias OptimalSystemAgent.Providers.Ollama
+
+  @type installed :: %{
+          name: String.t(),
+          size_bytes: non_neg_integer(),
+          modified: String.t() | nil,
+          family: String.t() | nil,
+          params: String.t() | nil,
+          quant: String.t() | nil,
+          digest: String.t() | nil,
+          remote: boolean()
+        }
+
+  @type loaded :: %{
+          name: String.t(),
+          size_bytes: non_neg_integer(),
+          vram_bytes: non_neg_integer(),
+          expires_at: String.t() | nil
+        }
+
+  @type details :: %{
+          name: String.t(),
+          capabilities: [String.t()],
+          family: String.t() | nil,
+          params: String.t() | nil,
+          quant: String.t() | nil,
+          context_length: non_neg_integer() | nil,
+          params_count: non_neg_integer() | nil,
+          kv_bytes_per_token: non_neg_integer() | nil,
+          model_info: map()
+        }
+
+  @spec url() :: String.t()
+  def url, do: Ollama.local_daemon_url()
+
+  # ── read ────────────────────────────────────────────────────────────────
+
+  @doc "Models the daemon has on disk (`/api/tags`). Cloud tags are flagged `remote`."
+  @spec installed(keyword()) :: {:ok, [installed()]} | {:error, String.t()}
+  def installed(req_opts \\ []) do
+    case get("/api/tags", req_opts) do
+      {:ok, %{"models" => models}} when is_list(models) ->
+        {:ok,
+         Enum.map(models, fn m ->
+           d = m["details"] || %{}
+
+           name = m["name"] || m["model"]
+
+           %{
+             name: name,
+             size_bytes: m["size"] || 0,
+             modified: m["modified_at"],
+             family: d["family"],
+             params: d["parameter_size"],
+             quant: quant_of(d["quantization_level"], name),
+             digest: m["digest"],
+             remote: is_binary(m["remote_host"]) or cloud_tag?(name || "")
+           }
+         end)}
+
+      other ->
+        err(other)
+    end
+  end
+
+  @doc "Models currently resident (`/api/ps`)."
+  @spec loaded(keyword()) :: {:ok, [loaded()]} | {:error, String.t()}
+  def loaded(req_opts \\ []) do
+    case get("/api/ps", req_opts) do
+      {:ok, %{"models" => models}} when is_list(models) ->
+        {:ok,
+         Enum.map(models, fn m ->
+           %{
+             name: m["name"] || m["model"],
+             size_bytes: m["size"] || 0,
+             vram_bytes: m["size_vram"] || 0,
+             expires_at: m["expires_at"]
+           }
+         end)}
+
+      other ->
+        err(other)
+    end
+  end
+
+  @doc "Capabilities and GGUF metadata for one installed model (`/api/show`)."
+  @spec show(String.t(), keyword()) :: {:ok, details()} | {:error, String.t()}
+  def show(name, req_opts \\ []) when is_binary(name) do
+    case post("/api/show", %{model: name}, req_opts) do
+      {:ok, %{} = body} ->
+        d = body["details"] || %{}
+        info = body["model_info"] || %{}
+        arch = info["general.architecture"]
+
+        {:ok,
+         %{
+           name: name,
+           capabilities: body["capabilities"] || [],
+           family: d["family"] || arch,
+           params: d["parameter_size"],
+           quant: d["quantization_level"],
+           context_length: if(is_binary(arch), do: info["#{arch}.context_length"]),
+           params_count: info["general.parameter_count"],
+           kv_bytes_per_token: OptimalSystemAgent.LocalModels.Fit.kv_from_model_info(info),
+           model_info: info
+         }}
+
+      other ->
+        err(other)
+    end
+  end
+
+  # ── write ───────────────────────────────────────────────────────────────
+
+  @doc """
+  Pull a model, streaming progress to `on_progress` as
+  `%{status, completed, total}` maps. Blocks until done. A pull that Ollama
+  reports as an error (bad tag, no such quant, no space) is returned as
+  `{:error, message}`.
+  """
+  @spec pull(String.t(), (map() -> any()), keyword()) :: :ok | {:error, String.t()}
+  def pull(name, on_progress \\ fn _ -> :ok end, req_opts \\ []) when is_binary(name) do
+    acc = %{buffer: "", error: nil, done: false}
+
+    result =
+      Req.post(
+        [
+          url: url() <> "/api/pull",
+          json: %{model: name, stream: true},
+          receive_timeout: :timer.hours(6),
+          retry: false,
+          into: fn {:data, data}, {req, resp} ->
+            state = Process.get(:osa_pull_acc, acc)
+            {lines, rest} = split_lines(state.buffer <> data)
+
+            state =
+              Enum.reduce(lines, %{state | buffer: rest}, fn line, st ->
+                case Jason.decode(line) do
+                  {:ok, %{"error" => e}} ->
+                    %{st | error: to_string(e)}
+
+                  {:ok, %{"status" => status} = ev} ->
+                    on_progress.(%{
+                      status: status,
+                      completed: ev["completed"] || 0,
+                      total: ev["total"] || 0
+                    })
+
+                    if status == "success", do: %{st | done: true}, else: st
+
+                  _ ->
+                    st
+                end
+              end)
+
+            Process.put(:osa_pull_acc, state)
+            {:cont, {req, resp}}
+          end
+        ] ++ req_opts
+      )
+
+    state = Process.get(:osa_pull_acc, acc)
+    Process.delete(:osa_pull_acc)
+
+    case {result, state} do
+      {_, %{error: e}} when is_binary(e) -> {:error, e}
+      {{:ok, %{status: 200}}, %{done: true}} -> :ok
+      {{:ok, %{status: 200}}, _} -> {:error, "pull ended without success status"}
+      {{:ok, %{status: s}}, _} -> {:error, "HTTP #{s}"}
+      {{:error, reason}, _} -> {:error, describe(reason)}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  @doc "Remove a model from disk (`/api/delete`)."
+  @spec delete(String.t(), keyword()) :: :ok | {:error, String.t()}
+  def delete(name, req_opts \\ []) when is_binary(name) do
+    case request(:delete, "/api/delete", %{model: name}, req_opts) do
+      {:ok, _} -> :ok
+      other -> err(other)
+    end
+  end
+
+  @doc "Add a second tag for a model, sharing its blobs (`/api/copy`)."
+  @spec copy(String.t(), String.t(), keyword()) :: :ok | {:error, String.t()}
+  def copy(from, to, req_opts \\ []) when is_binary(from) and is_binary(to) do
+    case post("/api/copy", %{source: from, destination: to}, req_opts) do
+      {:ok, _} -> :ok
+      other -> err(other)
+    end
+  end
+
+  @doc "Load into VRAM and keep it there (`keep_alive: -1`) without generating."
+  @spec load(String.t(), keyword()) :: :ok | {:error, String.t()}
+  def load(name, req_opts \\ []) when is_binary(name) do
+    case post(
+           "/api/generate",
+           %{model: name, keep_alive: -1},
+           req_opts ++ [receive_timeout: :timer.minutes(5)]
+         ) do
+      {:ok, _} -> :ok
+      other -> err(other)
+    end
+  end
+
+  @doc "Evict from VRAM now (`keep_alive: 0`)."
+  @spec unload(String.t(), keyword()) :: :ok | {:error, String.t()}
+  def unload(name, req_opts \\ []) when is_binary(name) do
+    case post("/api/generate", %{model: name, keep_alive: 0}, req_opts) do
+      {:ok, _} -> :ok
+      other -> err(other)
+    end
+  end
+
+  @doc """
+  Measured decode speed: generate `n` tokens and read Ollama's own timing
+  (`eval_count / eval_duration`). Returns tokens/s for decode and prompt
+  processing, plus load time. Loads the model if it is not resident.
+  """
+  @spec bench(String.t(), pos_integer(), keyword()) ::
+          {:ok, %{decode_tps: float(), prompt_tps: float() | nil, load_ms: non_neg_integer()}}
+          | {:error, String.t()}
+  def bench(name, n \\ 64, req_opts \\ []) when is_binary(name) do
+    body = %{
+      model: name,
+      prompt: "Write a long, detailed paragraph about the history of computing.",
+      stream: false,
+      options: %{num_predict: n, temperature: 0},
+      think: false
+    }
+
+    case post("/api/generate", body, req_opts ++ [receive_timeout: :timer.minutes(10)]) do
+      {:ok, %{"eval_count" => count, "eval_duration" => dur} = r}
+      when is_integer(count) and is_integer(dur) and dur > 0 ->
+        prompt_tps =
+          case {r["prompt_eval_count"], r["prompt_eval_duration"]} do
+            {c, d} when is_integer(c) and is_integer(d) and d > 0 ->
+              Float.round(c / (d / 1.0e9), 1)
+
+            _ ->
+              nil
+          end
+
+        {:ok,
+         %{
+           decode_tps: Float.round(count / (dur / 1.0e9), 1),
+           prompt_tps: prompt_tps,
+           load_ms: div(r["load_duration"] || 0, 1_000_000)
+         }}
+
+      {:ok, _} ->
+        {:error, "no timing in response"}
+
+      other ->
+        err(other)
+    end
+  end
+
+  # ── helpers ─────────────────────────────────────────────────────────────
+
+  defp get(path, req_opts) do
+    request(:get, path, nil, req_opts)
+  end
+
+  defp post(path, body, req_opts) do
+    request(:post, path, body, req_opts)
+  end
+
+  defp request(method, path, body, req_opts) do
+    opts =
+      [method: method, url: url() <> path, receive_timeout: 15_000, retry: false] ++
+        if(body, do: [json: body], else: []) ++ req_opts
+
+    case Req.request(opts) do
+      {:ok, %{status: s, body: body}} when s in 200..299 -> {:ok, body}
+      {:ok, %{status: s, body: %{"error" => e}}} -> {:error, "HTTP #{s}: #{e}"}
+      {:ok, %{status: s}} -> {:error, "HTTP #{s}"}
+      {:error, reason} -> {:error, describe(reason)}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp err({:error, msg}) when is_binary(msg), do: {:error, msg}
+  defp err(other), do: {:error, inspect(other)}
+
+  defp describe(%{reason: :econnrefused}), do: "Ollama is not running at #{url()}"
+  defp describe(%{__exception__: true} = e), do: Exception.message(e)
+  defp describe(other), do: inspect(other)
+
+  defp split_lines(data) do
+    parts = String.split(data, "\n")
+    {Enum.drop(parts, -1), List.last(parts) || ""}
+  end
+
+  defp cloud_tag?(name), do: OptimalSystemAgent.Providers.OllamaCloud.cloud_tag?(name)
+
+  # Ollama reports `unknown` for a GGUF pulled from Hugging Face; the quant is
+  # in the tag (`hf.co/<repo>:Q4_K_M`).
+  defp quant_of(level, name) when level in [nil, "", "unknown"] and is_binary(name) do
+    case OptimalSystemAgent.LocalModels.Catalog.split_tag(name) do
+      {_, q} when is_binary(q) and q != "latest" -> String.upcase(q)
+      _ -> nil
+    end
+  end
+
+  defp quant_of(level, _name), do: level
+end

--- a/lib/optimal_system_agent/onboarding.ex
+++ b/lib/optimal_system_agent/onboarding.ex
@@ -2938,9 +2938,24 @@ defmodule OptimalSystemAgent.Onboarding do
 
   # ── Private: Model Fetching ──────────────────────────────────────────
 
+  defp local_model_notes do
+    OptimalSystemAgent.LocalModels.overview().installed
+    |> Map.new(&{&1.tag, OptimalSystemAgent.LocalModels.note(&1)})
+  rescue
+    _ -> %{}
+  catch
+    :exit, _ -> %{}
+  end
+
   defp fetch_ollama_models(url) do
     case Req.get("#{url}/api/tags", receive_timeout: 10_000) do
       {:ok, %{status: 200, body: %{"models" => models}}} when is_list(models) ->
+        # The picker renders `note` under each row: say whether the model fits
+        # THIS machine, how fast it decodes (measured beats estimated) and
+        # what it can do. `LocalModels` never raises, so a hiccup there costs
+        # the notes, not the list.
+        notes = local_model_notes()
+
         parsed =
           Enum.map(models, fn m ->
             name = m["name"] || m["model"] || "unknown"
@@ -2953,7 +2968,8 @@ defmodule OptimalSystemAgent.Onboarding do
               ctx: 0,
               tools: true,
               size_bytes: size,
-              params: params
+              params: params,
+              note: Map.get(notes, name)
             }
           end)
 

--- a/lib/optimal_system_agent/providers/registry.ex
+++ b/lib/optimal_system_agent/providers/registry.ex
@@ -1903,7 +1903,7 @@ defmodule OptimalSystemAgent.Providers.Registry do
 
   defp apply_local_ceiling(trained, model, provider) do
     if provider in [:ollama, :lmstudio, :llamacpp] and not ollama_cloud_model?(model) do
-      ceiling = Application.get_env(:optimal_system_agent, :ollama_num_ctx, 32_768)
+      ceiling = OptimalSystemAgent.LocalModels.num_ctx_ceiling(model)
 
       # Floor against the model's REAL trained window too, not just the config
       # ceiling. A static/catalog entry (or a family prefix match) can advertise

--- a/priv/models/local_catalog.json
+++ b/priv/models/local_catalog.json
@@ -1,0 +1,370 @@
+{
+  "version": 1,
+  "note": "Curated local GGUF models for the /models picker. Repo ids are Hugging Face repos pulled as hf.co/<repo>:<quant>. Sizes are fetched live from the Hub; params_b/active_params_b drive the offline fit estimate.",
+  "models": [
+    {
+      "id": "superqwen-abliterated",
+      "name": "SuperQwen 3.8 27B abliterated",
+      "repo": "Jiunsong/SuperQwen3.8-27b-abliterated-GGUF",
+      "family": "qwen3.5",
+      "params_b": 27,
+      "quant": "Q4_K_M",
+      "quants": [
+        "Q4_K_M"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking",
+        "vision"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "general",
+        "vision"
+      ],
+      "blurb": "Qwen 3.8 27B with refusals removed. Strong all-rounder; vision + tools."
+    },
+    {
+      "id": "huihui-qwen3.8-27b",
+      "name": "Huihui Qwen 3.8 27B abliterated",
+      "repo": "huihui-ai/Huihui-Qwen3.8-27B-abliterated-GGUF",
+      "family": "qwen3.5",
+      "params_b": 27,
+      "quant": "Q4_K",
+      "quants": [
+        "Q2_K",
+        "Q3_K",
+        "Q4_K",
+        "Q5_K",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking",
+        "vision"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "general",
+        "vision"
+      ],
+      "blurb": "The most-downloaded 27B abliteration. Q4_K fits a 24 GB card; Q6_K needs ~23 GB."
+    },
+    {
+      "id": "qwen3.8-27b-uncensored",
+      "name": "Qwen 3.8 27B Uncensored",
+      "repo": "JonathanColetti/Qwen3.8-27B-Uncensored-GGUF",
+      "family": "qwen3.5",
+      "params_b": 27,
+      "quant": "Q4_K_M",
+      "quants": [
+        "IQ4_XS",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking",
+        "vision"
+      ],
+      "context": 262144,
+      "tags": [
+        "uncensored",
+        "general",
+        "vision"
+      ],
+      "blurb": "Full quant ladder from IQ4_XS to Q8_0 \u2014 pick the one that fits."
+    },
+    {
+      "id": "huihui-qwen3.6-35b-a3b",
+      "name": "Huihui Qwen 3.6 35B-A3B abliterated (MoE)",
+      "repo": "huihui-ai/Huihui-Qwen3.6-35B-A3B-abliterated-MTP-GGUF",
+      "family": "qwen3.6-moe",
+      "params_b": 35,
+      "active_params_b": 3,
+      "quant": "Q3_K",
+      "quants": [
+        "Q2_K",
+        "Q3_K",
+        "Q4_K",
+        "Q5_K",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking",
+        "vision"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "moe",
+        "fast"
+      ],
+      "blurb": "Mixture-of-experts: 35B of knowledge, 3B active per token \u2014 decodes several times faster than a dense 27B."
+    },
+    {
+      "id": "huihui-qwen3.5-9b",
+      "name": "Huihui Qwen 3.5 9B abliterated",
+      "repo": "mradermacher/Huihui-Qwen3.5-9B-abliterated-GGUF",
+      "family": "qwen3.5",
+      "params_b": 9,
+      "quant": "Q5_K_M",
+      "quants": [
+        "Q3_K_M",
+        "IQ4_XS",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking",
+        "vision"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "small",
+        "fast"
+      ],
+      "blurb": "Fits 8 GB cards at Q4. Fast, capable, tool-calling."
+    },
+    {
+      "id": "qwen3-vl-8b-abliterated",
+      "name": "Qwen3-VL 8B abliterated",
+      "repo": "mradermacher/Qwen3-VL-8B-Instruct-abliterated-GGUF",
+      "family": "qwen3-vl",
+      "params_b": 8,
+      "quant": "Q5_K_M",
+      "quants": [
+        "Q3_K_M",
+        "IQ4_XS",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "vision"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "vision",
+        "small"
+      ],
+      "blurb": "Vision-first 8B. Screenshots, documents, images \u2014 no refusals."
+    },
+    {
+      "id": "gemma4-12b-heretic",
+      "name": "Gemma 4 12B heretic abliterated",
+      "repo": "culturerevolt/gemma-4-12b-heretic-abliterated-GGUF",
+      "family": "gemma4",
+      "params_b": 12,
+      "quant": "Q5_K_M",
+      "quants": [
+        "IQ4_XS",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "vision"
+      ],
+      "context": 131072,
+      "tags": [
+        "abliterated",
+        "gemma"
+      ],
+      "blurb": "Google's Gemma 4 12B with the guardrails stripped. Good prose."
+    },
+    {
+      "id": "supergemma4-26b-uncensored",
+      "name": "SuperGemma 4 26B-A4B uncensored (MoE)",
+      "repo": "Jiunsong/supergemma4-26b-uncensored-gguf-v2",
+      "family": "gemma4-moe",
+      "params_b": 26,
+      "active_params_b": 4,
+      "quant": "Q4_K_M",
+      "quants": [
+        "Q4_K_M"
+      ],
+      "capabilities": [
+        "tools",
+        "vision"
+      ],
+      "context": 131072,
+      "tags": [
+        "uncensored",
+        "gemma",
+        "moe",
+        "fast"
+      ],
+      "blurb": "Gemma 4 MoE \u2014 26B total, 4B active. Fast decode with a 26B-class brain."
+    },
+    {
+      "id": "llama3.1-8b-abliterated",
+      "name": "Llama 3.1 8B Instruct abliterated",
+      "repo": "mlabonne/Meta-Llama-3.1-8B-Instruct-abliterated-GGUF",
+      "family": "llama3",
+      "params_b": 8,
+      "quant": "Q5_K_M",
+      "quants": [
+        "Q3_K_M",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools"
+      ],
+      "context": 131072,
+      "tags": [
+        "abliterated",
+        "llama",
+        "small"
+      ],
+      "blurb": "The classic abliteration by mlabonne. Light, dependable, tool-calling."
+    },
+    {
+      "id": "llama3.3-70b-abliterated",
+      "name": "Llama 3.3 70B Instruct abliterated",
+      "repo": "bartowski/Llama-3.3-70B-Instruct-abliterated-GGUF",
+      "family": "llama3",
+      "params_b": 70,
+      "quant": "Q4_K_M",
+      "quants": [
+        "Q3_K_M",
+        "IQ4_XS",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools"
+      ],
+      "context": 131072,
+      "tags": [
+        "abliterated",
+        "llama",
+        "large"
+      ],
+      "blurb": "70B \u2014 needs ~42 GB at Q4. Partial offload on a 24 GB card; fits a 48 GB card or a Mac with 64 GB+."
+    },
+    {
+      "id": "qwen3-coder-next-abliterated",
+      "name": "Qwen3 Coder Next abliterated (MoE)",
+      "repo": "bartowski/huihui-ai_Qwen3-Coder-Next-abliterated-GGUF",
+      "family": "qwen3-moe",
+      "params_b": 80,
+      "active_params_b": 3,
+      "quant": "IQ4_XS",
+      "quants": [
+        "Q3_K_M",
+        "IQ4_XS",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "coding",
+        "moe",
+        "large"
+      ],
+      "blurb": "Coding MoE, 3B active. ~43 GB at IQ4_XS \u2014 a 24 GB card runs it with offload, still quick thanks to the sparse decode."
+    },
+    {
+      "id": "cyberstrike-offsec-35b",
+      "name": "CyberStrike OffSec 35B abliterated (MoE)",
+      "repo": "huihui-ai/Huihui-CyberStrike-OffSec-35B-abliterated-GGUF",
+      "family": "qwen3.6-moe",
+      "params_b": 35,
+      "active_params_b": 3,
+      "quant": "Q3_K",
+      "quants": [
+        "Q2_K",
+        "Q3_K",
+        "Q4_K",
+        "Q5_K",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking"
+      ],
+      "context": 262144,
+      "tags": [
+        "abliterated",
+        "security",
+        "moe"
+      ],
+      "blurb": "Offensive-security tuned MoE. Pairs with OSA's pentest skills."
+    },
+    {
+      "id": "lfm2.5-2.6b-heretic",
+      "name": "LFM 2.5 2.6B heretic abliterated",
+      "repo": "Abiray/LFM2.5-2.6B-Heretic-Abliterated-GGUF",
+      "family": "lfm2",
+      "params_b": 2.6,
+      "quant": "Q8_0",
+      "quants": [
+        "Q3_K_M",
+        "Q4_K_M",
+        "Q5_K_M",
+        "Q6_K",
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools"
+      ],
+      "context": 32768,
+      "tags": [
+        "abliterated",
+        "tiny",
+        "fast"
+      ],
+      "blurb": "Under 3 GB. Runs on anything, including CPU-only laptops."
+    },
+    {
+      "id": "deepseek-v4-flash-abliterated",
+      "name": "DeepSeek V4 Flash abliterated",
+      "repo": "huihui-ai/Huihui-DeepSeek-V4-Flash-0731-abliterated-GGUF",
+      "family": "deepseek",
+      "params_b": 16,
+      "quant": "Q8_0",
+      "quants": [
+        "Q8_0"
+      ],
+      "capabilities": [
+        "tools",
+        "thinking"
+      ],
+      "context": 131072,
+      "tags": [
+        "abliterated",
+        "reasoning"
+      ],
+      "blurb": "DeepSeek's small reasoning model, refusals removed. Q8 only."
+    }
+  ]
+}

--- a/priv/rust/tui/src/app/handle_actions.rs
+++ b/priv/rust/tui/src/app/handle_actions.rs
@@ -3066,3 +3066,80 @@ mod queue_gate_tests {
         assert!(queue_may_drain(AppState::Idle, true));
     }
 }
+
+
+// ── Local model catalog (picker screens) ────────────────────────────────────
+impl App {
+    /// GET /models/local → `LocalCatalogLoaded`.
+    pub(crate) fn load_local_catalog(&self) {
+        let client = self.client.clone();
+        let tx = self.event_tx.clone();
+        tokio::spawn(async move {
+            let result = client.local_models().await.map_err(|e| e.to_string());
+            let _ = tx.send(Event::Backend(BackendEvent::LocalCatalogLoaded(result)));
+        });
+    }
+
+    /// GET /models/local/info → `LocalModelInfoLoaded`.
+    pub(crate) fn load_local_info(&self, reff: String) {
+        let client = self.client.clone();
+        let tx = self.event_tx.clone();
+        tokio::spawn(async move {
+            let result = client.local_model_info(&reff).await.map_err(|e| e.to_string());
+            let _ = tx.send(Event::Backend(BackendEvent::LocalModelInfoLoaded(result)));
+        });
+    }
+
+    /// POST /models/local/install, then poll the job once a second until it
+    /// reaches `done` or `error`. A single failed poll is not a failed pull.
+    pub(crate) fn install_local_model(&self, reff: String, quant: Option<String>) {
+        let client = self.client.clone();
+        let tx = self.event_tx.clone();
+        tokio::spawn(async move {
+            let started = match client.local_model_install(&reff, quant.as_deref()).await {
+                Ok(s) => s,
+                Err(e) => {
+                    let _ = tx.send(Event::Backend(BackendEvent::LocalInstallUpdate(Err(
+                        e.to_string(),
+                    ))));
+                    return;
+                }
+            };
+            let id = started.job_id;
+            if id.is_empty() {
+                let _ = tx.send(Event::Backend(BackendEvent::LocalInstallUpdate(Err(
+                    "backend returned no job id".to_string(),
+                ))));
+                return;
+            }
+            let mut ticker = tokio::time::interval(std::time::Duration::from_millis(1000));
+            let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(6 * 3600);
+            loop {
+                ticker.tick().await;
+                if tokio::time::Instant::now() >= deadline {
+                    return;
+                }
+                match client.local_model_install_status(&id).await {
+                    Ok(job) => {
+                        let done = matches!(job.state.as_str(), "done" | "error");
+                        let _ = tx.send(Event::Backend(BackendEvent::LocalInstallUpdate(Ok(job))));
+                        if done {
+                            return;
+                        }
+                    }
+                    Err(_) => continue,
+                }
+            }
+        });
+    }
+
+    /// POST /models/local/remove → `LocalModelRemoved`.
+    pub(crate) fn remove_local_model(&self, tag: String) {
+        let client = self.client.clone();
+        let tx = self.event_tx.clone();
+        tokio::spawn(async move {
+            let result = client.local_model_remove(&tag).await.map_err(|e| e.to_string());
+            let _ = tx.send(Event::Backend(BackendEvent::LocalModelRemoved(result)));
+        });
+    }
+}

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -1782,6 +1782,35 @@ impl App {
             }
 
             // === Provider-first picker: dynamic model list loaded ===
+            BackendEvent::LocalCatalogLoaded(result) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.set_local_catalog(result);
+                }
+            }
+            BackendEvent::LocalModelInfoLoaded(result) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.set_local_info(result);
+                }
+            }
+            BackendEvent::LocalInstallUpdate(result) => {
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.set_local_job(result);
+                }
+            }
+            BackendEvent::LocalModelRemoved(result) => {
+                let msg = match &result {
+                    Ok(tag) => Some((format!("Removed {}", tag), crate::components::toast::ToastLevel::Info)),
+                    Err(e) => Some((format!("Remove failed: {}", e), crate::components::toast::ToastLevel::Error)),
+                };
+                if let Some(picker) = self.model_picker.as_mut() {
+                    picker.set_local_removed(result);
+                }
+                if let Some((m, lvl)) = msg {
+                    self.toasts.push(m, lvl);
+                }
+                // The list is stale now; refetch it.
+                self.load_local_catalog();
+            }
             BackendEvent::ProviderModelsLoaded(result) => {
                 if let Some(picker) = self.model_picker.as_mut() {
                     match result {

--- a/priv/rust/tui/src/app/handle_dialogs.rs
+++ b/priv/rust/tui/src/app/handle_dialogs.rs
@@ -133,6 +133,13 @@ impl App {
                 } => {
                     self.load_provider_models(provider, base_url, api_key);
                 }
+                // Local catalog: all non-terminal — the picker owns these screens.
+                ModelPickerAction::LoadLocalCatalog => self.load_local_catalog(),
+                ModelPickerAction::LoadLocalInfo { reff } => self.load_local_info(reff),
+                ModelPickerAction::InstallLocal { reff, quant } => {
+                    self.install_local_model(reff, quant);
+                }
+                ModelPickerAction::RemoveLocal { tag } => self.remove_local_model(tag),
                 // Hotfix: retry the catalog+detection fetch on demand — the
                 // picker stays open (on the fallback catalog, if that's why
                 // Reload was needed) until the fresh data arrives and

--- a/priv/rust/tui/src/client/http.rs
+++ b/priv/rust/tui/src/client/http.rs
@@ -1952,3 +1952,59 @@ mod health_check_retry_tests {
         assert_eq!(percent_encode_query("a#b"), "a%23b");
     }
 }
+
+
+// === Local model manager (/models/local) ===
+impl ApiClient {
+    async fn local_json<T: serde::de::DeserializeOwned>(resp: reqwest::Response) -> Result<T> {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            let msg = serde_json::from_str::<serde_json::Value>(&text)
+                .ok()
+                .and_then(|v| v.get("error").and_then(|e| e.as_str()).map(|s| s.to_string()))
+                .unwrap_or_else(|| text.clone());
+            anyhow::bail!("{}", if msg.is_empty() { status.to_string() } else { msg });
+        }
+        Ok(serde_json::from_str(&text)?)
+    }
+
+    /// GET /models/local — hardware, installed + catalog with fit verdicts.
+    pub async fn local_models(&self) -> Result<LocalModelsResponse> {
+        let resp = self.get("/models/local").await?;
+        Self::local_json(resp).await
+    }
+
+    /// GET /models/local/info?ref= — one model, per-quant sizes and fit.
+    pub async fn local_model_info(&self, reff: &str) -> Result<LocalModelInfo> {
+        let resp = self
+            .get(&format!("/models/local/info?ref={}", Self::percent_encode(reff)))
+            .await?;
+        Self::local_json(resp).await
+    }
+
+    /// POST /models/local/install — start a pull job.
+    pub async fn local_model_install(
+        &self,
+        reff: &str,
+        quant: Option<&str>,
+    ) -> Result<LocalInstallStarted> {
+        let body = serde_json::json!({ "ref": reff, "quant": quant });
+        let resp = self.post_allow_status("/models/local/install", &body).await?;
+        Self::local_json(resp).await
+    }
+
+    /// GET /models/local/install/:id — poll a pull job.
+    pub async fn local_model_install_status(&self, id: &str) -> Result<LocalInstallJob> {
+        let resp = self.get(&format!("/models/local/install/{}", id)).await?;
+        Self::local_json(resp).await
+    }
+
+    /// POST /models/local/remove — delete a model from disk.
+    pub async fn local_model_remove(&self, tag: &str) -> Result<String> {
+        let body = serde_json::json!({ "tag": tag });
+        let resp = self.post_allow_status("/models/local/remove", &body).await?;
+        let v: serde_json::Value = Self::local_json(resp).await?;
+        Ok(v.get("removed").and_then(|s| s.as_str()).unwrap_or(tag).to_string())
+    }
+}

--- a/priv/rust/tui/src/client/types.rs
+++ b/priv/rust/tui/src/client/types.rs
@@ -1113,3 +1113,158 @@ mod health_update_parse_tests {
         assert!(h.update.is_none());
     }
 }
+
+
+// === Local model manager (/models/local) ===
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalFit {
+    #[serde(default)]
+    pub verdict: String,
+    #[serde(default)]
+    pub est_tps: Option<f64>,
+    #[serde(default)]
+    pub weights_bytes: u64,
+    #[serde(default)]
+    pub kv_bytes: u64,
+    #[serde(default)]
+    pub gpu_share: f64,
+    #[serde(default)]
+    pub ctx: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalHardware {
+    #[serde(default)]
+    pub summary: String,
+    #[serde(default)]
+    pub gpu: Option<String>,
+    #[serde(default)]
+    pub vram_bytes: u64,
+    #[serde(default)]
+    pub ram_bytes: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalModelRow {
+    #[serde(default)]
+    pub tag: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub installed: bool,
+    #[serde(default)]
+    pub loaded: bool,
+    #[serde(default)]
+    pub size_bytes: u64,
+    #[serde(default)]
+    pub params: Option<String>,
+    #[serde(default)]
+    pub quant: Option<String>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub fit: Option<LocalFit>,
+    #[serde(default)]
+    pub measured_tps: Option<f64>,
+    #[serde(default)]
+    pub catalog_id: Option<String>,
+    #[serde(default)]
+    pub blurb: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalModelsResponse {
+    #[serde(default)]
+    pub hardware: LocalHardware,
+    #[serde(default)]
+    pub ctx: u64,
+    #[serde(default)]
+    pub installed: Vec<LocalModelRow>,
+    #[serde(default)]
+    pub catalog: Vec<LocalModelRow>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalQuantRow {
+    #[serde(default)]
+    pub quant: String,
+    #[serde(default)]
+    pub bytes: u64,
+    #[serde(default)]
+    pub exact: bool,
+    #[serde(default)]
+    pub fit: Option<LocalFit>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalModelInfo {
+    #[serde(default)]
+    pub tag: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub installed: bool,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub family: Option<String>,
+    #[serde(default)]
+    pub params: Option<String>,
+    #[serde(default)]
+    pub quant: Option<String>,
+    #[serde(default)]
+    pub context_length: Option<u64>,
+    #[serde(default)]
+    pub size_bytes: u64,
+    #[serde(default)]
+    pub fit: Option<LocalFit>,
+    #[serde(default)]
+    pub quants: Vec<LocalQuantRow>,
+    #[serde(default)]
+    pub blurb: Option<String>,
+    #[serde(default)]
+    pub catalog_id: Option<String>,
+    #[serde(default)]
+    pub measured: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalBench {
+    #[serde(default)]
+    pub decode_tps: f64,
+    #[serde(default)]
+    pub prompt_tps: Option<f64>,
+    #[serde(default)]
+    pub load_ms: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalInstallJob {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default, rename = "ref")]
+    pub reff: String,
+    #[serde(default)]
+    pub tag: Option<String>,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub completed: u64,
+    #[serde(default)]
+    pub total: u64,
+    #[serde(default)]
+    pub bench: Option<LocalBench>,
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LocalInstallStarted {
+    #[serde(default)]
+    pub job_id: String,
+}

--- a/priv/rust/tui/src/dialogs/model_picker.rs
+++ b/priv/rust/tui/src/dialogs/model_picker.rs
@@ -16,6 +16,8 @@ use ratatui::{
 
 use crate::client::types::{DetectedProvidersResponse, OnboardingModel, OnboardingProvider};
 
+mod local;
+
 /// Narrowest the dialog is allowed to get before it simply takes the whole
 /// terminal. Also the width it used to be pinned at, unconditionally.
 const MIN_W: u16 = 82;
@@ -83,6 +85,14 @@ pub enum ModelPickerAction {
     /// Reachable from Providers mode any time (not just after a load
     /// failure) so a newcomer is never stuck on a stale/degraded list.
     Reload,
+    /// Fetch `/models/local` for the local catalog screen (non-terminal).
+    LoadLocalCatalog,
+    /// Fetch one local model's detail — quant ladder, fit, speed (non-terminal).
+    LoadLocalInfo { reff: String },
+    /// Start pulling a local model; the picker polls the job (non-terminal).
+    InstallLocal { reff: String, quant: Option<String> },
+    /// Delete an installed local model from disk (non-terminal).
+    RemoveLocal { tag: String },
 }
 
 // ── Internal enums ───────────────────────────────────────────────────────────
@@ -111,6 +121,14 @@ enum PickerMode {
     /// dialog. Owns the screen and the keyboard for the same reason
     /// `AccountLogin` does: the child's prompts have nowhere else to go.
     CliLogin,
+    /// Local model catalog: installed + curated, with fit for this machine.
+    LocalCatalog,
+    /// A `/models/local*` fetch is in flight.
+    LocalLoading,
+    /// One local model: quant ladder, pick one to install (or use it).
+    LocalDetail,
+    /// A pull is running; progress, then benchmark, then "use it".
+    LocalInstalling,
 }
 
 /// How the user proves who they are for a provider.
@@ -262,6 +280,19 @@ pub struct ModelPicker {
     /// the user knows they're on a degraded static catalog and can ask for
     /// a fresh one instead of silently being stuck on stale data.
     load_failed: bool,
+
+    /// Local catalog screen state (see `local.rs`).
+    local: Option<crate::client::types::LocalModelsResponse>,
+    local_cursor: usize,
+    local_scroll: usize,
+    local_info: Option<crate::client::types::LocalModelInfo>,
+    local_quant_cursor: usize,
+    local_job: Option<crate::client::types::LocalInstallJob>,
+    /// Armed by the first `d`; the second `d` on the same tag deletes.
+    local_pending_delete: Option<String>,
+    /// Where `Esc` from the catalog goes back to.
+    local_return: PickerMode,
+    local_error: Option<String>,
 }
 
 impl ModelPicker {
@@ -297,6 +328,15 @@ impl ModelPicker {
             usage_loaded: false,
             list_viewport: Cell::new((MAX_H as usize).saturating_sub(6)),
             load_failed: false,
+            local: None,
+            local_cursor: 0,
+            local_scroll: 0,
+            local_info: None,
+            local_quant_cursor: 0,
+            local_job: None,
+            local_pending_delete: None,
+            local_return: PickerMode::Providers,
+            local_error: None,
         }
     }
 
@@ -595,6 +635,10 @@ impl ModelPicker {
             PickerMode::KeyEntry => self.handle_key_entry_key(key),
             PickerMode::AccountLogin => self.handle_account_login_key(key),
             PickerMode::CliLogin => self.handle_cli_login_key(key),
+            PickerMode::LocalCatalog => self.handle_local_catalog_key(key),
+            PickerMode::LocalLoading => self.handle_local_loading_key(key),
+            PickerMode::LocalDetail => self.handle_local_detail_key(key),
+            PickerMode::LocalInstalling => self.handle_local_installing_key(key),
         }
     }
 
@@ -608,6 +652,9 @@ impl ModelPicker {
         }
         if key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
             return None;
+        }
+        if key.code == KeyCode::Tab {
+            return self.open_local_catalog();
         }
         let vis = self.visible_providers();
         let total = vis.len() + 1; // +1 for the "Default" row
@@ -1087,6 +1134,10 @@ impl ModelPicker {
                 self.mode = PickerMode::Providers;
                 self.filter.clear();
             }
+            // Tab from the Ollama Local list: browse and install more.
+            KeyCode::Tab if self.models_provider == "ollama_local" => {
+                return self.open_local_catalog();
+            }
             KeyCode::Up | KeyCode::Char('k') if self.filter.is_empty() => {
                 self.models_cursor = self.models_cursor.saturating_sub(1);
                 self.adjust_models_scroll();
@@ -1441,6 +1492,10 @@ impl ModelPicker {
                     c.draw(frame, dialog_rect, &theme);
                 }
             }
+            PickerMode::LocalCatalog => self.draw_local_catalog(frame, inner, &theme),
+            PickerMode::LocalLoading => self.draw_local_loading(frame, inner, &theme),
+            PickerMode::LocalDetail => self.draw_local_detail(frame, inner, &theme),
+            PickerMode::LocalInstalling => self.draw_local_installing(frame, inner, &theme),
         }
     }
 
@@ -1704,6 +1759,7 @@ impl ModelPicker {
                 ("↑↓/jk", "nav"),
                 ("Enter", "open"),
                 ("type", "filter"),
+                ("Tab", "local models"),
                 ("Ctrl+R", "reload"),
                 ("Esc", "cancel"),
             ],
@@ -1999,15 +2055,21 @@ impl ModelPicker {
             }
         }
 
+        let help: &[(&str, &str)] = if self.models_provider == "ollama_local" {
+            &[
+                ("↑↓/jk", "nav"),
+                ("Enter", "select"),
+                ("Tab", "browse & install more"),
+                ("Esc", "back"),
+            ]
+        } else {
+            &[("↑↓/jk", "nav"), ("Enter", "select"), ("Esc", "back")]
+        };
         self.draw_help(
             frame,
             inner,
             theme,
-            &[
-                ("↑↓/jk", "nav"),
-                ("Enter", "select"),
-                ("Esc", "back"),
-            ],
+            help,
         );
     }
 

--- a/priv/rust/tui/src/dialogs/model_picker/local.rs
+++ b/priv/rust/tui/src/dialogs/model_picker/local.rs
@@ -1,0 +1,794 @@
+//! Local model catalog screens inside the model picker.
+//!
+//! Four modes layered on the picker's state machine:
+//!
+//! * `LocalCatalog`    — installed models, then the curated catalog, each with
+//!                       a fit badge for THIS machine, tok/s, capabilities.
+//! * `LocalLoading`    — a fetch is in flight (catalog or one model's detail).
+//! * `LocalDetail`     — one model: quant ladder with size + fit + est. tok/s;
+//!                       pick a quant and install, or use it if installed.
+//! * `LocalInstalling` — the pull, with a progress bar, then the benchmark
+//!                       result and a one-key "use it now".
+//!
+//! The backend does the thinking (`/models/local*`); this file only asks,
+//! shows, and asks again. Every inbound setter is guarded on the mode, like
+//! `set_provider_models`, so a late reply cannot yank the user off a screen
+//! they already left.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::{prelude::*, widgets::Paragraph};
+
+use super::{ModelPicker, ModelPickerAction, PickerMode};
+use crate::client::types::{LocalInstallJob, LocalModelInfo, LocalModelRow, LocalModelsResponse};
+
+const LOCAL_BASE_URL: &str = "http://localhost:11434";
+
+/// What a row in the catalog list refers to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LocalRow {
+    Header(&'static str),
+    Installed(usize),
+    Catalog(usize),
+}
+
+impl ModelPicker {
+    // ── entry / exit ─────────────────────────────────────────────────────────
+
+    /// Open the catalog from wherever the picker is; `Esc` returns there.
+    pub(super) fn open_local_catalog(&mut self) -> Option<ModelPickerAction> {
+        self.local_return = self.mode;
+        self.local_error = None;
+        self.local_pending_delete = None;
+        self.mode = PickerMode::LocalLoading;
+        Some(ModelPickerAction::LoadLocalCatalog)
+    }
+
+    fn leave_local(&mut self) {
+        self.mode = match self.local_return {
+            PickerMode::Models => PickerMode::Models,
+            _ => PickerMode::Providers,
+        };
+        self.filter.clear();
+    }
+
+    // ── inbound ──────────────────────────────────────────────────────────────
+
+    pub fn set_local_catalog(&mut self, result: Result<LocalModelsResponse, String>) {
+        if !matches!(
+            self.mode,
+            PickerMode::LocalLoading | PickerMode::LocalCatalog | PickerMode::LocalInstalling
+        ) {
+            return;
+        }
+        match result {
+            Ok(resp) => {
+                self.local_error = resp.error.clone();
+                self.local = Some(resp);
+                let rows = self.local_rows();
+                if self.local_cursor >= rows.len() {
+                    self.local_cursor = 0;
+                }
+                self.local_cursor = Self::first_selectable(&rows, self.local_cursor);
+                if self.mode != PickerMode::LocalInstalling {
+                    self.mode = PickerMode::LocalCatalog;
+                }
+            }
+            Err(e) => {
+                self.local_error = Some(e);
+                if self.local.is_none() {
+                    self.local = Some(LocalModelsResponse::default());
+                }
+                if self.mode == PickerMode::LocalLoading {
+                    self.mode = PickerMode::LocalCatalog;
+                }
+            }
+        }
+    }
+
+    pub fn set_local_info(&mut self, result: Result<LocalModelInfo, String>) {
+        if self.mode != PickerMode::LocalLoading {
+            return;
+        }
+        match result {
+            Ok(info) => {
+                // Cursor starts on the recommended quant.
+                let want = info.quant.clone().unwrap_or_default().to_uppercase();
+                self.local_quant_cursor = info
+                    .quants
+                    .iter()
+                    .position(|q| q.quant.to_uppercase() == want)
+                    .unwrap_or(0);
+                self.local_info = Some(info);
+                self.local_error = None;
+                self.mode = PickerMode::LocalDetail;
+            }
+            Err(e) => {
+                self.local_error = Some(e);
+                self.mode = PickerMode::LocalCatalog;
+            }
+        }
+    }
+
+    pub fn set_local_job(&mut self, result: Result<LocalInstallJob, String>) {
+        if self.mode != PickerMode::LocalInstalling {
+            return;
+        }
+        match result {
+            Ok(job) => self.local_job = Some(job),
+            Err(e) => {
+                // A single failed poll is not a failed pull; keep the last
+                // known job but show the transport error.
+                self.local_error = Some(e);
+            }
+        }
+    }
+
+    pub fn set_local_removed(&mut self, result: Result<String, String>) {
+        match result {
+            Ok(_) => self.local_error = None,
+            Err(e) => self.local_error = Some(e),
+        }
+        self.local_pending_delete = None;
+    }
+
+    // ── rows ─────────────────────────────────────────────────────────────────
+
+    pub(super) fn local_rows(&self) -> Vec<LocalRow> {
+        let mut rows = Vec::new();
+        if let Some(l) = self.local.as_ref() {
+            if !l.installed.is_empty() {
+                rows.push(LocalRow::Header("Installed"));
+                for i in 0..l.installed.len() {
+                    rows.push(LocalRow::Installed(i));
+                }
+            }
+            if !l.catalog.is_empty() {
+                rows.push(LocalRow::Header("Available — curated abliterated / uncensored"));
+                for i in 0..l.catalog.len() {
+                    rows.push(LocalRow::Catalog(i));
+                }
+            }
+        }
+        rows
+    }
+
+    fn first_selectable(rows: &[LocalRow], from: usize) -> usize {
+        (from..rows.len())
+            .chain(0..from)
+            .find(|&i| !matches!(rows[i], LocalRow::Header(_)))
+            .unwrap_or(0)
+    }
+
+    fn row_model(&self, row: LocalRow) -> Option<&LocalModelRow> {
+        let l = self.local.as_ref()?;
+        match row {
+            LocalRow::Installed(i) => l.installed.get(i),
+            LocalRow::Catalog(i) => l.catalog.get(i),
+            LocalRow::Header(_) => None,
+        }
+    }
+
+    fn move_local_cursor(&mut self, delta: isize) {
+        let rows = self.local_rows();
+        if rows.is_empty() {
+            return;
+        }
+        let mut i = self.local_cursor as isize;
+        loop {
+            i += delta;
+            if i < 0 || i as usize >= rows.len() {
+                return;
+            }
+            if !matches!(rows[i as usize], LocalRow::Header(_)) {
+                self.local_cursor = i as usize;
+                break;
+            }
+        }
+        let visible = self.list_height();
+        if self.local_cursor < self.local_scroll {
+            self.local_scroll = self.local_cursor;
+        } else if self.local_cursor >= self.local_scroll + visible {
+            self.local_scroll = self.local_cursor - visible + 1;
+        }
+    }
+
+    fn select_action(model: &str) -> ModelPickerAction {
+        ModelPickerAction::SelectModel {
+            provider: "ollama_local".to_string(),
+            runtime_provider: "ollama".to_string(),
+            model: model.to_string(),
+            base_url: Some(LOCAL_BASE_URL.to_string()),
+        }
+    }
+
+    // ── keys ─────────────────────────────────────────────────────────────────
+
+    pub(super) fn handle_local_loading_key(&mut self, key: KeyEvent) -> Option<ModelPickerAction> {
+        if key.code == KeyCode::Esc {
+            if self.local.is_some() {
+                self.mode = PickerMode::LocalCatalog;
+            } else {
+                self.leave_local();
+            }
+        }
+        None
+    }
+
+    pub(super) fn handle_local_catalog_key(&mut self, key: KeyEvent) -> Option<ModelPickerAction> {
+        if key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+            return None;
+        }
+        let rows = self.local_rows();
+        let current = rows.get(self.local_cursor).copied();
+        match key.code {
+            KeyCode::Esc => {
+                if self.local_pending_delete.take().is_some() {
+                    return None;
+                }
+                self.leave_local();
+            }
+            KeyCode::Up | KeyCode::Char('k') => self.move_local_cursor(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.move_local_cursor(1),
+            KeyCode::Char('r') => {
+                self.mode = PickerMode::LocalLoading;
+                return Some(ModelPickerAction::LoadLocalCatalog);
+            }
+            KeyCode::Enter => {
+                let row = current?;
+                let m = self.row_model(row)?.clone();
+                if m.installed {
+                    return Some(Self::select_action(&m.tag));
+                }
+                let reff = m.catalog_id.clone().unwrap_or(m.tag.clone());
+                self.mode = PickerMode::LocalLoading;
+                return Some(ModelPickerAction::LoadLocalInfo { reff });
+            }
+            KeyCode::Char('i') | KeyCode::Char(' ') => {
+                let row = current?;
+                let m = self.row_model(row)?.clone();
+                let reff = if m.installed {
+                    m.tag.clone()
+                } else {
+                    m.catalog_id.clone().unwrap_or(m.tag.clone())
+                };
+                self.mode = PickerMode::LocalLoading;
+                return Some(ModelPickerAction::LoadLocalInfo { reff });
+            }
+            KeyCode::Char('d') | KeyCode::Delete => {
+                let row = current?;
+                let m = self.row_model(row)?.clone();
+                if !m.installed {
+                    return None;
+                }
+                // Two presses: the first arms, the second fires. A model is a
+                // 17 GB download; one stray key must not be able to delete it.
+                if self.local_pending_delete.as_deref() == Some(m.tag.as_str()) {
+                    self.local_pending_delete = None;
+                    return Some(ModelPickerAction::RemoveLocal { tag: m.tag });
+                }
+                self.local_pending_delete = Some(m.tag);
+            }
+            _ => {}
+        }
+        None
+    }
+
+    pub(super) fn handle_local_detail_key(&mut self, key: KeyEvent) -> Option<ModelPickerAction> {
+        if key.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) {
+            return None;
+        }
+        let info = self.local_info.clone()?;
+        match key.code {
+            KeyCode::Esc => {
+                self.local_error = None;
+                self.mode = if self.local.is_some() {
+                    PickerMode::LocalCatalog
+                } else {
+                    PickerMode::LocalLoading
+                };
+                if self.mode == PickerMode::LocalLoading {
+                    return Some(ModelPickerAction::LoadLocalCatalog);
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.local_quant_cursor = self.local_quant_cursor.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.local_quant_cursor + 1 < info.quants.len() {
+                    self.local_quant_cursor += 1;
+                }
+            }
+            KeyCode::Enter => {
+                if info.installed {
+                    return Some(Self::select_action(&info.tag));
+                }
+                let quant = info.quants.get(self.local_quant_cursor).cloned();
+                if let Some(q) = quant.as_ref() {
+                    if q.fit.as_ref().map(|f| f.verdict.as_str()) == Some("no") {
+                        self.local_error =
+                            Some(format!("{} won't fit this machine — pick a smaller quant", q.quant));
+                        return None;
+                    }
+                }
+                let reff = info.catalog_id.clone().unwrap_or(info.tag.clone());
+                self.local_job = None;
+                self.local_error = None;
+                self.mode = PickerMode::LocalInstalling;
+                return Some(ModelPickerAction::InstallLocal {
+                    reff,
+                    quant: quant.map(|q| q.quant),
+                });
+            }
+            _ => {}
+        }
+        None
+    }
+
+    pub(super) fn handle_local_installing_key(&mut self, key: KeyEvent) -> Option<ModelPickerAction> {
+        let job = self.local_job.clone();
+        match key.code {
+            KeyCode::Esc => {
+                // The pull keeps running on the backend; leaving the screen
+                // just stops watching it. The catalog will show it installed
+                // once it lands.
+                self.mode = PickerMode::LocalLoading;
+                return Some(ModelPickerAction::LoadLocalCatalog);
+            }
+            KeyCode::Enter => {
+                if let Some(j) = job {
+                    if j.state == "done" {
+                        if let Some(tag) = j.tag {
+                            return Some(Self::select_action(&tag));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        None
+    }
+
+    // ── drawing ──────────────────────────────────────────────────────────────
+
+    fn fit_badge(fit: Option<&crate::client::types::LocalFit>, theme: &crate::style::Theme) -> Span<'static> {
+        match fit.map(|f| f.verdict.as_str()) {
+            Some("fits") => Span::styled("✓", Style::default().fg(theme.colors.success)),
+            Some("partial") | Some("cpu") => Span::styled("⚠", Style::default().fg(theme.colors.warning)),
+            Some("no") => Span::styled("✗", Style::default().fg(theme.colors.error)),
+            _ => Span::styled("·", Style::default().fg(theme.colors.dim)),
+        }
+    }
+
+    fn fit_label(verdict: &str) -> &'static str {
+        match verdict {
+            "fits" => "fits in VRAM",
+            "partial" => "partial offload (slow)",
+            "cpu" => "CPU only",
+            "no" => "won't fit",
+            _ => "?",
+        }
+    }
+
+    fn gb(bytes: u64) -> String {
+        format!("{:.1} GB", bytes as f64 / 1e9)
+    }
+
+    fn row_summary(m: &LocalModelRow) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        if m.size_bytes > 0 {
+            let approx = if m.installed { "" } else { "~" };
+            parts.push(format!("{}{}", approx, Self::gb(m.size_bytes)));
+        }
+        if let Some(q) = m.quant.as_ref() {
+            parts.push(q.clone());
+        }
+        if let Some(p) = m.params.as_ref() {
+            parts.push(p.clone());
+        }
+        if let Some(f) = m.fit.as_ref() {
+            parts.push(Self::fit_label(&f.verdict).to_string());
+        }
+        if let Some(t) = m.measured_tps {
+            parts.push(format!("{:.0} tok/s measured", t));
+        } else if let Some(t) = m.fit.as_ref().and_then(|f| f.est_tps) {
+            parts.push(format!("~{:.0} tok/s est.", t));
+        }
+        if !m.capabilities.is_empty() {
+            parts.push(m.capabilities.join(", "));
+        }
+        parts.join(" · ")
+    }
+
+    fn draw_local_title(&self, frame: &mut Frame, inner: Rect, theme: &crate::style::Theme, title: &str) -> u16 {
+        let mut cy = inner.y;
+        frame.render_widget(
+            Paragraph::new(title.to_string())
+                .style(theme.dialog_title())
+                .alignment(Alignment::Center),
+            Rect::new(inner.x, cy, inner.width, 1),
+        );
+        cy += 1;
+        let hw = self
+            .local
+            .as_ref()
+            .map(|l| l.hardware.summary.clone())
+            .unwrap_or_default();
+        if !hw.is_empty() {
+            let ctx = self.local.as_ref().map(|l| l.ctx).unwrap_or(0);
+            let line = if ctx > 0 {
+                format!("  {} · fit at {}K ctx", hw, ctx / 1024)
+            } else {
+                format!("  {}", hw)
+            };
+            frame.render_widget(
+                Paragraph::new(line).style(Style::default().fg(theme.colors.secondary)),
+                Rect::new(inner.x, cy, inner.width, 1),
+            );
+            cy += 1;
+        }
+        let sep = "─".repeat(inner.width as usize);
+        frame.render_widget(
+            Paragraph::new(sep).style(Style::default().fg(theme.colors.dim)),
+            Rect::new(inner.x, cy, inner.width, 1),
+        );
+        cy + 1
+    }
+
+    fn draw_local_error(&self, frame: &mut Frame, inner: Rect, theme: &crate::style::Theme) {
+        if let Some(e) = self.local_error.as_ref() {
+            let y = inner.y + inner.height.saturating_sub(2);
+            frame.render_widget(
+                Paragraph::new(Span::styled(
+                    format!(" {}", e),
+                    Style::default().fg(theme.colors.warning),
+                )),
+                Rect::new(inner.x, y, inner.width, 1),
+            );
+        }
+    }
+
+    pub(super) fn draw_local_loading(&self, frame: &mut Frame, inner: Rect, theme: &crate::style::Theme) {
+        let cy = self.draw_local_title(frame, inner, theme, "Local models");
+        let body_h = inner.height.saturating_sub(cy - inner.y + 1);
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                "Checking what fits this machine…",
+                Style::default().fg(theme.colors.secondary),
+            ))
+            .alignment(Alignment::Center),
+            Rect::new(inner.x, cy + body_h / 2, inner.width, 1),
+        );
+        self.draw_help(frame, inner, theme, &[("Esc", "back")]);
+    }
+
+    pub(super) fn draw_local_catalog(&self, frame: &mut Frame, inner: Rect, theme: &crate::style::Theme) {
+        let cy = self.draw_local_title(frame, inner, theme, "Local models");
+        let rows = self.local_rows();
+        // Two lines per model row (name, then summary) so the summary never
+        // fights the name for width.
+        let list_h = inner.height.saturating_sub(cy - inner.y + 2) as usize;
+        let per_row = 2usize;
+        let visible_rows = (list_h / per_row).max(1);
+        self.list_viewport.set(visible_rows);
+        let scroll = super::super::clamp_scroll_to_cursor(self.local_scroll, self.local_cursor, visible_rows);
+
+        if rows.is_empty() {
+            let msg = if self.local_error.is_some() {
+                "Ollama is not reachable — start it and press r"
+            } else {
+                "No local models and an empty catalog"
+            };
+            frame.render_widget(
+                Paragraph::new(Span::styled(msg, Style::default().fg(theme.colors.muted)))
+                    .alignment(Alignment::Center),
+                Rect::new(inner.x, cy + (list_h as u16) / 2, inner.width, 1),
+            );
+        }
+
+        let mut y = cy;
+        for abs in scroll..rows.len() {
+            if (y - cy) as usize + per_row > list_h {
+                break;
+            }
+            match rows[abs] {
+                LocalRow::Header(h) => {
+                    frame.render_widget(
+                        Paragraph::new(Span::styled(
+                            format!(" {}", h),
+                            Style::default().fg(theme.colors.secondary).add_modifier(Modifier::BOLD),
+                        )),
+                        Rect::new(inner.x, y, inner.width, 1),
+                    );
+                    y += 1;
+                }
+                row => {
+                    let Some(m) = self.row_model(row) else { continue };
+                    let selected = abs == self.local_cursor;
+                    let name_style = if selected {
+                        Style::default().fg(theme.colors.primary).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(theme.colors.muted)
+                    };
+                    let cursor = if selected { "▸" } else { " " };
+                    let mut spans = vec![
+                        Span::styled(format!("{} ", cursor), name_style),
+                        Self::fit_badge(m.fit.as_ref(), theme),
+                        Span::styled(" ", name_style),
+                    ];
+                    let label = match (&m.catalog_id, m.installed) {
+                        (Some(id), false) => format!("{}  ", id),
+                        _ => format!("{}  ", m.tag),
+                    };
+                    spans.push(Span::styled(label, name_style));
+                    if m.installed && m.name != m.tag {
+                        spans.push(Span::styled(m.name.clone(), Style::default().fg(theme.colors.dim)));
+                    } else if !m.installed {
+                        spans.push(Span::styled(m.name.clone(), Style::default().fg(theme.colors.dim)));
+                    }
+                    if m.loaded {
+                        spans.push(Span::styled("  ● in VRAM", Style::default().fg(theme.colors.success)));
+                    }
+                    if self.local_pending_delete.as_deref() == Some(m.tag.as_str()) {
+                        spans.push(Span::styled(
+                            "  press d again to delete",
+                            Style::default().fg(theme.colors.error),
+                        ));
+                    }
+                    frame.render_widget(
+                        Paragraph::new(Line::from(spans)),
+                        Rect::new(inner.x, y, inner.width, 1),
+                    );
+                    frame.render_widget(
+                        Paragraph::new(Span::styled(
+                            format!("      {}", Self::row_summary(m)),
+                            Style::default().fg(theme.colors.dim),
+                        )),
+                        Rect::new(inner.x, y + 1, inner.width, 1),
+                    );
+                    y += 2;
+                }
+            }
+        }
+
+        self.draw_local_error(frame, inner, theme);
+        self.draw_help(
+            frame,
+            inner,
+            theme,
+            &[
+                ("↑↓", "nav"),
+                ("Enter", "use / details"),
+                ("i", "info"),
+                ("d", "delete"),
+                ("r", "refresh"),
+                ("Esc", "back"),
+            ],
+        );
+    }
+
+    pub(super) fn draw_local_detail(&self, frame: &mut Frame, inner: Rect, theme: &crate::style::Theme) {
+        let Some(info) = self.local_info.as_ref() else {
+            return self.draw_local_loading(frame, inner, theme);
+        };
+        let mut cy = self.draw_local_title(frame, inner, theme, &info.name);
+        let dim = Style::default().fg(theme.colors.dim);
+        let text = Style::default().fg(theme.colors.muted);
+
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push(Line::from(vec![
+            Span::styled("  Tag         ", dim),
+            Span::styled(info.tag.clone(), text),
+        ]));
+        let mut facts: Vec<String> = Vec::new();
+        if let Some(p) = info.params.as_ref() {
+            facts.push(p.clone());
+        }
+        if let Some(f) = info.family.as_ref() {
+            facts.push(f.clone());
+        }
+        if let Some(c) = info.context_length {
+            facts.push(format!("{}K ctx trained", c / 1024));
+        }
+        if !info.capabilities.is_empty() {
+            facts.push(info.capabilities.join(", "));
+        }
+        lines.push(Line::from(vec![
+            Span::styled("  Model       ", dim),
+            Span::styled(facts.join(" · "), text),
+        ]));
+        if let Some(b) = info.blurb.as_ref() {
+            if !b.is_empty() {
+                lines.push(Line::from(Span::styled(format!("  {}", b), dim)));
+            }
+        }
+        lines.push(Line::from(Span::styled(
+            if info.installed { "  Installed on this machine" } else { "  Not installed" },
+            Style::default().fg(if info.installed { theme.colors.success } else { theme.colors.muted }),
+        )));
+        for l in lines {
+            frame.render_widget(Paragraph::new(l), Rect::new(inner.x, cy, inner.width, 1));
+            cy += 1;
+        }
+        cy += 1;
+
+        if info.installed {
+            if let Some(f) = info.fit.as_ref() {
+                let speed = info
+                    .measured
+                    .as_ref()
+                    .and_then(|m| m.get("decode_tps"))
+                    .and_then(|v| v.as_f64())
+                    .map(|t| format!("{:.1} tok/s measured", t))
+                    .or_else(|| f.est_tps.map(|t| format!("~{:.0} tok/s est.", t)))
+                    .unwrap_or_default();
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![
+                        Span::styled("  ", dim),
+                        Self::fit_badge(Some(f), theme),
+                        Span::styled(
+                            format!(
+                                " {} · weights {} + KV {} · {}",
+                                Self::fit_label(&f.verdict),
+                                Self::gb(f.weights_bytes),
+                                Self::gb(f.kv_bytes),
+                                speed
+                            ),
+                            text,
+                        ),
+                    ])),
+                    Rect::new(inner.x, cy, inner.width, 1),
+                );
+            }
+        } else {
+            frame.render_widget(
+                Paragraph::new(Span::styled("  Pick a quant:", Style::default().fg(theme.colors.secondary))),
+                Rect::new(inner.x, cy, inner.width, 1),
+            );
+            cy += 1;
+            let avail = inner.height.saturating_sub(cy - inner.y + 2) as usize;
+            let recommended = info.quant.clone().unwrap_or_default().to_uppercase();
+            for (i, q) in info.quants.iter().enumerate().take(avail) {
+                let selected = i == self.local_quant_cursor;
+                let style = if selected {
+                    Style::default().fg(theme.colors.primary).add_modifier(Modifier::BOLD)
+                } else {
+                    text
+                };
+                let est = q
+                    .fit
+                    .as_ref()
+                    .and_then(|f| f.est_tps)
+                    .map(|t| format!("~{:.0} tok/s", t))
+                    .unwrap_or_else(|| "—".to_string());
+                let verdict = q.fit.as_ref().map(|f| Self::fit_label(&f.verdict)).unwrap_or("?");
+                let star = if q.quant.to_uppercase() == recommended { " ★" } else { "" };
+                let approx = if q.exact { "" } else { "~" };
+                frame.render_widget(
+                    Paragraph::new(Line::from(vec![
+                        Span::styled(format!("  {} ", if selected { "▸" } else { " " }), style),
+                        Self::fit_badge(q.fit.as_ref(), theme),
+                        Span::styled(
+                            format!(
+                                " {:<8} {:>9}  {:<22} {}{}",
+                                q.quant,
+                                format!("{}{}", approx, Self::gb(q.bytes)),
+                                verdict,
+                                est,
+                                star
+                            ),
+                            style,
+                        ),
+                    ])),
+                    Rect::new(inner.x, cy, inner.width, 1),
+                );
+                cy += 1;
+            }
+        }
+
+        self.draw_local_error(frame, inner, theme);
+        let help: &[(&str, &str)] = if info.installed {
+            &[("Enter", "use this model"), ("Esc", "back")]
+        } else {
+            &[("↑↓", "quant"), ("Enter", "install"), ("Esc", "back")]
+        };
+        self.draw_help(frame, inner, theme, help);
+    }
+
+    pub(super) fn draw_local_installing(&self, frame: &mut Frame, inner: Rect, theme: &crate::style::Theme) {
+        let name = self
+            .local_info
+            .as_ref()
+            .map(|i| i.name.clone())
+            .unwrap_or_else(|| "model".to_string());
+        let mut cy = self.draw_local_title(frame, inner, theme, &format!("Installing {}", name));
+        cy += 1;
+        let text = Style::default().fg(theme.colors.muted);
+
+        match self.local_job.as_ref() {
+            None => {
+                frame.render_widget(
+                    Paragraph::new(Span::styled("  Starting pull…", text)),
+                    Rect::new(inner.x, cy, inner.width, 1),
+                );
+            }
+            Some(job) => {
+                let (label, pct) = match job.state.as_str() {
+                    "pulling" if job.total > 0 => (
+                        format!(
+                            "  {}  {} / {}",
+                            job.status,
+                            Self::gb(job.completed),
+                            Self::gb(job.total)
+                        ),
+                        (job.completed as f64 / job.total as f64).clamp(0.0, 1.0),
+                    ),
+                    "pulling" => (format!("  {}", job.status), 0.0),
+                    "benchmarking" => ("  Downloaded — measuring tokens/sec…".to_string(), 1.0),
+                    "done" => ("  Installed".to_string(), 1.0),
+                    _ => (format!("  Failed: {}", job.error.clone().unwrap_or_default()), 0.0),
+                };
+                frame.render_widget(
+                    Paragraph::new(Span::styled(label, text)),
+                    Rect::new(inner.x, cy, inner.width, 1),
+                );
+                cy += 1;
+                let bar_w = inner.width.saturating_sub(12) as usize;
+                let filled = ((bar_w as f64) * pct).round() as usize;
+                let bar = format!(
+                    "  [{}{}] {:>3}%",
+                    "█".repeat(filled),
+                    "░".repeat(bar_w.saturating_sub(filled)),
+                    (pct * 100.0).round() as u64
+                );
+                frame.render_widget(
+                    Paragraph::new(Span::styled(
+                        bar,
+                        Style::default().fg(if job.state == "error" {
+                            theme.colors.error
+                        } else {
+                            theme.colors.primary
+                        }),
+                    )),
+                    Rect::new(inner.x, cy, inner.width, 1),
+                );
+                cy += 2;
+
+                if job.state == "done" {
+                    if let Some(b) = job.bench.as_ref() {
+                        let prompt = b
+                            .prompt_tps
+                            .map(|p| format!(" · prompt {:.0} tok/s", p))
+                            .unwrap_or_default();
+                        frame.render_widget(
+                            Paragraph::new(Line::from(vec![
+                                Span::styled("  ✓ ", Style::default().fg(theme.colors.success)),
+                                Span::styled(
+                                    format!("{:.1} tok/s measured{}", b.decode_tps, prompt),
+                                    Style::default().fg(theme.colors.success).add_modifier(Modifier::BOLD),
+                                ),
+                            ])),
+                            Rect::new(inner.x, cy, inner.width, 1),
+                        );
+                        cy += 1;
+                    }
+                    frame.render_widget(
+                        Paragraph::new(Span::styled(
+                            format!("  {}", job.tag.clone().unwrap_or_default()),
+                            Style::default().fg(theme.colors.dim),
+                        )),
+                        Rect::new(inner.x, cy, inner.width, 1),
+                    );
+                }
+            }
+        }
+
+        self.draw_local_error(frame, inner, theme);
+        let done = self.local_job.as_ref().map(|j| j.state == "done").unwrap_or(false);
+        let help: &[(&str, &str)] = if done {
+            &[("Enter", "use it now"), ("Esc", "back to list")]
+        } else {
+            &[("Esc", "back (pull keeps running)")]
+        };
+        self.draw_help(frame, inner, theme, help);
+    }
+}

--- a/priv/rust/tui/src/event/backend.rs
+++ b/priv/rust/tui/src/event/backend.rs
@@ -685,6 +685,14 @@ pub enum BackendEvent {
     AccountLoginUpdate(Result<crate::client::types::LoginSessionResponse, String>),
     /// A provider's dynamic model list loaded → switch picker to Models mode.
     ProviderModelsLoaded(Result<OnboardingModelsResponse, String>),
+    /// `/models/local` — the local catalog screen's data.
+    LocalCatalogLoaded(Result<crate::client::types::LocalModelsResponse, String>),
+    /// `/models/local/info` — one model's quant ladder and fit.
+    LocalModelInfoLoaded(Result<crate::client::types::LocalModelInfo, String>),
+    /// One poll of a pull job (`/models/local/install/:id`), or the start failing.
+    LocalInstallUpdate(Result<crate::client::types::LocalInstallJob, String>),
+    /// `/models/local/remove` finished — Ok(tag) or the reason.
+    LocalModelRemoved(Result<String, String>),
     /// A reading of `/auth/cli/claude` — what to install, what to run, and who
     /// is signed in. Drives the in-TUI vendor-CLI sign-in screen.
     ClaudeCliState(Result<crate::client::types::ClaudeCliState, String>),

--- a/test/agent/loop/small_window_regime_test.exs
+++ b/test/agent/loop/small_window_regime_test.exs
@@ -118,24 +118,34 @@ defmodule OptimalSystemAgent.Agent.Loop.SmallWindowRegimeTest do
       assert variant == :native_tools
     end
 
-    test "genuinely small weights still get :lite" do
+    # :lite (13.2k) is bigger than :native_tools (8.95k); on a transport that
+    # ships tool schemas natively the small window gets the smaller base.
+    test "genuinely small weights on a native transport get :native_tools" do
       variant =
         Context.static_base_variant(
           :ollama,
           Context.small_window?(@small_model, :ollama)
         )
 
-      assert variant == :lite
+      assert variant == :native_tools
+      assert Soul.static_token_count(:native_tools) < Soul.static_token_count(:lite)
     end
 
-    test "Context.build/1 assembles the SMALLER prefix for the big-window model" do
+    test "genuinely small weights on a prompt-text transport keep :lite" do
+      assert Context.static_base_variant(:claude_cli, true) == :lite
+    end
+
+    test "Context.build/1 assembles the :native_tools prefix for both window sizes on :ollama" do
       big = build_system_content(@cloud_model)
       small = build_system_content(@small_model)
 
       assert String.starts_with?(big, Soul.static_base(:native_tools)),
              "the assembled system prompt must open with the :native_tools base"
 
-      assert String.starts_with?(small, Soul.static_base(:lite))
+      # The small window used to get :lite here — 4.2k tokens MORE than the
+      # native base it now shares with the big window.
+      assert String.starts_with?(small, Soul.static_base(:native_tools))
+      refute String.starts_with?(small, Soul.static_base(:lite))
 
       IO.puts(
         "\n[measured] Context.build system prompt bytes: " <>

--- a/test/channels/http/local_models_routes_test.exs
+++ b/test/channels/http/local_models_routes_test.exs
@@ -1,0 +1,96 @@
+defmodule OptimalSystemAgent.Channels.HTTP.LocalModelsRoutesTest do
+  use ExUnit.Case, async: false
+  import Plug.Test
+  import Plug.Conn
+
+  alias OptimalSystemAgent.Channels.HTTP
+
+  # A fresh OSA_HOME (no .env) means first-run, so the routes are open — the
+  # same rule the onboarding routes follow. A dead daemon port keeps the
+  # overview deterministic (installed: [], error set) while the catalog and
+  # hardware still come back.
+  setup do
+    dir = Path.join(System.tmp_dir!(), "osa-home-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    prev_home = System.get_env("OSA_HOME")
+    prev_url = Application.get_env(:optimal_system_agent, :ollama_url)
+    System.put_env("OSA_HOME", dir)
+    Application.put_env(:optimal_system_agent, :ollama_url, "http://127.0.0.1:1")
+
+    on_exit(fn ->
+      if prev_home, do: System.put_env("OSA_HOME", prev_home), else: System.delete_env("OSA_HOME")
+
+      if prev_url,
+        do: Application.put_env(:optimal_system_agent, :ollama_url, prev_url),
+        else: Application.delete_env(:optimal_system_agent, :ollama_url)
+
+      File.rm_rf(dir)
+    end)
+
+    :ok
+  end
+
+  defp call(conn), do: HTTP.call(conn, HTTP.init([]))
+  defp json(conn), do: Jason.decode!(conn.resp_body)
+
+  test "GET /models/local returns hardware, the catalog, and the daemon error" do
+    conn = call(conn(:get, "/models/local"))
+    assert conn.status == 200
+    body = json(conn)
+    assert is_binary(body["hardware"]["summary"])
+    assert body["installed"] == []
+    assert length(body["catalog"]) >= 10
+    assert body["error"] =~ "not running"
+
+    row = Enum.find(body["catalog"], &(&1["catalog_id"] == "superqwen-abliterated"))
+    assert row["fit"]["verdict"] in ["fits", "partial", "cpu", "no"]
+    assert row["capabilities"] == ["tools", "thinking", "vision"]
+  end
+
+  test "GET /models/local/info?ref= sizes a catalog entry per quant (offline estimate)" do
+    conn = call(conn(:get, "/models/local/info?ref=llama3.1-8b-abliterated"))
+    assert conn.status == 200
+    body = json(conn)
+    assert body["tag"] =~ "hf.co/mlabonne/Meta-Llama-3.1-8B-Instruct-abliterated-GGUF:"
+    assert body["installed"] == false
+    assert Enum.all?(body["quants"], &is_binary(&1["fit"]["verdict"]))
+
+    conn = call(conn(:get, "/models/local/info?ref=nope"))
+    assert conn.status == 400
+    assert json(conn)["error"] =~ "unknown model"
+  end
+
+  test "POST /models/local/install starts a job that GET /install/:id can poll" do
+    conn =
+      conn(
+        :post,
+        "/models/local/install",
+        Jason.encode!(%{ref: "route-test-#{System.unique_integer([:positive])}"})
+      )
+      |> put_req_header("content-type", "application/json")
+      |> call()
+
+    assert conn.status == 200
+    %{"job_id" => id} = json(conn)
+
+    conn = call(conn(:get, "/models/local/install/#{id}"))
+    assert conn.status == 200
+    assert json(conn)["state"] in ["pulling", "error"]
+
+    conn = call(conn(:get, "/models/local/install/job-nope"))
+    assert conn.status == 400
+  end
+
+  test "bad bodies are 400s" do
+    conn =
+      conn(:post, "/models/local/install", "{}")
+      |> put_req_header("content-type", "application/json")
+      |> call()
+
+    assert conn.status == 400
+    assert json(conn)["error"] =~ "ref is required"
+
+    conn = conn(:post, "/models/local/remove", "not json") |> call()
+    assert conn.status == 400
+  end
+end

--- a/test/local_models/installer_test.exs
+++ b/test/local_models/installer_test.exs
@@ -1,0 +1,48 @@
+defmodule OptimalSystemAgent.LocalModels.InstallerTest do
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.LocalModels.Installer
+
+  test "a job reports pull progress, then benchmarking, then done with the tag and bench" do
+    {:ok, id} =
+      Installer.start("fake-ref-#{System.unique_integer([:positive])}", "Q4_K_M", run: false)
+
+    job = Installer.status(id)
+    assert %{state: :pulling, status: "starting"} = job
+
+    fake = fn _ref, opts ->
+      cb = Keyword.fetch!(opts, :on_progress)
+      cb.(%{status: "pulling abc", completed: 50, total: 100})
+      assert %{state: :pulling, completed: 50, total: 100} = Installer.status(id)
+      cb.(%{status: "success", completed: 100, total: 100})
+      assert %{state: :benchmarking} = Installer.status(id)
+      {:ok, %{tag: "hf.co/x:Q4_K_M", bench: %{decode_tps: 42.0}}}
+    end
+
+    Installer.run(id, job.ref, "Q4_K_M", fake)
+
+    assert %{state: :done, tag: "hf.co/x:Q4_K_M", bench: %{decode_tps: 42.0}} =
+             Installer.status(id)
+
+    assert Enum.any?(Installer.list(), &(&1.id == id))
+    Installer.forget(id)
+    assert Installer.status(id) == nil
+  end
+
+  test "a failed pull is reported, and a crash inside the job does not lose it" do
+    {:ok, id} = Installer.start("bad-#{System.unique_integer([:positive])}", nil, run: false)
+    Installer.run(id, "bad", nil, fn _, _ -> {:error, "no such quant"} end)
+    assert %{state: :error, error: "no such quant"} = Installer.status(id)
+
+    {:ok, id2} = Installer.start("boom-#{System.unique_integer([:positive])}", nil, run: false)
+    Installer.run(id2, "boom", nil, fn _, _ -> raise "kaboom" end)
+    assert %{state: :error, error: "kaboom"} = Installer.status(id2)
+  end
+
+  test "the same ref cannot be installed twice at once" do
+    ref = "dup-#{System.unique_integer([:positive])}"
+    {:ok, _} = Installer.start(ref, nil, run: false)
+    assert {:error, msg} = Installer.start(ref, nil, run: false)
+    assert msg =~ "already installing"
+  end
+end

--- a/test/local_models/local_models_test.exs
+++ b/test/local_models/local_models_test.exs
@@ -378,6 +378,21 @@ defmodule OptimalSystemAgent.LocalModelsTest do
     end
   end
 
+  describe "note/1" do
+    test "summarises fit, speed and capabilities for a picker row" do
+      row = %{
+        fit: %{verdict: :fits, est_tps: 26.4},
+        measured_tps: nil,
+        capabilities: ["tools", "vision"],
+        size_bytes: 17_200_000_000
+      }
+
+      assert LocalModels.note(row) == "✓ fits in VRAM · ~26 tok/s est. · 17.2 GB · tools, vision"
+      assert LocalModels.note(%{row | measured_tps: 25.6}) =~ "25.6 tok/s measured"
+      assert LocalModels.note(%{row | fit: nil, capabilities: [], size_bytes: 0}) == ""
+    end
+  end
+
   describe "/models command" do
     test "is registered and prints usage for bad input" do
       assert "models" in Commands.list()

--- a/test/local_models/local_models_test.exs
+++ b/test/local_models/local_models_test.exs
@@ -393,6 +393,39 @@ defmodule OptimalSystemAgent.LocalModelsTest do
     end
   end
 
+  describe "auto_ctx_for/3" do
+    test "SuperQwen 27B Q4 on a 24 GiB card: 64k fits (17.2 + 4.3 + 1 GB), 96k does not, never below 32k" do
+      spec = %{weights_bytes: 17_200_000_000, quant: "Q4_K_M", kv_bytes_per_token: 64 * 1024}
+      assert LocalModels.auto_ctx_for(spec, hw(), 262_144) == 65_536
+      # A 48 GB card takes the whole trained window's worth up to the cap.
+      assert LocalModels.auto_ctx_for(spec, hw(%{vram_bytes: 48 * @gib}), 262_144) == 262_144
+      # Capped by the trained window.
+      assert LocalModels.auto_ctx_for(spec, hw(%{vram_bytes: 48 * @gib}), 131_072) == 131_072
+      # Too big for any bucket still returns the floor rather than nothing.
+      assert LocalModels.auto_ctx_for(%{spec | weights_bytes: 23_000_000_000}, hw(), 262_144) ==
+               32_768
+    end
+  end
+
+  describe "to_json/1" do
+    test "flattens the catalog entry, stringifies atoms and drops model_info" do
+      row = %{
+        tag: "hf.co/x:Q4_K_M",
+        fit: %{verdict: :fits, est_tps: 26.4, weights_exact: true},
+        entry: %{id: "x", blurb: "b", tags: ["t"], repo: "x/y", quants: ["Q4_K_M"], name: "X"},
+        model_info: %{"big" => "blob"},
+        installed: false
+      }
+
+      json = LocalModels.to_json(row)
+      assert json.fit.verdict == "fits"
+      assert json.catalog_id == "x" and json.repo == "x/y" and json.catalog_quants == ["Q4_K_M"]
+      refute Map.has_key?(json, :entry) or Map.has_key?(json, :model_info)
+      assert json.installed == false
+      assert Jason.encode!(json)
+    end
+  end
+
   describe "/models command" do
     test "is registered and prints usage for bad input" do
       assert "models" in Commands.list()

--- a/test/local_models/local_models_test.exs
+++ b/test/local_models/local_models_test.exs
@@ -393,6 +393,34 @@ defmodule OptimalSystemAgent.LocalModelsTest do
     end
   end
 
+  describe "kv_cache_scale/0" do
+    setup do
+      prev = Application.get_env(:optimal_system_agent, :ollama_kv_cache_type)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:optimal_system_agent, :ollama_kv_cache_type, prev),
+          else: Application.delete_env(:optimal_system_agent, :ollama_kv_cache_type)
+      end)
+
+      :ok
+    end
+
+    test "a q4_0 KV cache lets SuperQwen's full 262k window fit a 24 GiB card" do
+      spec = %{weights_bytes: 17_200_000_000, quant: "Q4_K_M", kv_bytes_per_token: 64 * 1024}
+      Application.put_env(:optimal_system_agent, :ollama_kv_cache_type, "f16")
+      assert Fit.assess(spec, hw(), 262_144).verdict == :partial
+      assert LocalModels.auto_ctx_for(spec, hw(), 262_144) == 65_536
+
+      Application.put_env(:optimal_system_agent, :ollama_kv_cache_type, "q8_0")
+      assert LocalModels.auto_ctx_for(spec, hw(), 262_144) == 131_072
+
+      Application.put_env(:optimal_system_agent, :ollama_kv_cache_type, "q4_0")
+      assert Fit.assess(spec, hw(), 262_144).verdict == :fits
+      assert LocalModels.auto_ctx_for(spec, hw(), 262_144) == 262_144
+    end
+  end
+
   describe "auto_ctx_for/3" do
     test "SuperQwen 27B Q4 on a 24 GiB card: 64k fits (17.2 + 4.3 + 1 GB), 96k does not, never below 32k" do
       spec = %{weights_bytes: 17_200_000_000, quant: "Q4_K_M", kv_bytes_per_token: 64 * 1024}

--- a/test/local_models/local_models_test.exs
+++ b/test/local_models/local_models_test.exs
@@ -1,0 +1,397 @@
+defmodule OptimalSystemAgent.LocalModelsTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias OptimalSystemAgent.Channels.CLI.Commands
+  alias OptimalSystemAgent.LocalModels
+  alias OptimalSystemAgent.LocalModels.{Catalog, Fit, Hardware, HuggingFace, OllamaAdmin}
+
+  @gib 1024 * 1024 * 1024
+
+  defp hw(overrides \\ %{}) do
+    Map.merge(
+      Hardware.from_probe(%{
+        os: :linux,
+        ram_bytes: 64 * @gib,
+        cpu: "Intel Core Ultra 9",
+        cores: 24,
+        nvidia: {"NVIDIA GeForce RTX 5090 Laptop GPU", 24 * @gib}
+      }),
+      overrides
+    )
+  end
+
+  describe "Hardware.from_probe/1" do
+    test "picks the NVIDIA card and looks up its bandwidth" do
+      h = hw()
+      assert h.backend == :cuda
+      assert h.gpu =~ "5090 Laptop"
+      assert h.vram_bytes == 24 * @gib
+      assert {896, true} = {h.bandwidth_gbps, h.bandwidth_known}
+      assert Hardware.summary(h) == "RTX 5090 Laptop · 24 GB VRAM · 64 GB RAM"
+    end
+
+    test "no GPU means CPU backend at CPU bandwidth" do
+      h = Hardware.from_probe(%{os: :linux, ram_bytes: 16 * @gib, cpu: "i5"})
+      assert h.backend == :cpu
+      assert h.vram_bytes == 0
+      assert h.bandwidth_gbps == Hardware.cpu_bandwidth_gbps()
+    end
+
+    test "Apple Silicon uses 3/4 of unified memory as VRAM" do
+      h = Hardware.from_probe(%{os: :macos, ram_bytes: 64 * @gib, apple_chip: "Apple M3 Max"})
+      assert h.backend == :metal
+      assert h.vram_bytes == 48 * @gib
+      assert {400, true} = {h.bandwidth_gbps, h.bandwidth_known}
+    end
+
+    test "an unknown GPU gets the default bandwidth, flagged as a guess" do
+      h =
+        Hardware.from_probe(%{os: :linux, ram_bytes: 32 * @gib, nvidia: {"Tesla P40", 24 * @gib}})
+
+      refute h.bandwidth_known
+      assert h.bandwidth_gbps > 0
+    end
+  end
+
+  describe "Fit.assess/3" do
+    test "a 16.5 GB hybrid 27B fits a 24 GB card at 32k ctx and gets a bandwidth-based estimate" do
+      f =
+        Fit.assess(
+          %{weights_bytes: 16_500_000_000, params_b: 27, quant: "Q4_K_M", family: "qwen3.5"},
+          hw(),
+          32_768
+        )
+
+      assert f.verdict == :fits
+      assert f.weights_exact
+      # 896 GB/s × 0.5 / 16.5 GB ≈ 27 tok/s (measured on this exact setup: 25.6)
+      assert_in_delta f.est_tps, 27, 3
+      assert f.kv_bytes == 64 * 1024 * 32_768
+    end
+
+    test "the same weights as a classic GQA transformer spill at 32k ctx (256 KB/token KV)" do
+      f =
+        Fit.assess(%{weights_bytes: 16_500_000_000, params_b: 27, quant: "Q4_K_M"}, hw(), 32_768)
+
+      assert f.kv_bytes == 256 * 1024 * 32_768
+      assert f.verdict == :partial
+    end
+
+    test "a 70B Q4 is a partial offload on 24 GB + 64 GB RAM, and slow" do
+      f = Fit.assess(%{params_b: 70, quant: "Q4_K_M"}, hw(), 32_768)
+      assert f.verdict == :partial
+      refute f.weights_exact
+      assert f.gpu_share < 0.6
+      assert f.est_tps < 10
+    end
+
+    test "nothing fits when weights exceed VRAM + RAM" do
+      f = Fit.assess(%{params_b: 400, quant: "Q8_0"}, hw(), 8_192)
+      assert f.verdict == :no
+      assert f.est_tps == nil
+    end
+
+    test "a MoE streams only its active parameters, so it decodes faster than a dense model of the same size" do
+      dense = Fit.assess(%{params_b: 35, quant: "Q6_K"}, hw(%{vram_bytes: 48 * @gib}), 8_192)
+
+      moe =
+        Fit.assess(
+          %{params_b: 35, active_params_b: 3, quant: "Q6_K"},
+          hw(%{vram_bytes: 48 * @gib}),
+          8_192
+        )
+
+      assert moe.est_tps > dense.est_tps * 4
+    end
+
+    test "CPU-only boxes get a :cpu verdict when the model fits RAM" do
+      cpu = Hardware.from_probe(%{os: :linux, ram_bytes: 32 * @gib})
+      assert Fit.assess(%{params_b: 8, quant: "Q4_K_M"}, cpu, 8_192).verdict == :cpu
+      assert Fit.assess(%{params_b: 70, quant: "Q4_K_M"}, cpu, 8_192).verdict == :no
+    end
+
+    test "exact KV bytes come from GGUF metadata" do
+      info = %{
+        "general.architecture" => "qwen35",
+        "qwen35.block_count" => 64,
+        "qwen35.attention.head_count" => 40,
+        "qwen35.attention.head_count_kv" => 8,
+        "qwen35.embedding_length" => 5120
+      }
+
+      assert Fit.kv_from_model_info(info) == 64 * 8 * (128 + 128) * 2
+      assert Fit.kv_from_model_info(%{}) == nil
+
+      # Qwen 3.5 27B as Ollama reports it: 64 layers, full attention every 4th,
+      # 4 KV heads, 256-dim keys and values -> 64 KB/token.
+      hybrid = %{
+        "general.architecture" => "qwen35",
+        "qwen35.block_count" => 64,
+        "qwen35.full_attention_interval" => 4,
+        "qwen35.attention.head_count" => 24,
+        "qwen35.attention.head_count_kv" => 4,
+        "qwen35.attention.key_length" => 256,
+        "qwen35.attention.value_length" => 256,
+        "qwen35.embedding_length" => 5120
+      }
+
+      assert Fit.kv_from_model_info(hybrid) == 64 * 1024
+    end
+  end
+
+  describe "HuggingFace.parse_repo/1" do
+    test "groups split parts per quant and separates the vision projector" do
+      body = %{
+        "id" => "x/y-GGUF",
+        "downloads" => 10,
+        "siblings" => [
+          %{"rfilename" => "y-Q4_K_M-00001-of-00002.gguf", "size" => 10},
+          %{"rfilename" => "y-Q4_K_M-00002-of-00002.gguf", "size" => 5},
+          %{"rfilename" => "y.Q8_0.gguf", "size" => 30},
+          %{"rfilename" => "mmproj-y-f16.gguf", "size" => 1},
+          %{"rfilename" => "README.md", "size" => 99}
+        ]
+      }
+
+      repo = HuggingFace.parse_repo(body)
+      assert repo.mmproj_bytes == 1
+      assert [%{quant: "Q4_K_M", bytes: 15}, %{quant: "Q8_0", bytes: 30}] = repo.quants
+      assert HuggingFace.quant(repo, "q8_0").bytes == 30
+    end
+
+    test "quant_of reads the usual labels" do
+      assert HuggingFace.quant_of("Model-Q4_K_M.gguf") == "Q4_K_M"
+      assert HuggingFace.quant_of("model.iq4_xs.gguf") == "IQ4_XS"
+      assert HuggingFace.quant_of("model-UD-Q2_K_XL.gguf") == "Q2_K"
+      assert HuggingFace.quant_of("model-bf16-00001-of-00003.gguf") == "BF16"
+      assert HuggingFace.quant_of("mmproj.gguf") == nil
+    end
+  end
+
+  describe "Catalog" do
+    test "ships the curated list and resolves ids, repos and hf.co tags" do
+      all = Catalog.all()
+      assert length(all) >= 10
+      assert Enum.all?(all, &(&1.repo =~ "/" and &1.params_b > 0 and &1.quant != ""))
+
+      e = Catalog.find("superqwen-abliterated")
+      assert e.repo == "Jiunsong/SuperQwen3.8-27b-abliterated-GGUF"
+      assert Catalog.tag(e) == "hf.co/Jiunsong/SuperQwen3.8-27b-abliterated-GGUF:Q4_K_M"
+      assert Catalog.find("hf.co/Jiunsong/SuperQwen3.8-27b-abliterated-GGUF:Q4_K_M") == e
+      assert Catalog.find("jiunsong/superqwen3.8-27b-abliterated-gguf") == e
+      assert Catalog.find("nope") == nil
+    end
+
+    test "user catalog entries merge on top of shipped ones" do
+      dir = Path.join(System.tmp_dir!(), "osa-cat-#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+      path = Path.join(dir, "local_catalog.json")
+
+      File.write!(
+        path,
+        Jason.encode!(%{
+          "models" => [
+            %{"id" => "mine", "repo" => "me/my-GGUF", "params_b" => 4, "quant" => "Q8_0"},
+            %{
+              "id" => "superqwen-abliterated",
+              "repo" => "me/override-GGUF",
+              "params_b" => 1,
+              "quant" => "Q8_0"
+            }
+          ]
+        })
+      )
+
+      Application.put_env(:optimal_system_agent, :local_catalog_user_path, path)
+
+      on_exit(fn ->
+        Application.delete_env(:optimal_system_agent, :local_catalog_user_path)
+        File.rm_rf(dir)
+      end)
+
+      assert %{source: :user, repo: "me/my-GGUF"} = Catalog.find("mine")
+      assert %{source: :user, repo: "me/override-GGUF"} = Catalog.find("superqwen-abliterated")
+    end
+  end
+
+  describe "OllamaAdmin (stubbed daemon)" do
+    setup do
+      name = :"osa_admin_#{System.unique_integer([:positive])}"
+      {:ok, plug: [plug: {Req.Test, name}], name: name}
+    end
+
+    test "installed/1 flags cloud tags as remote", %{plug: plug, name: name} do
+      Req.Test.stub(name, fn conn ->
+        Req.Test.json(conn, %{
+          "models" => [
+            %{
+              "name" => "superqwen-abliterated:latest",
+              "size" => 17,
+              "details" => %{"quantization_level" => "Q4_K_M", "parameter_size" => "26.9B"}
+            },
+            %{"name" => "glm-5.2:cloud", "size" => 0, "remote_host" => "https://ollama.com"}
+          ]
+        })
+      end)
+
+      assert {:ok, [local, cloud]} = OllamaAdmin.installed(plug)
+      assert %{name: "superqwen-abliterated:latest", quant: "Q4_K_M", remote: false} = local
+      assert cloud.remote
+    end
+
+    test "installed/1 reads the quant from the tag when Ollama says unknown", %{
+      plug: plug,
+      name: name
+    } do
+      Req.Test.stub(name, fn conn ->
+        Req.Test.json(conn, %{
+          "models" => [
+            %{
+              "name" => "hf.co/x/y-GGUF:q5_k_m",
+              "size" => 1,
+              "digest" => "abc",
+              "details" => %{"quantization_level" => "unknown"}
+            },
+            %{
+              "name" => "alias:latest",
+              "size" => 1,
+              "digest" => "abc",
+              "details" => %{"quantization_level" => "unknown"}
+            }
+          ]
+        })
+      end)
+
+      assert {:ok, [%{quant: "Q5_K_M", digest: "abc"}, %{quant: nil, digest: "abc"}]} =
+               OllamaAdmin.installed(plug)
+    end
+
+    test "show/2 extracts capabilities and exact KV size", %{plug: plug, name: name} do
+      Req.Test.stub(name, fn conn ->
+        Req.Test.json(conn, %{
+          "capabilities" => ["tools", "vision"],
+          "details" => %{"family" => "qwen35", "quantization_level" => "Q4_K_M"},
+          "model_info" => %{
+            "general.architecture" => "qwen35",
+            "general.parameter_count" => 26_895_998_464,
+            "qwen35.context_length" => 262_144,
+            "qwen35.block_count" => 64,
+            "qwen35.attention.head_count" => 40,
+            "qwen35.attention.head_count_kv" => 8,
+            "qwen35.embedding_length" => 5120
+          }
+        })
+      end)
+
+      assert {:ok, d} = OllamaAdmin.show("x", plug)
+      assert d.capabilities == ["tools", "vision"]
+      assert d.context_length == 262_144
+      assert d.kv_bytes_per_token == 2 * 64 * 8 * 128 * 2
+    end
+
+    test "bench/3 converts Ollama's nanosecond timings to tok/s", %{plug: plug, name: name} do
+      Req.Test.stub(name, fn conn ->
+        Req.Test.json(conn, %{
+          "eval_count" => 64,
+          "eval_duration" => 2_000_000_000,
+          "prompt_eval_count" => 20,
+          "prompt_eval_duration" => 100_000_000,
+          "load_duration" => 1_500_000_000
+        })
+      end)
+
+      assert {:ok, %{decode_tps: 32.0, prompt_tps: 200.0, load_ms: 1500}} =
+               OllamaAdmin.bench("x", 64, plug)
+    end
+
+    test "pull/3 streams progress and reports Ollama errors", %{plug: plug, name: name} do
+      Req.Test.stub(name, fn conn ->
+        body =
+          [
+            ~s({"status":"pulling manifest"}),
+            ~s({"status":"pulling abc","total":100,"completed":50}),
+            ~s({"status":"success"})
+          ]
+          |> Enum.join("\n")
+
+        conn
+        |> Plug.Conn.put_resp_content_type("application/x-ndjson")
+        |> Plug.Conn.send_resp(200, body <> "\n")
+      end)
+
+      {:ok, agent} = Agent.start_link(fn -> [] end)
+      assert :ok = OllamaAdmin.pull("x", fn ev -> Agent.update(agent, &[ev | &1]) end, plug)
+      events = agent |> Agent.get(& &1) |> Enum.reverse()
+
+      assert [%{status: "pulling manifest"}, %{completed: 50, total: 100}, %{status: "success"}] =
+               events
+
+      Req.Test.stub(name, fn conn ->
+        Plug.Conn.send_resp(
+          conn,
+          200,
+          ~s({"error":"pull model manifest: file does not exist"}) <> "\n"
+        )
+      end)
+
+      assert {:error, "pull model manifest: file does not exist"} =
+               OllamaAdmin.pull("x", fn _ -> :ok end, plug)
+    end
+
+    test "a daemon that is down is an error, not a crash", %{plug: plug, name: name} do
+      Req.Test.stub(name, fn conn -> Req.Test.transport_error(conn, :econnrefused) end)
+      assert {:error, msg} = OllamaAdmin.installed(plug)
+      assert msg =~ "not running"
+    end
+  end
+
+  describe "LocalModels.resolve/1" do
+    # Point the "local daemon" at a dead port so the real one on this machine
+    # cannot turn a catalog id into an installed tag.
+    setup do
+      prev = Application.get_env(:optimal_system_agent, :ollama_url)
+      Application.put_env(:optimal_system_agent, :ollama_url, "http://127.0.0.1:1")
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:optimal_system_agent, :ollama_url, prev),
+          else: Application.delete_env(:optimal_system_agent, :ollama_url)
+      end)
+
+      :ok
+    end
+
+    test "catalog ids, hf tags and unknowns" do
+      assert {:catalog, %{id: "superqwen-abliterated"}, nil} =
+               LocalModels.resolve("superqwen-abliterated")
+
+      assert {:catalog, %{id: "superqwen-abliterated"}, "Q4_K_M"} =
+               LocalModels.resolve("hf.co/Jiunsong/SuperQwen3.8-27b-abliterated-GGUF:Q4_K_M")
+
+      assert {:hf, "some/other-GGUF", "Q5_K_M"} =
+               LocalModels.resolve("hf.co/some/other-GGUF:Q5_K_M")
+
+      assert {:hf, "some/other-GGUF", nil} = LocalModels.resolve("some/other-GGUF")
+      assert :unknown = LocalModels.resolve("")
+    end
+  end
+
+  describe "/models command" do
+    test "is registered and prints usage for bad input" do
+      assert "models" in Commands.list()
+      out = capture_io(fn -> Commands.dispatch("models bogus", "no-session") end)
+      assert out =~ "/models install"
+
+      assert capture_io(fn -> Commands.dispatch("models install", "no-session") end) =~
+               "/models install"
+    end
+
+    test "hardware prints what was detected" do
+      out = capture_io(fn -> Commands.dispatch("models hardware", "no-session") end)
+      assert out =~ "VRAM"
+      assert out =~ "Bandwidth"
+    end
+  end
+end

--- a/test/tools/prompt_assembler_native_dedup_test.exs
+++ b/test/tools/prompt_assembler_native_dedup_test.exs
@@ -211,12 +211,12 @@ defmodule OptimalSystemAgent.Tools.PromptAssemblerNativeDedupTest do
       assert Context.static_base_variant(:replicate, false) == :full
     end
 
-    test "the lite path is untouched and wins over the cut" do
+    test "a small window takes the smaller of lite / native, per transport" do
       Application.put_env(:optimal_system_agent, :dedupe_native_tool_prompt, true)
-
-      assert Context.static_base_variant(:ollama, true) == :lite,
-             "on the lite path ToolFilter separately caps the native array, so the " <>
-               "prose and the array describe different sets and nothing may be dropped"
+      assert Context.static_base_variant(:anthropic, true) == :native_tools
+      assert Context.static_base_variant(:claude_cli, true) == :lite
+      Application.put_env(:optimal_system_agent, :dedupe_native_tool_prompt, false)
+      assert Context.static_base_variant(:anthropic, true) == :lite
     end
 
     test "the config flag reverts everything without a code change" do


### PR DESCRIPTION
Stacked on #191 (base branch = `feat/system-prompt-overrides`); rebase onto `main` once that merges.

## What

**`/models` (CLI)** — manage local GGUF models from inside OSA:

```
/models                      installed + curated catalog, each with a fit verdict for THIS machine
/models info <model>         capabilities, size per quant (exact, from Hugging Face), est./measured tok/s,
                             and the "OSA on this model" profile (window, prompt variant, compaction, tools)
/models install <model> [q]  pull with streamed progress (catalog id, hf.co/repo:quant, or Ollama tag), then benchmark
/models use <model>          switch this session + make it the default
/models remove | load | unload | bench | alias | search | hardware
```

**TUI catalog screen** — `Tab` in the model picker (provider list, or inside Ollama Local): installed models (● in VRAM, measured tok/s), then the curated catalog with `✓/⚠/✗` fit badges → Enter shows the quant ladder (exact GB, fit, est. tok/s, ★ recommended for this card) → Enter installs with a live progress bar, benchmarks, and offers "use it now". `d d` deletes, `r` refreshes. Existing Ollama Local rows also carry a fit/speed/capabilities note.

**Auto context window** — `:ollama_num_ctx` was a compile-time 32,768 with no override. Default is now `auto`: the largest bucket whose KV cache fits VRAM beside the weights (floored at 32k, capped at the trained window); `OLLAMA_NUM_CTX=<n>` pins it. SuperQwen 27B Q4 on a 24 GiB card: 65,536.

**Small windows take the smaller base** — measured with the lean template: `:full` 17,215 · `:lite` 13,201 · `:native_tools` 8,950. Under 40k the variant was always `:lite`, 4.2k tokens more than the native base, on the models that could least afford it. On native-schema transports a small window now gets `:native_tools`; `:lite` stays for prompt-text transports.

## How

- `LocalModels.Hardware` — GPU/VRAM (nvidia-smi, `/sys` for AMD, unified memory on Apple Silicon), RAM, CPU, bandwidth table keyed on GPU name.
- `LocalModels.Fit` — weights (exact or `params × bytes/param(quant)`) + KV cache (exact from GGUF metadata incl. `full_attention_interval` for hybrid archs like Qwen 3.5; family-aware fallback) + 1 GiB overhead vs 92% VRAM / 70% RAM → `fits | partial | cpu | no`, plus a bandwidth-bound tok/s estimate (0.5 efficiency, calibrated: est. 26 vs measured 25.6 on a 5090 Laptop; MoE scaled by active params ×0.5).
- `LocalModels.OllamaAdmin` — `/api/tags`, `/api/ps`, `/api/show`, streamed `/api/pull`, delete, copy, keep_alive load/unload, 64-token benchmark from Ollama's `eval_duration`. Always the local daemon (`Ollama.local_daemon_url/0`).
- `LocalModels.HuggingFace` — repo file list with sizes (split parts summed, mmproj separate), 24 h disk cache; search.
- `LocalModels.Catalog` — `priv/models/local_catalog.json`, 14 verified repos 2.6B–80B; users add their own in `~/.osa/local_catalog.json`.
- `LocalModels.Installer` — background pull job in ETS with pollable progress.
- HTTP: `GET /models/local`, `GET /models/local/info?ref=`, `POST /models/local/install` → `GET /models/local/install/:id`, `POST /models/local/remove` (root router, same gate as `/onboarding/*`).
- TUI: `dialogs/model_picker/local.rs` — four picker modes (`LocalCatalog`, `LocalLoading`, `LocalDetail`, `LocalInstalling`), four actions, four `BackendEvent`s, 1 Hz poll for the pull job.

## Verified live (RTX 5090 Laptop 24 GB)

- Pulled `lfm2.5-2.6b-heretic` at Q4_K_M → measured 229.8 tok/s; info → installed; alias; remove.
- SuperQwen 27B Q4_K_M: est. ~26 tok/s, measured 25.6; auto window 65,536; profile: native_tools 9K prompt, compaction at 49K, ~40K free.
- 70B Q4 flagged partial offload at ~1 tok/s; F16 35B flagged won't fit.

## Tests

- `test/local_models/` — 29 (hardware, fit incl. hybrid KV, HF parsing, catalog, stubbed daemon, installer job, resolution, JSON view, `/models`).
- `test/channels/http/local_models_routes_test.exs` — 4.
- Updated `small_window_regime_test` / `prompt_assembler_native_dedup_test` for the variant change, with the measured numbers.
- 241 across touched suites, 0 failures. Rust: picker tests 47/47. One pre-existing env-dependent failure in `onboarding_health_check_hotfix_test.exs:218` (fails on `main` too when a signed-in daemon is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184wBQcp9hHjY9ve62w3pNG
