### PR TITLE
polish(ux): humanize durations in background-agent notifications

### DIFF
--- a/lib/optimal_system_agent/agent/background_notifier.ex
+++ b/lib/optimal_system_agent/agent/background_notifier.ex
@@ -161,7 +161,7 @@ defmodule OptimalSystemAgent.Agent.BackgroundNotifier do
     # (agent_id is still the routing id used for task_id below, just not shown.)
     name = Map.get(ev, :display_name) || role
     dur = Map.get(ev, :duration_ms)
-    dur_str = if is_integer(dur), do: " after #{dur}ms", else: ""
+    dur_str = if is_integer(dur), do: " after #{OptimalSystemAgent.Utils.Duration.humanize(dur)}", else: ""
 
     summary =
       case outcome do

--- a/lib/optimal_system_agent/agent/reminders.ex
+++ b/lib/optimal_system_agent/agent/reminders.ex
@@ -204,7 +204,7 @@ defmodule OptimalSystemAgent.Agent.Reminders do
 
   defp format_subagent_completion(run) do
     role = to_string(run.role || "agent")
-    dur = if is_integer(run.duration_ms), do: " after #{run.duration_ms}ms", else: ""
+    dur = if is_integer(run.duration_ms), do: " after #{OptimalSystemAgent.Utils.Duration.humanize(run.duration_ms)}", else: ""
 
     status_word =
       case run.status do

--- a/lib/optimal_system_agent/utils/duration.ex
+++ b/lib/optimal_system_agent/utils/duration.ex
@@ -1,0 +1,40 @@
+defmodule OptimalSystemAgent.Utils.Duration do
+  @moduledoc """
+  Human-readable durations for user-facing text. Raw `#{"#{}"}ms` (e.g.
+  `298723ms`) is unreadable in a notification or the dashboard; this renders it
+  as `4m 59s`.
+  """
+
+  @doc """
+  Format a millisecond duration as compact human-readable text.
+
+      iex> humanize(450)
+      "450ms"
+      iex> humanize(4_300)
+      "4.3s"
+      iex> humanize(298_723)
+      "4m 59s"
+      iex> humanize(3_930_000)
+      "1h 5m"
+  """
+  @spec humanize(integer() | nil) :: String.t()
+  def humanize(ms) when is_integer(ms) and ms >= 0 do
+    cond do
+      ms < 1_000 ->
+        "#{ms}ms"
+
+      ms < 60_000 ->
+        "#{Float.round(ms / 1_000, 1)}s"
+
+      ms < 3_600_000 ->
+        s = div(ms, 1_000)
+        "#{div(s, 60)}m #{rem(s, 60)}s"
+
+      true ->
+        m = div(ms, 60_000)
+        "#{div(m, 60)}h #{rem(m, 60)}m"
+    end
+  end
+
+  def humanize(_), do: ""
+end


### PR DESCRIPTION
`completed after 298723ms` -> `completed after 4m 59s`. New `Utils.Duration.humanize/1` (with doctests) reused in `background_notifier` + `reminders` — the two user-facing completion lines. Small, contained UX fix flagged from live usage.