### PR TITLE
fix(cli): bare /compact runs the aggressive fold, not the light trim

### DIFF
--- a/lib/optimal_system_agent/channels/cli/commands.ex
+++ b/lib/optimal_system_agent/channels/cli/commands.ex
@@ -174,9 +174,11 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
     IO.puts("")
     IO.puts("  #{@dim}Compacting context...#{@reset}")
 
-    # CC parity: `/compact <instructions>` threads user guidance into the
-    # summary prompt via the proactive path; bare `/compact` keeps the
-    # legacy reactive Loop.compact path.
+    # Both forms use the aggressive proactive fold (the 9-section LLM summary
+    # that folds old turns down to a small summary + recent tail).
+    # `/compact <instructions>` threads user guidance into the summary prompt;
+    # bare `/compact` folds with no extra instructions. The old bare path used
+    # the light reactive `Loop.compact` trimmer, which only shaved ~15% off.
     case String.trim(args || "") do
       "" ->
         compact_without_instructions(session_id)
@@ -204,34 +206,27 @@ defmodule OptimalSystemAgent.Channels.CLI.Commands do
       session_id
   end
 
-  # Bare `/compact` — original reactive compaction with before/after stats.
+  # Bare `/compact` — aggressive proactive fold (no extra instructions), with
+  # before/after stats. Same crush as `/compact <instructions>`.
   defp compact_without_instructions(session_id) do
-    case Loop.get_state(session_id) do
-      {:ok, state} ->
-        before_tokens = state[:tokens_used] || state[:estimated_tokens] || 0
+    case Loop.proactive_compact(session_id, nil) do
+      {:ok, stats} ->
+        saved = stats.tokens_before - stats.tokens_after
 
-        case Loop.compact(session_id) do
-          :ok ->
-            case Loop.get_state(session_id) do
-              {:ok, after_state} ->
-                after_tokens = after_state[:tokens_used] || after_state[:estimated_tokens] || 0
-                saved = before_tokens - after_tokens
-                pct = if before_tokens > 0, do: round(saved / before_tokens * 100), else: 0
+        pct =
+          if stats.tokens_before > 0,
+            do: round(saved / stats.tokens_before * 100),
+            else: 0
 
-                IO.puts(
-                  "  #{@green}#{@reset} Compacted: #{format_tokens(before_tokens)} -> #{format_tokens(after_tokens)} (#{pct}% reduction)"
-                )
+        IO.puts(
+          "  #{@green}#{@reset} Compacted: #{format_tokens(stats.tokens_before)} -> #{format_tokens(stats.tokens_after)} (#{pct}% reduction)"
+        )
 
-              _ ->
-                IO.puts("  #{@green}#{@reset} Compacted successfully")
-            end
-
-          {:error, reason} ->
-            IO.puts("  #{@yellow}error: #{reason}#{@reset}")
-        end
-
-      _ ->
+      {:error, :no_session} ->
         IO.puts("  #{@yellow}error: no active session#{@reset}")
+
+      {:error, reason} ->
+        IO.puts("  #{@yellow}error: #{inspect(reason)}#{@reset}")
     end
   end
 


### PR DESCRIPTION
Bare `/compact` routed to `Loop.compact` — the reactive importance-weighted sliding-window trimmer — while only `/compact <instructions>` used `Loop.proactive_compact`, the 9-section LLM fold.

The trimmer keeps the hot/warm zones and only lightly summarizes the cold zone, so on a large context window it frees ~15% (e.g. **85% → 70%**). Anyone typing plain `/compact` expects the history to actually collapse, and it did not.

## Change
- Route bare `/compact` to `proactive_compact(session_id, nil)`, so **both** forms run the aggressive fold.
- `/compact <instructions>` still threads user guidance into the summary prompt; bare `/compact` folds with no extra instructions.
- Before/after stats now read straight from the proactive path's returned token counts.

Single file, `lib/optimal_system_agent/channels/cli/commands.ex`. Compiles clean; verified live on a local 1.0.163 build (bare `/compact` now folds hard instead of shaving ~15%).