### PR TITLE
Agent dashboard: live per-agent context % instead of a misleading cumulative token count

### DIFF
--- a/lib/optimal_system_agent/agent/loop/telemetry.ex
+++ b/lib/optimal_system_agent/agent/loop/telemetry.ex
@@ -103,6 +103,26 @@ defmodule OptimalSystemAgent.Agent.Loop.Telemetry do
         "above_warning=#{warning.above_warning} above_compact=#{warning.above_compact}"
     )
 
+    # Mirror this session's LIVE context utilization into the per-agent control
+    # store. A subagent's session_id IS its agent_id (Orchestrator), so the
+    # progress forwarder can read it back and surface a real "N% ctx" on the
+    # agent-dashboard row instead of a cumulative, cache-inclusive token count
+    # that reads like runaway spend. Best-effort — a telemetry write must never
+    # break the turn.
+    _ =
+      try do
+        OptimalSystemAgent.Agent.ExecutionControl.progress(
+          state.session_id,
+          # Integer percent 0..100. The TUI decodes this as Option<u32>; a float
+          # would fail that decode and drop the whole progress frame, so round.
+          %{context_percent: round(utilization * 1.0)}
+        )
+      rescue
+        _ -> :ok
+      catch
+        _, _ -> :ok
+      end
+
     Bus.emit(:system_event, %{
       event: :context_pressure,
       session_id: state.session_id,

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -3177,7 +3177,11 @@ defmodule OptimalSystemAgent.Orchestrator do
           :skill_reason,
           :retry_count,
           :failure_count,
-          :delivery_status
+          :delivery_status,
+          # Live context-window utilization (percent) mirrored from this
+          # subagent's own telemetry, so the dashboard row can show real
+          # occupancy instead of a cumulative token count.
+          :context_percent
         ])
         |> Map.put(
           :available_controls,

--- a/priv/rust/tui/src/app/handle_backend.rs
+++ b/priv/rust/tui/src/app/handle_backend.rs
@@ -1965,6 +1965,7 @@ impl App {
                 failure_count,
                 delivery_status,
                 available_controls,
+                context_percent,
             } => {
                 self.agents.agent_progress(
                     &agent_name,
@@ -1975,6 +1976,7 @@ impl App {
                     recent_actions,
                     elapsed_ms,
                 );
+                self.agents.set_agent_context(&agent_name, context_percent);
                 self.agents.agent_runtime(
                     &agent_name,
                     active_skills,

--- a/priv/rust/tui/src/client/sse.rs
+++ b/priv/rust/tui/src/client/sse.rs
@@ -1175,6 +1175,10 @@ fn parse_system_event(data: &[u8]) -> Option<BackendEvent> {
                 delivery_status: String,
                 #[serde(default)]
                 available_controls: Vec<String>,
+                /// Live context-window utilization (percent) for this agent's
+                /// own session. Absent from older backends -> None.
+                #[serde(default)]
+                context_percent: Option<u32>,
             }
             let ev: Ev = serde_json::from_slice(data).ok()?;
             Some(BackendEvent::OrchestratorAgentProgress {
@@ -1192,6 +1196,7 @@ fn parse_system_event(data: &[u8]) -> Option<BackendEvent> {
                 failure_count: ev.failure_count,
                 delivery_status: ev.delivery_status,
                 available_controls: ev.available_controls,
+                context_percent: ev.context_percent,
             })
         }
 
@@ -2760,6 +2765,27 @@ mod tests {
                 assert_eq!(retry_count, 2);
                 assert_eq!(failure_count, 1);
                 assert_eq!(delivery_status, "acknowledged");
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn progress_carries_live_context_percent() {
+        // A frame that includes the live context utilization decodes it...
+        let frame = br#"{"event":"orchestrator_agent_progress","agent_name":"worker","current_action":"searching","tool_uses":8,"tokens_used":900000,"context_percent":42}"#;
+        match parse_sse_event("orchestrator_agent_progress", frame) {
+            Some(BackendEvent::OrchestratorAgentProgress { context_percent, .. }) => {
+                assert_eq!(context_percent, Some(42));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+
+        // ...and an older frame without it decodes to None rather than dropping.
+        let legacy = br#"{"event":"orchestrator_agent_progress","agent_name":"worker","current_action":"searching","tool_uses":8,"tokens_used":900000}"#;
+        match parse_sse_event("orchestrator_agent_progress", legacy) {
+            Some(BackendEvent::OrchestratorAgentProgress { context_percent, .. }) => {
+                assert_eq!(context_percent, None);
             }
             other => panic!("unexpected: {:?}", other),
         }

--- a/priv/rust/tui/src/components/agents/entry.rs
+++ b/priv/rust/tui/src/components/agents/entry.rs
@@ -50,6 +50,11 @@ pub struct AgentEntry {
     pub recent_actions: Vec<String>,
     pub tool_uses: u32,
     pub tokens_used: u32,
+    /// Live context-window utilization (percent) for this agent's own session,
+    /// mirrored from its telemetry. `None` until the first progress frame that
+    /// carries it (older backends never send it). Shown on the row as `N% ctx`
+    /// so the dashboard reflects real occupancy, not a cumulative token count.
+    pub context_percent: Option<u32>,
     pub batch_id: Option<String>,
     /// When this agent's RUN started — drives the dashboard "elapsed" column.
     ///

--- a/priv/rust/tui/src/components/agents/mod.rs
+++ b/priv/rust/tui/src/components/agents/mod.rs
@@ -796,6 +796,7 @@ impl Agents {
                     recent_actions: Vec::new(),
                     tool_uses: 0,
                     tokens_used: 0,
+                    context_percent: None,
                     batch_id: None,
                     started_at: std::time::Instant::now(),
                     finished_at: None,
@@ -873,6 +874,7 @@ impl Agents {
                 recent_actions: Vec::new(),
                 tool_uses: 0,
                 tokens_used: 0,
+                context_percent: None,
                 batch_id,
                 started_at: std::time::Instant::now(),
                 finished_at: None,
@@ -934,6 +936,17 @@ impl Agents {
             }
             if !subject.is_empty() && entry.subject.is_empty() {
                 entry.subject = subject;
+            }
+        }
+    }
+
+    /// Update an agent's live context-window utilization from its own telemetry.
+    /// `None` leaves the last reading untouched, so a progress frame from an
+    /// older backend that omits the field never wipes a good value.
+    pub fn set_agent_context(&mut self, name: &str, context_percent: Option<u32>) {
+        if let Some(pct) = context_percent {
+            if let Some(entry) = self.entries.iter_mut().find(|e| e.name == name) {
+                entry.context_percent = Some(pct);
             }
         }
     }
@@ -1099,6 +1112,7 @@ impl Agents {
                 recent_actions: Vec::new(),
                 tool_uses: 0,
                 tokens_used: 0,
+                context_percent: None,
                 batch_id: Some("background".to_string()),
                 started_at: now,
                 finished_at: None,

--- a/priv/rust/tui/src/components/agents/render.rs
+++ b/priv/rust/tui/src/components/agents/render.rs
@@ -901,13 +901,23 @@ impl Agents {
                 // elapsed/tool/token counts, and — once the agent is finished —
                 // what it cost. A finished agent whose cost was never reported
                 // shows `—`, because `$0.00` would be a claim we cannot make.
+                // Live context-window occupancy for this agent's own session,
+                // when its telemetry has reported it. This is the number that
+                // actually answers "is it close to full?" — the `tok` count is
+                // cumulative throughput (cache reads re-counted every turn) and
+                // reads like runaway spend, so ctx% is the honest gauge.
+                let ctx = match entry.context_percent {
+                    Some(p) => format!(" · {}% ctx", p),
+                    None => String::new(),
+                };
                 let meta = format!(
-                    "  {} {} · {} tool{} · {} tok · {}",
+                    "  {} {} · {} tool{} · {} tok{} · {}",
                     token_bar(entry.tokens_used, max_tokens),
                     fmt_elapsed(entry.elapsed_secs()),
                     entry.tool_uses,
                     if entry.tool_uses == 1 { "" } else { "s" },
                     fmt_tokens(entry.tokens_used),
+                    ctx,
                     fmt_cost_opt(entry.cost_usd),
                 );
 

--- a/priv/rust/tui/src/event/backend.rs
+++ b/priv/rust/tui/src/event/backend.rs
@@ -183,6 +183,9 @@ pub enum BackendEvent {
         failure_count: u32,
         delivery_status: String,
         available_controls: Vec<String>,
+        /// Live context-window utilization (percent) for this agent's session,
+        /// or None from an older backend.
+        context_percent: Option<u32>,
     },
     AgentControlResult {
         agent_id: String,


### PR DESCRIPTION
The agent dashboard showed each subagent's **cumulative, cache-inclusive** token count (the "2.9M–4.1M tok" that looked like runaway spend). That number is mostly cheap cache re-reads counted every turn — it answers neither "how full is the window?" nor "what did it cost?".

## What changed
Each subagent's telemetry already computes its live context-window utilization. Now it mirrors that into `ExecutionControl` (a subagent's `session_id` **is** its `agent_id`), the orchestrator progress forwarder ships it as `context_percent`, and the TUI renders **`N% ctx`** on the row next to the throughput count.

- **Backend:** `telemetry.ex` writes a rounded integer percent into `ExecutionControl` (best-effort, can't break the turn); `orchestrator.ex` adds `:context_percent` to the progress event via `execution_event_fields`.
- **Rust TUI:** decode the field, store `AgentEntry.context_percent`, `set_agent_context`, render `· N% ctx`. +1 decode test (with field → `Some`, without → `None`).
- **Additive / backward-compatible:** the field is `Option`; absent from older backends → `None` → the row is unchanged.

## Deliberately NOT changed
The "Cost: not reported" line stays — it's **honest** for a model OSA has no rate card for (glm-cloud); a fake `$0.00` would be worse.

## Verification
- Elixir backend compiles clean; `execution_control` tests 4/0.
- Rust TUI compiles clean; SSE decode tests pass (new + existing).
- **Needs a visual check:** I can't render the TUI from here — the `N% ctx` on the row should be eyeballed after `osa update` before this is considered fully done.