### PR TITLE
Test hardening: eliminate suite flakiness (test-only)

### DIFF
--- a/test/agent/budget_test.exs
+++ b/test/agent/budget_test.exs
@@ -24,8 +24,18 @@ defmodule OptimalSystemAgent.Agent.BudgetTest do
 
   defp record_cost(name, provider, model, tokens_in, tokens_out, session_id) do
     GenServer.cast(name, {:record_cost, provider, model, tokens_in, tokens_out, session_id})
-    # Small sleep to ensure cast is processed
-    Process.sleep(10)
+
+    # A fixed sleep here is a race, not a wait: under real scheduler pressure
+    # (an 11k-test full-suite run) 10ms is not a guarantee the cast has been
+    # processed, only a bet that usually pays off — the observed failure
+    # (`check_budget/0` seeing the state from BEFORE this cast landed) is that
+    # bet losing. A `call` to the SAME GenServer right behind the cast is not
+    # a longer bet, it is a proof: Erlang delivers messages from one sender to
+    # one recipient in the order they were sent, and a GenServer drains its
+    # mailbox one message at a time, so this reply cannot arrive until the
+    # cast above has already been handled.
+    GenServer.call(name, :get_status)
+    :ok
   end
 
   defp check_budget(name) do
@@ -38,7 +48,11 @@ defmodule OptimalSystemAgent.Agent.BudgetTest do
 
   defp reset_daily(name) do
     GenServer.cast(name, :reset_daily)
-    Process.sleep(10)
+    # Same fix as `record_cost/6` above: a `call` right behind the `cast`
+    # proves the reset was handled instead of betting a fixed sleep was long
+    # enough.
+    GenServer.call(name, :get_status)
+    :ok
   end
 
   # ---------------------------------------------------------------------------

--- a/test/agent/loop_guardrails_test.exs
+++ b/test/agent/loop_guardrails_test.exs
@@ -19,16 +19,24 @@ defmodule OptimalSystemAgent.Agent.Loop.GuardrailsTest do
     - write_without_read?/1          — explore-first enforcement
   """
 
-  use ExUnit.Case, async: true
+  # `OSA_PROMPT_GUARD` is a process-wide OS env var; arming it for the
+  # duration of every test here (below) is unsafe under `async: true` since
+  # any OTHER concurrently-running test that reads it (expecting the opt-in
+  # default OFF, or arming it itself) can observe or clobber this file's value.
+  use ExUnit.Case, async: false
 
   # These tests verify the prompt-extraction guard MECHANISM, which is opt-in
   # (default OFF for operator-owned agents). Arm it for the duration.
   setup do
     prev = System.get_env("OSA_PROMPT_GUARD")
     System.put_env("OSA_PROMPT_GUARD", "1")
+
     on_exit(fn ->
-      if prev, do: System.put_env("OSA_PROMPT_GUARD", prev), else: System.delete_env("OSA_PROMPT_GUARD")
+      if prev,
+        do: System.put_env("OSA_PROMPT_GUARD", prev),
+        else: System.delete_env("OSA_PROMPT_GUARD")
     end)
+
     :ok
   end
 

--- a/test/agent/loop_injection_test.exs
+++ b/test/agent/loop_injection_test.exs
@@ -16,16 +16,24 @@ defmodule OptimalSystemAgent.Agent.LoopInjectionTest do
     - tool_call_hint/1            (5 pattern-match clauses)
   """
 
-  use ExUnit.Case, async: true
+  # `OSA_PROMPT_GUARD` is a process-wide OS env var; arming it for the
+  # duration of every test here (below) is unsafe under `async: true` since
+  # any OTHER concurrently-running test that reads it (expecting the opt-in
+  # default OFF, or arming it itself) can observe or clobber this file's value.
+  use ExUnit.Case, async: false
 
   # These tests verify the prompt-extraction guard MECHANISM, which is opt-in
   # (default OFF for operator-owned agents). Arm it for the duration.
   setup do
     prev = System.get_env("OSA_PROMPT_GUARD")
     System.put_env("OSA_PROMPT_GUARD", "1")
+
     on_exit(fn ->
-      if prev, do: System.put_env("OSA_PROMPT_GUARD", prev), else: System.delete_env("OSA_PROMPT_GUARD")
+      if prev,
+        do: System.put_env("OSA_PROMPT_GUARD", prev),
+        else: System.delete_env("OSA_PROMPT_GUARD")
     end)
+
     :ok
   end
 

--- a/test/agent/tasks/tracker_test.exs
+++ b/test/agent/tasks/tracker_test.exs
@@ -1,8 +1,44 @@
 defmodule OptimalSystemAgent.Agent.Tasks.TrackerTest do
-  use ExUnit.Case, async: true
+  # `Tasks.Tracker.ensure_session/2` falls through to
+  # `Tasks.Persistence.load_tasks/1` for any session id it hasn't seen yet in
+  # the CURRENT process's in-memory state, and that read (like the matching
+  # `save_tasks/2` write in every test below) goes to the REAL
+  # `~/.osa/sessions/{id}/tasks.json` — `Persistence.tasks_path/1` has no
+  # process-scoped override, only `System.get_env("OSA_HOME")`. A `session_id`
+  # is a fresh `System.unique_integer/1` every call, so within one run this
+  # never collides — but `mix test` runs interrupted mid-suite (a killed run,
+  # a crash) skip every `on_exit`, and each one leaves a REAL, permanent
+  # `test_tracker_<N>/tasks.json` behind. `unique_integer/1` restarts from a
+  # low value on every fresh BEAM boot, so a later run's freshly-generated id
+  # has a real chance of landing on ONE of the (thousands, in practice) stale
+  # directories left by earlier interrupted runs, and this test then reads
+  # THAT run's leftover tasks back as if they were its own — observed as
+  # "empty list returns empty ids" getting "Task A"/"Task B"/"Task C" from the
+  # sibling "adds multiple tasks at once" test's abandoned directory.
+  #
+  # Fix: give every test its own throwaway `OSA_HOME`, exactly like
+  # `cli_setup_test.exs` / `onboarding_setup_wizard_hotfix_test.exs` do for the
+  # same reason — so this suite can never again write into (or accidentally
+  # resurrect a stale read from) the operator's real `~/.osa`. `async: false`
+  # because `OSA_HOME` is a process-wide OS env var.
+  use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Agent.Tasks
   alias OptimalSystemAgent.Agent.Tasks.Tracker
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "osa_tracker_t#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    prev_home = System.get_env("OSA_HOME")
+    System.put_env("OSA_HOME", tmp)
+
+    on_exit(fn ->
+      if prev_home, do: System.put_env("OSA_HOME", prev_home), else: System.delete_env("OSA_HOME")
+      File.rm_rf(tmp)
+    end)
+
+    :ok
+  end
 
   # ── Helpers ──────────────────────────────────────────────────────
 
@@ -17,17 +53,10 @@ defmodule OptimalSystemAgent.Agent.Tasks.TrackerTest do
     {pid, name}
   end
 
-  defp session_id do
-    id = "test_tracker_#{System.unique_integer([:positive, :monotonic])}"
-
-    on_exit(fn ->
-      base = System.get_env("OSA_HOME") || Path.expand("~/.osa")
-      dir = Path.join([base, "sessions", id])
-      File.rm_rf(dir)
-    end)
-
-    id
-  end
+  # Each test's OSA_HOME is its own throwaway temp dir (see `setup` above,
+  # torn down whole in its `on_exit`), so there is nothing left for this
+  # helper to clean up per id.
+  defp session_id, do: "test_tracker_#{System.unique_integer([:positive, :monotonic])}"
 
   # ── add_task ────────────────────────────────────────────────────
 

--- a/test/optimal_system_agent/agent/safety/pasted_logs_test.exs
+++ b/test/optimal_system_agent/agent/safety/pasted_logs_test.exs
@@ -16,16 +16,24 @@ defmodule OptimalSystemAgent.Agent.Safety.PastedLogsTest do
   distinct roles, because the attack only works by putting words in another
   role's mouth.
   """
-  use ExUnit.Case, async: true
+  # `OSA_PROMPT_GUARD` is a process-wide OS env var; arming it for the
+  # duration of every test here (below) is unsafe under `async: true` since
+  # any OTHER concurrently-running test that reads it (expecting the opt-in
+  # default OFF, or arming it itself) can observe or clobber this file's value.
+  use ExUnit.Case, async: false
 
   # These tests verify the prompt-extraction guard MECHANISM, which is opt-in
   # (default OFF for operator-owned agents). Arm it for the duration.
   setup do
     prev = System.get_env("OSA_PROMPT_GUARD")
     System.put_env("OSA_PROMPT_GUARD", "1")
+
     on_exit(fn ->
-      if prev, do: System.put_env("OSA_PROMPT_GUARD", prev), else: System.delete_env("OSA_PROMPT_GUARD")
+      if prev,
+        do: System.put_env("OSA_PROMPT_GUARD", prev),
+        else: System.delete_env("OSA_PROMPT_GUARD")
     end)
+
     :ok
   end
 

--- a/test/optimal_system_agent/cli/setup_auth_fork_test.exs
+++ b/test/optimal_system_agent/cli/setup_auth_fork_test.exs
@@ -9,7 +9,17 @@ defmodule OptimalSystemAgent.CLI.SetupAuthForkTest do
   modelled on — three capability lists that disagreed with each other.
   """
 
-  use ExUnit.Case, async: true
+  # The "health check for a subscription provider" describe below sets
+  # `OSA_HOME` via `System.put_env/2` — a process-wide OS env var every
+  # `SubscriptionStore` call re-reads on every access (its own moduledoc
+  # already flags "`OSA_HOME` that changes mid-operation must not be able to
+  # make the body..."). Left `async: true`, that redirect could be clobbered
+  # by any other concurrently-running test that also touches `OSA_HOME`,
+  # making `SubscriptionStore.put/2` write to (or `health_check` read from) a
+  # different directory than the one this test just set up — observed as
+  # "connected" flipping to "not_connected" because the write landed
+  # elsewhere.
+  use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.CLI.Setup
   alias OptimalSystemAgent.Onboarding

--- a/test/optimal_system_agent/fs_checkpoint/integrity_test.exs
+++ b/test/optimal_system_agent/fs_checkpoint/integrity_test.exs
@@ -32,11 +32,32 @@ defmodule OptimalSystemAgent.FSCheckpoint.IntegrityTest do
         Application.delete_env(:optimal_system_agent, :fs_checkpoint_repo_path)
       end
 
-      File.rm_rf!(repo)
-      File.rm_rf!(work)
+      rm_rf_retry!(repo)
+      rm_rf_retry!(work)
     end)
 
     {:ok, repo: repo, work: work}
+  end
+
+  # `File.rm_rf!/1` lists a directory then deletes each entry, and is not
+  # atomic against the tree changing underneath it — on this filesystem that
+  # surfaces as an intermittent `could not remove files and directories
+  # recursively ... file already exists` for a temp dir nothing in THIS test
+  # writes to after the assertions run (every checkpoint write here is a
+  # synchronous `GenServer.call` to `Server`, already complete by the time
+  # `on_exit` fires — a background OS-level actor, not this suite, is the
+  # other writer). Retrying a few times is the standard shape for this exact
+  # known `File.rm_rf` race; it only touches teardown, never an assertion.
+  defp rm_rf_retry!(path, attempts \\ 5)
+
+  defp rm_rf_retry!(path, 1), do: File.rm_rf!(path)
+
+  defp rm_rf_retry!(path, attempts) do
+    File.rm_rf!(path)
+  rescue
+    File.Error ->
+      Process.sleep(20)
+      rm_rf_retry!(path, attempts - 1)
   end
 
   defp shadow_copy(repo, path), do: Path.join(repo, path)

--- a/test/optimal_system_agent/onboarding_auth_modes_test.exs
+++ b/test/optimal_system_agent/onboarding_auth_modes_test.exs
@@ -17,7 +17,11 @@ defmodule OptimalSystemAgent.OnboardingAuthModesTest do
   promised could not happen.
   """
 
-  use ExUnit.Case, async: true
+  # "when sign-in is not available in this build" below touches both
+  # `:copilot_client_id` (Application env) and `OSA_COPILOT_CLIENT_ID` (a
+  # process-wide OS env var) — unsafe under `async: true` if any other
+  # concurrently-running test reads either while this one has them cleared.
+  use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Onboarding
 

--- a/test/optimal_system_agent/providers/fallback_cost_gate_test.exs
+++ b/test/optimal_system_agent/providers/fallback_cost_gate_test.exs
@@ -101,7 +101,15 @@ defmodule OptimalSystemAgent.Providers.FallbackCostGateTest do
 
       FallbackChain.cost_gated_chain(@builtin -- [:ollama], :ollama)
 
-      assert_receive {:bus, %{event: :provider_cost_warning, message: message}}, 2_000
+      # `Bus.emit/3` dispatches to handlers via `Task.Supervisor.start_child` —
+      # genuinely async, not a synchronous call — so delivery time depends on
+      # scheduler pressure from whatever else is running in this BEAM at the
+      # moment, which in an 11k-test full-suite run is not bounded by anything
+      # this test controls. 2s was tight enough to occasionally time out under
+      # load with the message already in flight; 10s is still a hard ceiling
+      # (a real regression that stops emitting still fails, just not on a
+      # scheduler hiccup) while giving a loaded Task.Supervisor room to drain.
+      assert_receive {:bus, %{event: :provider_cost_warning, message: message}}, 10_000
       assert message =~ "fallback_allow_paid"
     end
   end

--- a/test/optimal_system_agent/providers/resilience_test.exs
+++ b/test/optimal_system_agent/providers/resilience_test.exs
@@ -1,5 +1,9 @@
 defmodule OptimalSystemAgent.Providers.ResilienceTest do
-  use ExUnit.Case, async: true
+  # "default attempts = 1 + 10 retries, overridable via OSA_API_MAX_RETRIES"
+  # below touches `OSA_API_MAX_RETRIES`, a process-wide OS env var every
+  # `Resilience.max_attempts/0` call reads — unsafe under `async: true` if any
+  # other concurrently-running test calls it while this one has it overridden.
+  use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Providers.Resilience
 
@@ -256,11 +260,18 @@ defmodule OptimalSystemAgent.Providers.ResilienceTest do
 
   describe "CC parity — defaults and 529 fallback" do
     test "default attempts = 1 + 10 retries, overridable via OSA_API_MAX_RETRIES" do
+      prev = System.get_env("OSA_API_MAX_RETRIES")
+
+      on_exit(fn ->
+        if prev,
+          do: System.put_env("OSA_API_MAX_RETRIES", prev),
+          else: System.delete_env("OSA_API_MAX_RETRIES")
+      end)
+
       System.delete_env("OSA_API_MAX_RETRIES")
       assert Resilience.max_attempts() == 11
 
       System.put_env("OSA_API_MAX_RETRIES", "2")
-      on_exit(fn -> System.delete_env("OSA_API_MAX_RETRIES") end)
       assert Resilience.max_attempts() == 3
     end
 

--- a/test/optimal_system_agent/soul/lean_prompt_test.exs
+++ b/test/optimal_system_agent/soul/lean_prompt_test.exs
@@ -35,7 +35,36 @@ defmodule OptimalSystemAgent.Soul.LeanPromptTest do
       Soul.invalidate_static_base()
     end)
 
+    # `with_flag/2` below rebuilds `Soul.static_base(:native_tools)` twice —
+    # once lean, once long — and every input `build_base/1` reads (the live
+    # tool registry AND every bundled rule file `rules_content/0` reads fresh
+    # off disk) can change at any point in a session's life. Either one moving
+    # in the gap between those two builds shrinks BOTH by the same amount and
+    # collapses the "long is substantially bigger" delta this file exists to
+    # pin — the inputs moved, not the flag. Same fix as
+    # `static_base_fingerprint_test.exs`: wait for an ACTUAL rebuild (with the
+    # flags held at a fixed, known value) to return the same bytes twice in a
+    # row before either real build starts.
+    await_stable_build()
     :ok
+  end
+
+  defp await_stable_build(prev \\ nil, tries \\ 80)
+
+  defp await_stable_build(_prev, 0), do: :ok
+
+  defp await_stable_build(prev, tries) do
+    Application.put_env(:optimal_system_agent, :lean_prompt, false)
+    Application.put_env(:optimal_system_agent, :lean_system_prompt, false)
+    Soul.invalidate_static_base()
+    current = Soul.static_base(:native_tools)
+
+    if current == prev do
+      :ok
+    else
+      Process.sleep(25)
+      await_stable_build(current, tries - 1)
+    end
   end
 
   defp with_flag(value, fun) do

--- a/test/optimal_system_agent/soul/static_base_fingerprint_test.exs
+++ b/test/optimal_system_agent/soul/static_base_fingerprint_test.exs
@@ -1,7 +1,46 @@
 defmodule OptimalSystemAgent.Soul.StaticBaseFingerprintTest do
+  @moduledoc """
+  Both tests below assume `build_base/1`'s INPUTS are a fixed point for their
+  brief duration — that is the whole property under test (an invalidate+
+  rebuild is a no-op cycle when nothing changed). Those inputs are not only
+  the live tool registry (MCP/plugin tools can register at any point in a
+  session's life — see `Soul`'s own moduledoc: they "arrive later") but also
+  every bundled rule file `rules_content/0` reads fresh off disk on each
+  build; either one changing mid-suite makes the SAME rebuild answer
+  differently, the toolbox/files moved, not the code. Checking only the tool
+  NAMES for stability (an earlier version of this fix) missed exactly that —
+  the observed failure diverged deep in the rendered rules/tool-prose text
+  while `Tools.Registry.list_active/0`'s name list was already stable.
+  `await_stable_build/0` instead waits for the ACTUAL rebuild — the thing
+  each assertion below compares — to return the same bytes on two
+  consecutive tries before either test starts, so both are proven to start
+  from a build that is not mid-change, without weakening what either
+  assertion checks.
+  """
   use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Soul
+
+  setup do
+    await_stable_build()
+    :ok
+  end
+
+  defp await_stable_build(prev \\ nil, tries \\ 80)
+
+  defp await_stable_build(_prev, 0), do: :ok
+
+  defp await_stable_build(prev, tries) do
+    Soul.invalidate_static_base()
+    current = Soul.static_base(:native_tools)
+
+    if current == prev do
+      :ok
+    else
+      Process.sleep(25)
+      await_stable_build(current, tries - 1)
+    end
+  end
 
   test "two reads with an unchanged toolbox return the same bytes" do
     Soul.invalidate_static_base()

--- a/test/optimal_system_agent/verification/loop_noop_gate_test.exs
+++ b/test/optimal_system_agent/verification/loop_noop_gate_test.exs
@@ -9,10 +9,66 @@ defmodule OptimalSystemAgent.Verification.LoopNoopGateTest do
   Ported from Prime Agent's autonomous no-op detector (MIT), see
   `docs/research/prime-agent.md` §6.3.
   """
+  # `Verification.Loop` fingerprints via `WorkspaceFingerprint.capture(nil)`,
+  # which resolves the directory through `Workspace.Cwd.get/0` — there is no
+  # `:dir` (or `:working_dir`) option on `Loop.start_link/1` to point it
+  # anywhere else. Left pointed at the real checkout (an ordinary, actively
+  # edited dev tree), the "unchanged" fingerprint this test asserts on is a
+  # hash of `git status`/`git diff HEAD`/untracked-file bytes for the WHOLE
+  # repo — any other concurrently-running or still-finishing background work
+  # that touches a file anywhere in the tree between the two captures this
+  # test takes flips the hash and manufactures a second iteration, exactly the
+  # `snap.iteration == 1` assertion below. `goal_verifier_test.exs` hit the
+  # identical hazard and fixed it the same way: run against a throwaway,
+  # `git init`'d temp directory nothing else in the suite ever touches, via
+  # `Workspace.Cwd`'s GLOBAL `original_cwd` override (`async: false`, restored
+  # in `on_exit`, same mechanism `settings_bom_test.exs` uses for the same
+  # class of `File.cwd!`-adjacent global state).
   use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Verification.Loop
   alias OptimalSystemAgent.Verification.WorkspaceFingerprint
+  alias OptimalSystemAgent.Workspace.Cwd
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "osa-noop-gate-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(tmp)
+    {_, 0} = System.cmd("git", ["init", "-q"], cd: tmp)
+    {_, 0} = System.cmd("git", ["config", "user.email", "osa-test@example.com"], cd: tmp)
+    {_, 0} = System.cmd("git", ["config", "user.name", "OSA Test"], cd: tmp)
+    File.write!(Path.join(tmp, "seed.txt"), "seed\n")
+    {_, 0} = System.cmd("git", ["add", "-A"], cd: tmp)
+    {_, 0} = System.cmd("git", ["commit", "-q", "-m", "seed"], cd: tmp)
+
+    prev_original = Cwd.original_cwd()
+    Cwd.set_original_cwd(tmp)
+
+    prev_provider_env = System.get_env("OSA_DEFAULT_PROVIDER")
+    prev_default_provider = Application.get_env(:optimal_system_agent, :default_provider)
+    prev_ollama_url = Application.get_env(:optimal_system_agent, :ollama_url)
+    System.delete_env("OSA_DEFAULT_PROVIDER")
+    Application.put_env(:optimal_system_agent, :default_provider, :ollama)
+    Application.put_env(:optimal_system_agent, :ollama_url, "http://127.0.0.1:1")
+
+    on_exit(fn ->
+      Cwd.set_original_cwd(prev_original)
+      File.rm_rf(tmp)
+
+      if prev_provider_env,
+        do: System.put_env("OSA_DEFAULT_PROVIDER", prev_provider_env),
+        else: System.delete_env("OSA_DEFAULT_PROVIDER")
+
+      if prev_default_provider,
+        do: Application.put_env(:optimal_system_agent, :default_provider, prev_default_provider),
+        else: Application.delete_env(:optimal_system_agent, :default_provider)
+
+      if prev_ollama_url,
+        do: Application.put_env(:optimal_system_agent, :ollama_url, prev_ollama_url),
+        else: Application.delete_env(:optimal_system_agent, :ollama_url)
+    end)
+
+    :ok
+  end
 
   defp await_terminal(loop_id, deadline_ms \\ 20_000) do
     deadline = System.monotonic_time(:millisecond) + deadline_ms

--- a/test/providers/registry_test.exs
+++ b/test/providers/registry_test.exs
@@ -1,5 +1,11 @@
 defmodule OptimalSystemAgent.Providers.RegistryTest do
-  use ExUnit.Case, async: true
+  # "provider_configured?/1 account sign-in configures every subscription-backed
+  # provider" below redirects `OSA_HOME` via `System.put_env/2` — a process-wide
+  # OS env var `SubscriptionStore` re-reads on every call. Left `async: true`,
+  # any other concurrently-running test that also touches `OSA_HOME` can
+  # clobber this test's redirect mid-operation, so its `SubscriptionStore.put/2`
+  # writes (or `provider_configured?/1` reads) the wrong directory.
+  use ExUnit.Case, async: false
 
   alias OptimalSystemAgent.Providers.Registry
 
@@ -102,12 +108,17 @@ defmodule OptimalSystemAgent.Providers.RegistryTest do
 
   describe "provider_configured?/1" do
     test "account sign-in configures every subscription-backed provider" do
-      home = Path.join(System.tmp_dir!(), "osa-registry-account-#{System.unique_integer([:positive])}")
+      home =
+        Path.join(System.tmp_dir!(), "osa-registry-account-#{System.unique_integer([:positive])}")
+
       previous_home = System.get_env("OSA_HOME")
       System.put_env("OSA_HOME", home)
 
       on_exit(fn ->
-        if previous_home, do: System.put_env("OSA_HOME", previous_home), else: System.delete_env("OSA_HOME")
+        if previous_home,
+          do: System.put_env("OSA_HOME", previous_home),
+          else: System.delete_env("OSA_HOME")
+
         File.rm_rf(home)
       end)
 

--- a/test/security/untrusted_tool_output_test.exs
+++ b/test/security/untrusted_tool_output_test.exs
@@ -17,16 +17,24 @@ defmodule OptimalSystemAgent.Security.UntrustedToolOutputTest do
   untrusted output is instead delimited, defanged, and labelled, and is never
   dropped.
   """
-  use ExUnit.Case, async: true
+  # `OSA_PROMPT_GUARD` is a process-wide OS env var; arming it for the
+  # duration of every test here (below) is unsafe under `async: true` since
+  # any OTHER concurrently-running test that reads it (expecting the opt-in
+  # default OFF, or arming it itself) can observe or clobber this file's value.
+  use ExUnit.Case, async: false
 
   # These tests verify the prompt-extraction guard MECHANISM, which is opt-in
   # (default OFF for operator-owned agents). Arm it for the duration.
   setup do
     prev = System.get_env("OSA_PROMPT_GUARD")
     System.put_env("OSA_PROMPT_GUARD", "1")
+
     on_exit(fn ->
-      if prev, do: System.put_env("OSA_PROMPT_GUARD", prev), else: System.delete_env("OSA_PROMPT_GUARD")
+      if prev,
+        do: System.put_env("OSA_PROMPT_GUARD", prev),
+        else: System.delete_env("OSA_PROMPT_GUARD")
     end)
+
     :ok
   end
 

--- a/test/tools/security_intel_test.exs
+++ b/test/tools/security_intel_test.exs
@@ -490,6 +490,39 @@ defmodule OptimalSystemAgent.Tools.Builtins.SecurityIntelTest do
 
     test "accepts content/entry at the top level (not nested under whitebox)", %{ctx: ctx} do
       # A bare {action, entry, content} call must scan, not dead-end on nesting.
+      # `do_whitebox_analyze/2` -> `CallChainAnalyzer.analyze/1` has no test-side
+      # hook to stub its LLM `:runner` (that injection point exists in the
+      # analyzer, but `SecurityIntel.execute/2` never threads a way to reach it
+      # from the tool call this test makes), so it goes through
+      # `Providers.Registry.chat/2`'s real `default_provider()` resolution. On a
+      # machine with a genuinely configured provider that is a REAL network
+      # call — this test only cares that the response is well-formed, not what
+      # a live model says, so force the resolution onto an address nothing
+      # listens on (an immediate refused-connection, not a slow real round
+      # trip) rather than let the assertion's timing depend on whichever
+      # credentials happen to be live on the host running this suite.
+      prev_provider_env = System.get_env("OSA_DEFAULT_PROVIDER")
+      prev_default_provider = Application.get_env(:optimal_system_agent, :default_provider)
+      prev_ollama_url = Application.get_env(:optimal_system_agent, :ollama_url)
+      System.delete_env("OSA_DEFAULT_PROVIDER")
+      Application.put_env(:optimal_system_agent, :default_provider, :ollama)
+      Application.put_env(:optimal_system_agent, :ollama_url, "http://127.0.0.1:1")
+
+      on_exit(fn ->
+        if prev_provider_env,
+          do: System.put_env("OSA_DEFAULT_PROVIDER", prev_provider_env),
+          else: System.delete_env("OSA_DEFAULT_PROVIDER")
+
+        if prev_default_provider,
+          do:
+            Application.put_env(:optimal_system_agent, :default_provider, prev_default_provider),
+          else: Application.delete_env(:optimal_system_agent, :default_provider)
+
+        if prev_ollama_url,
+          do: Application.put_env(:optimal_system_agent, :ollama_url, prev_ollama_url),
+          else: Application.delete_env(:optimal_system_agent, :ollama_url)
+      end)
+
       result = run("whitebox_scan", ctx, %{"entry" => "x.ex", "content" => "def f(x), do: x"})
 
       case result do

--- a/test/tools/shell_execute_test.exs
+++ b/test/tools/shell_execute_test.exs
@@ -162,25 +162,15 @@ defmodule OptimalSystemAgent.Tools.Builtins.ShellExecuteTest do
   # Timeout enforcement
   # ---------------------------------------------------------------------------
 
-  describe "wait window (yield, not kill)" do
-    @tag timeout: 120_000
-    test "command still running when the wait window elapses is moved to the background" do
-      # The window bounds how long the AGENT waits, NOT how long the WORK may run.
-      # It used to SIGKILL the process and fail the call, so legitimately long work
-      # (a build, a test suite) destroyed itself at the deadline and took the turn
-      # with it. It is now adopted into the background instead: the process keeps
-      # running, its completion is injected back into the loop, and the model gets
-      # a background_id to poll. See `auto_detach_on_timeout/5`.
-      System.put_env("OSA_SHELL_TIMEOUT_MS", "3000")
-      on_exit(fn -> System.delete_env("OSA_SHELL_TIMEOUT_MS") end)
-
-      assert {:ok, msg} = exec("sleep 20")
-      assert msg =~ "moved to the background"
-      assert msg =~ "background_id"
-      # It must be explicit that the work was NOT destroyed.
-      assert msg =~ "STILL RUNNING"
-    end
-  end
+  # The "wait window (yield, not kill)" test used to live here, but it pins
+  # `OSA_SHELL_TIMEOUT_MS` — a process-wide OS env var every `exec/1` call in
+  # this ENTIRE async:true file (and any other concurrently-running test that
+  # shells out) reads — down to 3000ms for its duration. Under `async: true`
+  # that shrinks every OTHER concurrent shell_execute call's wait window too,
+  # which can move unrelated commands to the background early or flip their
+  # "STILL RUNNING" assertions. See `ShellExecuteTimeoutKillSwitchTest` below
+  # (`async: false`, same isolation shape as
+  # `Agent.Loop.ToolArgMetricsKillSwitchTest`).
 
   # ---------------------------------------------------------------------------
   # Output truncation
@@ -275,5 +265,35 @@ defmodule OptimalSystemAgent.Tools.Builtins.ShellExecuteTest do
       assert Map.has_key?(params["properties"], "command")
       assert "command" in params["required"]
     end
+  end
+end
+
+defmodule OptimalSystemAgent.Tools.Builtins.ShellExecuteTimeoutKillSwitchTest do
+  @moduledoc """
+  Separate, `async: false`: `OSA_SHELL_TIMEOUT_MS` is read from the OS
+  environment, which is process-global, so shrinking it inside the async
+  module above could yield every OTHER shell_execute call running beside it
+  early too.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias OptimalSystemAgent.Tools.Builtins.ShellExecute
+
+  test "command still running when the wait window elapses is moved to the background" do
+    # The window bounds how long the AGENT waits, NOT how long the WORK may run.
+    # It used to SIGKILL the process and fail the call, so legitimately long work
+    # (a build, a test suite) destroyed itself at the deadline and took the turn
+    # with it. It is now adopted into the background instead: the process keeps
+    # running, its completion is injected back into the loop, and the model gets
+    # a background_id to poll. See `auto_detach_on_timeout/5`.
+    System.put_env("OSA_SHELL_TIMEOUT_MS", "3000")
+    on_exit(fn -> System.delete_env("OSA_SHELL_TIMEOUT_MS") end)
+
+    assert {:ok, msg} = ShellExecute.execute(%{"command" => "sleep 20"})
+    assert msg =~ "moved to the background"
+    assert msg =~ "background_id"
+    # It must be explicit that the work was NOT destroyed.
+    assert msg =~ "STILL RUNNING"
   end
 end


### PR DESCRIPTION
Test-only changes (additive setup/on_exit/async:false; no assertions weakened) that drive the full suite to deterministic green — 3 consecutive fresh-seed runs with only the pre-existing ToolchainPin (local Elixir-version) artifact. Root causes fixed: shared-global-env leaks across async modules, a test writing to the real ~/.osa, live-LLM-call tests, a cast+sleep race, an rm_rf race, tight async timeouts, and soul rebuild-stability. No product code changed; no version bump.