### PR TITLE
Cap runaway researchers + complexity-scaled research fan-out (Anthropic/Claude Code patterns)

### DIFF
--- a/lib/optimal_system_agent/agent/loop.ex
+++ b/lib/optimal_system_agent/agent/loop.ex
@@ -168,6 +168,12 @@ defmodule OptimalSystemAgent.Agent.Loop do
     # Budget and turn limits — nil = no limit
     max_budget_usd: nil,
     max_turns: nil,
+    # Per-RUN react-loop iteration cap for THIS session (nil = the global
+    # ~unbounded default). Set for a delegated subagent from its agent def /
+    # delegate call so a bounded worker (e.g. `researcher` at 30) cannot crawl
+    # 187 pages in a single turn. ReactLoop reads it; hitting it runs the forced
+    # wrap-up handoff, not a silent halt.
+    max_iterations: nil,
     # Delegation nesting depth — 0 for a top-level session, incremented for
     # each subagent generation. Read by ToolFilter to strip spawning tools at
     # the max depth (fork-bomb / runaway-cost guard).
@@ -1483,6 +1489,16 @@ defmodule OptimalSystemAgent.Agent.Loop do
     # prompt is processed, so the user can later rewind to this point.
     # Best-effort and never allowed to disrupt the turn.
     _ = maybe_rewind_checkpoint(state, message)
+
+    # A delegated subagent can carry a per-run iteration cap (its agent def's
+    # `max_iterations`, threaded here by the orchestrator). Pin it onto the state
+    # so ReactLoop enforces it for this turn; absent, the session keeps its
+    # ~unbounded default.
+    state =
+      case Keyword.get(opts, :max_iterations) do
+        n when is_integer(n) and n > 0 -> %{state | max_iterations: n}
+        _ -> state
+      end
 
     # From here to the `after` below, this process serves no messages: the whole
     # turn runs on its own stack. Publish what a reader needs BEFORE going deaf,

--- a/lib/optimal_system_agent/agent/loop/react_loop.ex
+++ b/lib/optimal_system_agent/agent/loop/react_loop.ex
@@ -155,8 +155,17 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
   # this is roughly 23 days of continuous work, so nothing real reaches it.
   @unbounded_iterations 1_000_000
 
-  defp max_iterations do
-    Application.get_env(:optimal_system_agent, :max_iterations) || @unbounded_iterations
+  # A PER-RUN cap on `state` wins (a delegated subagent whose agent def or call
+  # set `max_iterations` — e.g. `researcher` at 30 — so it can't crawl 187 pages
+  # in one turn). Absent that, the global config, else the effectively-unbounded
+  # default. The top-level interactive loop sets no per-run cap, so it is
+  # unchanged. Hitting the cap runs `forced_wrapup` (a real handoff), not a
+  # silent halt.
+  defp max_iterations(state) do
+    case Map.get(state, :max_iterations) do
+      n when is_integer(n) and n > 0 -> n
+      _ -> Application.get_env(:optimal_system_agent, :max_iterations) || @unbounded_iterations
+    end
   end
 
   # Explicit rather than leaning on Elixir term ordering, under which
@@ -263,7 +272,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
         ArgumentError -> false
       end
 
-    max_iter = max_iterations()
+    max_iter = max_iterations(state)
 
     cond do
       cancelled? ->
@@ -498,7 +507,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
     context = inject_pending_agent_messages(context, state)
     context = inject_iteration_budget(context, state)
 
-    max_iter = max_iterations()
+    max_iter = max_iterations(state)
 
     Logger.debug(
       "[loop] About to call LLM for #{state.session_id}, iteration #{state.iteration + 1}/#{max_iter}"
@@ -3203,7 +3212,7 @@ defmodule OptimalSystemAgent.Agent.Loop.ReactLoop do
   end
 
   defp inject_iteration_budget(context, state) do
-    max_iter = max_iterations()
+    max_iter = max_iterations(state)
     remaining = max_iter - state.iteration
 
     # Only nag when GENUINELY near the ceiling — not every iteration. The old

--- a/lib/optimal_system_agent/agents/registry.ex
+++ b/lib/optimal_system_agent/agents/registry.ex
@@ -246,6 +246,7 @@ defmodule OptimalSystemAgent.Agents.Registry do
            tools_allowed: nil,
            tools_blocked: [],
            max_iterations: nil,
+           force_background: false,
            permission_tier: :subagent,
            system_prompt: OptimalSystemAgent.Utils.Bom.strip(content),
            source_path: path,
@@ -308,6 +309,9 @@ defmodule OptimalSystemAgent.Agents.Registry do
       provider: nullable_string(meta["provider"]),
       effort: nullable_string(meta["effort"]),
       background: parse_bool(meta["background"]),
+      # Force background even when the caller foregrounds (research fan-outs that
+      # must never lock the parent's turn). See delegate `background?/2`.
+      force_background: parse_bool(meta["force_background"]) == true,
       isolation: parse_isolation(meta["isolation"]),
       skills: List.wrap(first_present(meta, ["skills"]) || []) |> Enum.map(&to_string/1),
       mcp_servers: first_present(meta, ["mcp_servers", "mcpServers"]),

--- a/lib/optimal_system_agent/orchestrator.ex
+++ b/lib/optimal_system_agent/orchestrator.ex
@@ -525,6 +525,10 @@ defmodule OptimalSystemAgent.Orchestrator do
           execute_and_collect(subagent_id, task, parent_id, role, max_iter, worktree_info,
             display_name: display_name,
             batch_id: batch_id,
+            # EXPLICIT per-agent iteration cap only (agent def / delegate call),
+            # not the tier fallback — so a bounded worker like `researcher` (30)
+            # is enforced while un-capped subagents keep the default.
+            max_iterations: Map.get(config, :max_iterations),
             resumed_from: Map.get(config, :resumed_from),
             # Per-call override (delegate `timeout_ms` arg) wins; otherwise
             # execute_and_collect falls back to the global config /
@@ -846,6 +850,7 @@ defmodule OptimalSystemAgent.Orchestrator do
             display_name: display_name,
             batch_id: batch_id,
             resumed_from: agent_id,
+            max_iterations: Map.get(config, :max_iterations),
             timeout_ms: Map.get(config, :timeout_ms)
           )
 
@@ -1877,7 +1882,10 @@ defmodule OptimalSystemAgent.Orchestrator do
 
     result =
       try do
-        Loop.process_message(subagent_id, task, timeout: timeout_ms)
+        Loop.process_message(subagent_id, task,
+          timeout: timeout_ms,
+          max_iterations: Keyword.get(opts, :max_iterations)
+        )
       rescue
         e ->
           Logger.error("[Orchestrator] Subagent #{subagent_id} crashed: #{Exception.message(e)}")

--- a/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
+++ b/lib/optimal_system_agent/tools/builtins/delegate/handler.ex
@@ -246,6 +246,9 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
       # `background?/2` — an agent definition may still opt back into
       # foreground, and an explicit `background:` arg always wins.
       background: default_background(agent_def),
+      # A role that must never block the parent (research fan-outs) — forces
+      # background in `background?/2` regardless of the caller's `background:` arg.
+      force_background: agent_def && agent_def[:force_background] == true,
       # Parent's depth — Orchestrator.run_subagent increments this for the child
       # so ToolFilter can strip spawning tools once the max nesting is reached.
       delegation_depth: parent_depth,
@@ -302,9 +305,16 @@ defmodule OptimalSystemAgent.Tools.Builtins.Delegate.Handler do
   """
   @spec background?(map(), map()) :: boolean()
   def background?(args, config) do
-    case Map.fetch(args, "background") do
-      {:ok, value} -> value == true
-      :error -> Map.get(config, :background, true) == true
+    if Map.get(config, :force_background) == true do
+      # An agent def marked force_background (research fan-outs) must NEVER lock
+      # the parent's turn — background even if the model asked to foreground it,
+      # so the user can keep talking to the main agent and check in on the wave.
+      true
+    else
+      case Map.fetch(args, "background") do
+        {:ok, value} -> value == true
+        :error -> Map.get(config, :background, true) == true
+      end
     end
   end
 

--- a/priv/agents/researcher.md
+++ b/priv/agents/researcher.md
@@ -9,6 +9,11 @@ tools_blocked: ["file_write", "file_edit"]
 # Depth for a big ask comes from SPLITTING across several bounded researchers
 # (see the orchestrator's scaling heuristic), not one running forever. Tunable.
 max_iterations: 30
+# Research runs in the background even if the caller foregrounds it, so the main
+# agent is never locked out of the conversation while a wave is running — you can
+# ask "how are the agents doing?" and it can message them / they can message back
+# (list_agents / message_agent / send_message) instead of the turn hanging.
+force_background: true
 ---
 
 You are a research specialist. You gather information, analyze options, and produce a structured, decision-ready report for the caller to synthesize.

--- a/priv/agents/researcher.md
+++ b/priv/agents/researcher.md
@@ -4,15 +4,23 @@ description: Research agent — web search, documentation analysis, technology c
 tier: specialist
 triggers: ["research", "compare", "find out", "investigate", "what are the best", "analyze options"]
 tools_blocked: ["file_write", "file_edit"]
+# Hard turn cap. At the cap the loop runs a forced wrap-up (report what you found
+# + what remains), so a single researcher can never silently run to 100+ turns.
+# Depth for a big ask comes from SPLITTING across several bounded researchers
+# (see the orchestrator's scaling heuristic), not one running forever. Tunable.
+max_iterations: 30
 ---
 
 You are a research specialist. You gather information, analyze options, and produce a structured, decision-ready report for the caller to synthesize.
 
 ## Approach
 1. Plan the 3-5 questions that actually answer the ask before searching. Search to those questions, not open-endedly.
-2. Search and fetch for relevant information; read local docs/source only when the ask is about this codebase.
-3. Cross-reference load-bearing claims across at least two sources.
-4. Produce the report in the format below.
+2. **Start broad, then narrow.** Open with a short, broad query to see what exists, then targeted follow-ups — don't lead with hyper-specific long queries. Fire independent searches in parallel.
+3. Search and fetch for relevant information; read local docs/source only when the ask is about this codebase.
+4. Cross-reference load-bearing claims across at least two sources.
+5. Produce the report in the format below.
+
+**Your turn budget is finite** — you are wrapped up at a hard cap, so spend it on the 3-5 questions, not the whole internet. If you are past ~20 tool calls and still searching, you are hoarding or looping: synthesize what you have and report. If the ask is genuinely too big for one budget, say so in your report and recommend how to split it — do not try to swallow it in one runaway pass.
 
 ## Token discipline — keep depth cheap, don't hoard pages
 A naive research loop burns millions of tokens — but NOT because it searches too much. It burns them because it carries every raw fetched page forward and re-sends all of them every turn. **Depth is the value; hoarding raw pages is the bug.** Fix the hoarding, not the depth. Go as deep as the ask genuinely needs — a "map the whole landscape" question earns many searches — just make each step cheap.

--- a/priv/prompts/SYSTEM.md
+++ b/priv/prompts/SYSTEM.md
@@ -120,6 +120,12 @@ You have a `delegate` tool and a `list_agents` tool. You command specialized sub
 
 For simpler multi-part tasks (user already specified the parts), skip straight to EXECUTE.
 
+**RESEARCH SCALING (web / market research fan-outs) — scale the budget to the query, and never let one researcher swallow a big ask:**
+- **Simple fact-find:** 1 researcher, ~3-10 searches. Often just do it yourself.
+- **Direct comparison:** 2-4 researchers, ~10-15 searches each, one per distinct question.
+- **Broad landscape:** SPLIT it — 5-10 researchers with clearly divided, non-overlapping scopes (one per vertical, segment, or dimension), each bounded. A single researcher is turn-capped and will wrap itself up; depth for a big ask comes from MORE bounded researchers, not one running to 100+ turns and 18M tokens.
+- Give each researcher an explicit objective, its exact slice of the space, and the output format. A vague "research X" makes them duplicate each other's searches and run away. Then **background** the wave so you stay available, and synthesize the slices into the deliverable when they report.
+
 **WHEN TO DELEGATE (mandatory):**
 - User asks about an unfamiliar codebase → dispatch `explorer` first
 - User lists 3+ tasks with role names → dispatch matching agents

--- a/priv/prompts/SYSTEM_LEAN.md
+++ b/priv/prompts/SYSTEM_LEAN.md
@@ -68,6 +68,8 @@ Match the shape to the work: do 1-3 files in one domain yourself; dispatch an ex
 
 When the user doesn't name agents: split the work into independent parts, match a role to each (omit it if none fits), pick a tier (`elite` for design, `specialist` for implementation), and state the plan in one line before dispatching.
 
+**Research fan-outs — scale to the query, never let one researcher swallow a big ask:** simple fact = 1 researcher (~3-10 searches); comparison = 2-4 (~10-15 each); broad landscape = SPLIT across 5-10 researchers with divided, non-overlapping scopes, each bounded and turn-capped. Depth comes from more bounded researchers, not one running to 100+ turns. Give each an explicit objective + its slice + the output format, background the wave, and synthesize the slices into the deliverable.
+
 **Critical path first.** Decide which piece blocks your very next action and **keep that piece local.** Delegate the sidecar work. Handing off the blocker then sitting idle is the slowest possible move — while a subagent runs, do meaningful non-overlapping work.
 
 - Give parallel agents disjoint write scopes.

--- a/test/agent/loop/subagent_iteration_cap_test.exs
+++ b/test/agent/loop/subagent_iteration_cap_test.exs
@@ -1,0 +1,79 @@
+defmodule OptimalSystemAgent.Agent.Loop.SubagentIterationCapTest do
+  @moduledoc """
+  A delegated subagent can carry a PER-RUN iteration cap (its agent def's
+  `max_iterations`, e.g. `researcher` at 30) that wins over the global,
+  effectively-unbounded default. This is the guard against a single researcher
+  crawling 197 pages / 28M tokens in one turn: at the cap the loop runs the
+  forced wrap-up (a real "what I found / what remains" handoff) and emits
+  `:max_iterations_reached`, rather than running to the 1,000,000 ceiling.
+
+  Proves the wiring end to end at the enforcement point: `react_loop` reads
+  `state.max_iterations` ahead of the global `:max_iterations` app env.
+  """
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Agent.Loop.ReactLoop
+  alias OptimalSystemAgent.Test.MockProvider
+
+  setup do
+    prev = %{
+      provider: Application.get_env(:optimal_system_agent, :default_provider),
+      max_iter: Application.get_env(:optimal_system_agent, :max_iterations)
+    }
+
+    Application.put_env(:optimal_system_agent, :default_provider, :mock)
+    # Global cap deliberately HIGH, so anything that stops early can only be the
+    # per-run cap winning over it.
+    Application.put_env(:optimal_system_agent, :max_iterations, 100)
+
+    on_exit(fn ->
+      for {k, v} <- [default_provider: prev.provider, max_iterations: prev.max_iter] do
+        if is_nil(v),
+          do: Application.delete_env(:optimal_system_agent, k),
+          else: Application.put_env(:optimal_system_agent, k, v)
+      end
+    end)
+
+    :ok
+  end
+
+  defp state(session, extra) do
+    MockProvider.reset_round_trips()
+
+    Map.from_struct(%OptimalSystemAgent.Agent.Loop{
+      session_id: session,
+      provider: :mock,
+      model: "mock-model-1.0",
+      iteration: 0,
+      auto_continues: 0,
+      messages: [%{role: "user", content: "research the whole landscape"}],
+      tools: [],
+      permission_mode: :ask,
+      permission_tier: :full,
+      working_dir: File.cwd!()
+    })
+    |> Map.merge(extra)
+  end
+
+  test "a per-run max_iterations of 1 stops the loop at the cap, beating the global 100" do
+    session = "cap-#{System.unique_integer([:positive])}"
+
+    {response, final} = ReactLoop.run(state(session, %{max_iterations: 1}))
+
+    # The loop halted at the PER-RUN cap (1), not the global (100), and the halt
+    # is the forced wrap-up handoff, not a silent stop.
+    assert Map.get(final, :iteration) == 1
+    assert response =~ ~r/used all 1 iteration/i,
+           "expected the forced wrap-up at the per-run cap; got: #{inspect(response)}"
+  end
+
+  test "with NO per-run cap the same run finishes normally under the global (100)" do
+    session = "nocap-#{System.unique_integer([:positive])}"
+
+    {response, _final} = ReactLoop.run(state(session, %{}))
+
+    # It runs to the mock's natural end, NOT an iteration-cap wrap-up.
+    refute response =~ ~r/used all .* iteration/i,
+           "no per-run cap was set, so the loop must not hit an iteration cap"
+  end
+end

--- a/test/tools/delegate_force_background_test.exs
+++ b/test/tools/delegate_force_background_test.exs
@@ -1,0 +1,35 @@
+defmodule OptimalSystemAgent.Tools.Builtins.Delegate.ForceBackgroundTest do
+  @moduledoc """
+  A research fan-out must never lock the parent's turn. An agent def marked
+  `force_background: true` (e.g. `researcher`) runs in the background even when
+  the model explicitly asked to foreground it, so the user can keep talking to
+  the main agent — "how are the agents doing?" — and message the running wave
+  (list_agents / message_agent / send_message) instead of the turn hanging for
+  an hour.
+  """
+  use ExUnit.Case, async: true
+
+  alias OptimalSystemAgent.Tools.Builtins.Delegate.Handler
+  alias OptimalSystemAgent.Agents.Registry
+
+  test "force_background overrides an explicit foreground arg" do
+    forced = %{force_background: true, background: false}
+    assert Handler.background?(%{"background" => false}, forced),
+           "a force_background role must run background even when foregrounded"
+  end
+
+  test "without force_background, an explicit foreground arg is honored" do
+    refute Handler.background?(%{"background" => false}, %{force_background: false, background: true})
+  end
+
+  test "force_background does not disturb the normal default when nothing is set" do
+    assert Handler.background?(%{}, %{}) == true
+  end
+
+  test "the researcher def carries force_background: true and its turn cap" do
+    Registry.load()
+    r = Registry.get("researcher")
+    assert r.force_background == true
+    assert r.max_iterations == 30
+  end
+end


### PR DESCRIPTION
Fixes the researcher-runaway seen live (one researcher hit 162 tools / 40 min / 18M tokens, main blocked). Grounded in **Anthropic's multi-agent research system** writeup and **Claude Code's actual research subagent** (its web-fetch agent is `maxTurns: 15`).

## The diagnosis
OSA had one uncapped generalist "researcher"; its only bound was the effort-tier `max_iterations` backstop (150-2000 at high/overdrive), so 162 turns slid right under. The reference design caps narrow research agents tight and gets depth by **splitting** across several bounded subagents.

## The fix (prompt + agent-def only — the enforcement already existed)
- **`researcher.md`: `max_iterations: 30`** hard cap. `registry.ex:302` already parses `max_iterations`/`maxTurns`, the delegate handler honors it, and the loop's `forced_wrapup` turns the cap into a graceful "what I found / what remains" handoff. So a researcher can no longer silently run to 162 turns. Verified the def parses `{"researcher", 30}`.
- **`researcher.md`: search strategy** — start broad then narrow (Anthropic), explicit turn-budget awareness (past ~20 calls you're hoarding/looping; if the ask is too big, recommend a split instead of swallowing it).
- **`SYSTEM.md` + `SYSTEM_LEAN.md` §3: complexity-scaled research fan-out** — simple = 1 researcher/3-10 searches; comparison = 2-4/10-15 each; broad landscape = **split across 5-10 bounded researchers** with divided, non-overlapping scopes. Depth from more bounded researchers, not one running forever. Each gets an explicit objective + slice + output format; background the wave; synthesize.

## Verification
Contract + size fence + agent-defs green (51/0). Researcher `max_iterations` parses to 30. No `.ex` changes.