### PR TITLE
[fix] Support persistent headless installs for OpenComputers hosts

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -10,3 +10,13 @@ The older development checkout lacked a release rebuild; current main already fi
 The native and Elixir lifetime fixes, cross-process helper slots, footprint watchdog, bounded frame pipeline, opt-in live tests, and release rebuild gate are documented in `docs/macos-desktop.md`.
 Real ScreenCaptureKit allocation growth still needs a permission-enabled soak test; the permission-free frame pipeline is a separate validation and must not be presented as that live test.
 Preserve unrelated pre-existing working-tree edits when committing this fix.
+
+## 2026-09-11: headless OpenComputers installation
+
+The v1.0.195 Linux full installer aborts before launcher creation on minimal Debian without libasound.so.2 because it unconditionally executes the standalone TUI.
+The backend and generated Bash launcher can perform login, HTTP serve, and a local WebSocket hello without the TUI or ALSA.
+OSA_INSTALL_MODE=headless records the installation mode in OSA_HOME/install_mode; reinstall and update preserve it, while absent mode files retain legacy full behavior.
+The updater must keep headless mode through launcher replacement and must reject old launchers that would reinstall the TUI.
+The service environment OSA_OPEN_COMPUTERS_ENABLED=true activates host mode without an enable marker or shell-profile changes.
+Root cannot provide interactive PTY sessions, and local mock handshake evidence is not authenticated MIOSA enrollment.
+See docs/headless-install.md for the contract, tests, and release handoff.

--- a/docs/headless-install.md
+++ b/docs/headless-install.md
@@ -1,0 +1,86 @@
+# Headless OpenComputers installation
+
+The prebuilt installer supports `OSA_INSTALL_MODE=headless` for service hosts that do not need the terminal UI.
+It installs the bundled Erlang runtime and the Bash `osa` launcher without downloading, installing, or executing the standalone Rust TUI.
+This avoids the TUI's ALSA dependency on minimal Linux servers.
+It does not remove native dependencies required by the backend.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/Miosa-osa/OSA/main/scripts/install.sh -o install-osa.sh
+OSA_INSTALL_MODE=headless bash install-osa.sh
+```
+
+`OSA_HOME` still defaults to `$HOME/.osa`, and `OSA_VERSION` still accepts a pinned release tag.
+Bash, a download tool with CA certificates, tar/gzip, and sha256sum or shasum are required.
+Headless install and update fail if the runtime checksum sidecar is unavailable, hashing is unavailable, or the checksum does not match.
+No system packages are installed automatically.
+
+## Saved mode and existing installations
+
+The successful installation records exactly `headless\n` or `full\n` in `$OSA_HOME/install_mode`.
+An explicit `OSA_INSTALL_MODE` takes precedence over that file.
+Without an explicit setting, reinstall and `osa update` preserve the saved mode.
+An installation without a saved mode is treated as legacy `full`; a new installation defaults to `full`.
+An invalid setting or unreadable/invalid saved mode fails instead of silently selecting another mode.
+
+Automation should preserve the saved mode, preserve legacy full installations, and explicitly select headless only for a new service installation or a requested conversion.
+After invoking the installer, check the exit status, the executable launcher, and the exact saved mode before proceeding.
+Checking the mode prevents an older installer that ignores `OSA_INSTALL_MODE` from being reported as a successful headless installation.
+
+Explicitly changing an existing full installation to headless does not delete its TUI or change its shell profiles.
+The retained TUI is disabled and no longer updated in headless mode.
+To resume using and updating it, rerun the installer with `OSA_INSTALL_MODE=full`.
+Fresh headless installations do not edit shell profiles; use the absolute launcher path in a service.
+
+`osa serve`, `osa opencomputers`, `osa doctor`, `osa setup`, and `osa version` work without the TUI.
+An interactive invocation such as bare `osa`, `osa resume`, or `osa overdrive` exits with an explanation before warming a background daemon.
+Headless `osa update` updates the backend and launcher, preserves the mode, and exits without launching a TUI or prompting to do so.
+The updater refuses a target launcher without headless support, including historical release launchers, before an upgrade stops the service or swaps its runtime.
+The first release containing this installer change must be published before the normal tag-based update path supports headless installations.
+
+## Service environment
+
+Use the same service account, `HOME`, and `OSA_HOME` for login and runtime startup.
+Login persists the host configuration with mode 0600.
+Set `OSA_OPEN_COMPUTERS_ENABLED=true` in the service environment and run the launcher with `serve` in the foreground.
+The environment variable activates host mode without an enable marker or a call to `osa opencomputers enable`.
+Use a UTF-8 locale, such as `LANG=C.UTF-8` on Debian.
+
+Running as root does not provide OpenComputers interactive PTY sessions: erlexec refuses root.
+Use a non-root service identity if PTY is required, and verify PTY separately before advertising that capability.
+A successful installation, local health response, or local mock handshake does not establish authenticated MIOSA enrollment, remote execution, or desktop functionality.
+
+## Validation
+
+The offline regression suite executes the real installer and generated launcher against small checksummed fixtures.
+It covers full/headless install, existing-user preservation, reinstall, same-version repair, version upgrades, launcher re-exec, checksum failures, invalid mode, and rejection of a legacy launcher.
+It requires Python 3.9 or later, Bash, tar, and a checksum tool; no Elixir dependencies are needed for the standalone run.
+The ExUnit wrapper also runs it in the normal test suite.
+
+```sh
+python3 test/shell/install_modes_test.py
+elixir -e 'ExUnit.start()' -r test/scripts/install_modes_test.exs -r test/scripts/launcher_args_test.exs
+```
+
+For native compatibility, use the real published release in a disposable amd64 Debian 12 container without ALSA or a TUI.
+Copy the candidate `scripts/install.sh` to `/tmp/candidate-install.sh` in that container, install only curl, ca-certificates, libstdc++6, libncurses6, libssl3, and Python for the smoke harness, and run:
+
+```sh
+mkdir -p /smoke-home /evidence
+HOME=/smoke-home OSA_HOME=/smoke-home/.osa OSA_VERSION=v1.0.195 OSA_INSTALL_MODE=headless bash /tmp/candidate-install.sh
+```
+
+Run this command inside the container, never against a user's real HOME.
+The installer verifies the published tarball checksum before extraction.
+To test same-version and v1.0.194-to-v1.0.195 updates before this change is released, set the existing `OSA_LAUNCHER_RAW_BASE` test override to a local `file://` directory containing the candidate installer at `v1.0.195/scripts/install.sh`.
+Leave the runtime asset URLs and checksums pointing at the actual published releases.
+This tests the candidate launcher with published binaries; it must not be described as a released headless updater.
+
+Disconnect the task container from Docker networking, copy `test/shell/headless_runtime_smoke.py` into it, and run that script with Python.
+The script refuses to run outside Docker or with a configured network route, asserts TUI/ALSA/marker absence, writes only a dummy host key, verifies a local WebSocket upgrade and binary hello, checks HTTP health, and stops its runtime process group.
+It retains focused logs in `/evidence` without copying private fingerprint files or release cookies.
+It deliberately sends no backend acceptance response and makes no enrollment or capability claim.
+
+The v1.0.195 Debian 12 smoke used tarball SHA256 `60299959594885ae8b2fec3fa60e9df5c42e35632ee58f62eef462b800cfe23e`.
+The original full installer failed without `libasound.so.2`; the candidate headless installer and updater succeeded without that library.
+These results were obtained under Docker amd64 emulation on an arm64 host, not a physical x64 machine.

--- a/docs/headless-install.md
+++ b/docs/headless-install.md
@@ -38,6 +38,22 @@ Headless `osa update` updates the backend and launcher, preserves the mode, and 
 The updater refuses a target launcher without headless support, including historical release launchers, before an upgrade stops the service or swaps its runtime.
 The first release containing this installer change must be published before the normal tag-based update path supports headless installations.
 
+## Release order for the enrollment wrapper
+
+Gate the complete compute rollout on a compatible published OSA release.
+Fresh installs using a merged main-branch installer can already run the existing v1.0.195 backend, but the normal updater will reject the old v1.0.195 tagged launcher.
+Merging the installer alone therefore fixes initial installation without completing the supported update path.
+
+1. Review and merge OSA PR #271, containing the headless installer and launcher.
+2. Have the release owner publish a new OSA version whose tag contains this change, with the normal runtime assets and checksum sidecars, and make it the latest release.
+3. Verify fresh headless install, persisted reinstall, same-version update, and an upgrade using the public installer and tagged launcher, with no `OSA_LAUNCHER_RAW_BASE` override.
+   Check a minimal Linux host without ALSA, preserve an existing full install, and repeat environment-only runtime startup and the local handshake gate.
+4. Review and merge the paired enrollment-wrapper change after its mode-selection and fail-closed checks pass against that published release.
+5. Roll out compute only after those gates pass, then verify authenticated enrollment and supported capabilities through the real product flow.
+
+Publishing and rollout are separate release-owner actions; running the candidate tests or merging a PR does neither.
+Do not bypass the old-launcher rejection by shipping the local test override or silently falling back to full installation.
+
 ## Service environment
 
 Use the same service account, `HOME`, and `OSA_HOME` for login and runtime startup.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,7 @@
 # Environment overrides:
 #   OSA_VERSION   Pin to a release tag (e.g. "v0.4.0"). Default: latest.
 #   OSA_HOME      Install root. Default: $HOME/.osa
+#   OSA_INSTALL_MODE  full or headless. Default: saved mode, otherwise full.
 #
 # Exit codes:
 #   0 success   1 unsupported platform   2 network error   3 extraction error
@@ -46,6 +47,20 @@ info() { printf "  ${CYAN}→${RESET} %s\n" "$*"; }
 ok()   { printf "  ${GREEN}✓${RESET} %s\n" "$*"; }
 warn() { printf "  ${YELLOW}!${RESET} %s\n" "$*" >&2; }
 fail() { printf "  ${RED}✗${RESET} %s\n" "$1" >&2; exit "${2:-1}"; }
+
+# An explicit setting wins; reinstall preserves the last successful mode.
+if [ "${OSA_INSTALL_MODE+x}" = x ]; then
+  INSTALL_MODE="$OSA_INSTALL_MODE"
+elif [ -e "$OSA_HOME/install_mode" ] || [ -L "$OSA_HOME/install_mode" ]; then
+  INSTALL_MODE="$(cat "$OSA_HOME/install_mode")" || fail "Could not read saved install mode."
+else
+  INSTALL_MODE=full
+fi
+case "$INSTALL_MODE" in
+  full|headless) ;;
+  *) fail "Invalid OSA_INSTALL_MODE: ${INSTALL_MODE}. Expected full or headless." ;;
+esac
+command -v bash >/dev/null 2>&1 || fail "Bash is required by the installed osa launcher."
 
 _download() {
   # _download <url> <dest> — curl first, wget fallback. Returns 2 on failure.
@@ -177,14 +192,16 @@ if ! _download "${BASE_URL}/${TARBALL}" "${TMP_DIR}/${TARBALL}"; then
 fi
 ok "Downloaded ${TARBALL}"
 
-info "Downloading ${TUI_ASSET}..."
-if ! _download "${BASE_URL}/${TUI_ASSET}" "${TMP_DIR}/${TUI_ASSET}"; then
-  fail "Download failed for ${TUI_ASSET}." 2
+if [ "$INSTALL_MODE" = "full" ]; then
+  info "Downloading ${TUI_ASSET}..."
+  if ! _download "${BASE_URL}/${TUI_ASSET}" "${TMP_DIR}/${TUI_ASSET}"; then
+    fail "Download failed for ${TUI_ASSET}." 2
+  fi
+  # Sanity: the TUI is executed directly, so it must be a non-empty file (a 404 or
+  # truncated download would otherwise be copied in and fail later at exec time).
+  [ -s "${TMP_DIR}/${TUI_ASSET}" ] || fail "Downloaded ${TUI_ASSET} is empty — aborting." 2
+  ok "Downloaded ${TUI_ASSET}"
 fi
-# Sanity: the TUI is executed directly, so it must be a non-empty file (a 404 or
-# truncated download would otherwise be copied in and fail later at exec time).
-[ -s "${TMP_DIR}/${TUI_ASSET}" ] || fail "Downloaded ${TUI_ASSET} is empty — aborting." 2
-ok "Downloaded ${TUI_ASSET}"
 
 # ---------------------------------------------------------------------------
 # Verify checksum (best effort — warn if sidecar absent)
@@ -198,6 +215,7 @@ if _download "${BASE_URL}/${TARBALL}.sha256" "${TMP_DIR}/${TARBALL}.sha256" 2>/d
     ACTUAL="$(shasum -a 256 "${TMP_DIR}/${TARBALL}" | awk '{print $1}')"
   else
     ACTUAL=""
+    [ "$INSTALL_MODE" != "headless" ] || fail "Headless install requires sha256sum or shasum." 3
     warn "No sha256sum/shasum found — skipping verification."
   fi
   if [ -n "$ACTUAL" ]; then
@@ -207,12 +225,15 @@ if _download "${BASE_URL}/${TARBALL}.sha256" "${TMP_DIR}/${TARBALL}.sha256" 2>/d
     ok "Checksum verified"
   fi
 else
+  [ "$INSTALL_MODE" != "headless" ] || fail "Headless install requires the release checksum sidecar." 3
   warn "No .sha256 sidecar for this release — skipping verification."
 fi
 
 # Verify the standalone TUI binary too (it is fetched separately from the
 # tarball, so it needs its own checksum — supply-chain hardening, M2).
-_verify_asset "${TMP_DIR}/${TUI_ASSET}" "${BASE_URL}/${TUI_ASSET}.sha256" "${TUI_ASSET}"
+if [ "$INSTALL_MODE" = "full" ]; then
+  _verify_asset "${TMP_DIR}/${TUI_ASSET}" "${BASE_URL}/${TUI_ASSET}.sha256" "${TUI_ASSET}"
+fi
 
 # ---------------------------------------------------------------------------
 # Extract OTP release into ~/.osa/release (fresh)
@@ -233,15 +254,17 @@ ok "Release installed"
 # Install the Rust TUI binary
 # ---------------------------------------------------------------------------
 mkdir -p "$BIN_DIR"
-cp "${TMP_DIR}/${TUI_ASSET}" "$TUI_BIN" || fail "Could not write ${TUI_BIN}." 3
-chmod +x "$TUI_BIN" || fail "Could not make ${TUI_BIN} executable." 3
-[ -s "$TUI_BIN" ] && [ -x "$TUI_BIN" ] \
-  || fail "${TUI_BIN} is empty or not executable after install." 3
-# The TUI is exec'd directly by the launcher, so prove it actually runs here
-# rather than discovering it at first launch.
-TUI_REPORTED="$("$TUI_BIN" --version 2>/dev/null | head -1 | awk '{print $NF}')"
-[ -n "$TUI_REPORTED" ] || fail "${TUI_BIN} did not run (--version produced no output)." 3
-ok "TUI installed to ${TUI_BIN} (reports ${TUI_REPORTED})"
+if [ "$INSTALL_MODE" = "full" ]; then
+  cp "${TMP_DIR}/${TUI_ASSET}" "$TUI_BIN" || fail "Could not write ${TUI_BIN}." 3
+  chmod +x "$TUI_BIN" || fail "Could not make ${TUI_BIN} executable." 3
+  [ -s "$TUI_BIN" ] && [ -x "$TUI_BIN" ] \
+    || fail "${TUI_BIN} is empty or not executable after install." 3
+  # The TUI is exec'd directly by the launcher, so prove it actually runs here
+  # rather than discovering it at first launch.
+  TUI_REPORTED="$("$TUI_BIN" --version 2>/dev/null | head -1 | awk '{print $NF}')"
+  [ -n "$TUI_REPORTED" ] || fail "${TUI_BIN} did not run (--version produced no output)." 3
+  ok "TUI installed to ${TUI_BIN} (reports ${TUI_REPORTED})"
+fi
 
 # macOS: best-effort clear of the com.apple.quarantine attribute. A curl/wget
 # download does NOT set quarantine (only Finder/browser downloads do), so this
@@ -290,6 +313,18 @@ OSA_HOME="${OSA_HOME:-$HOME/.osa}"
 export OSA_HOME
 RELEASE_BIN="$OSA_HOME/release/bin/osagent"
 TUI_BIN="$OSA_HOME/bin/osagent-tui"
+# OSA_HEADLESS_INSTALL_V1: updater compatibility sentinel; keep in generated launcher.
+if [ "${OSA_INSTALL_MODE+x}" = x ]; then
+  INSTALL_MODE="$OSA_INSTALL_MODE"
+elif [ -e "$OSA_HOME/install_mode" ] || [ -L "$OSA_HOME/install_mode" ]; then
+  INSTALL_MODE="$(cat "$OSA_HOME/install_mode")" || exit 1
+else
+  INSTALL_MODE=full
+fi
+case "$INSTALL_MODE" in
+  full|headless) ;;
+  *) echo "Invalid OSA_INSTALL_MODE: $INSTALL_MODE. Expected full or headless." >&2; exit 1 ;;
+esac
 LOG_DIR="$OSA_HOME/logs"
 RUN_DIR="$OSA_HOME/run"
 PID_FILE="$RUN_DIR/backend.pid"
@@ -699,6 +734,10 @@ _launcher_extract() {
 # that works. Loud on every rejection; 0 only when the file is genuinely ours.
 _launcher_verify() {
   _lv="$1"
+  if [ "$INSTALL_MODE" = "headless" ] && ! grep -qF '# OSA_HEADLESS_INSTALL_V1:' "$_lv"; then
+    printf 'The release launcher does not support headless installs; refusing to replace this launcher.\n' >&2
+    return 1
+  fi
   if [ ! -s "$_lv" ]; then
     printf "  ${RED}✗${RESET} The downloaded launcher is empty.\n" >&2
     return 1
@@ -782,6 +821,14 @@ _update_launcher() {
     rm -rf "$_ul_tmp"
     printf "  ${DIM}  Your working launcher was NOT touched. Nothing was overwritten.${RESET}\n" >&2
     printf "  ${DIM}  Repair with:${RESET} ${CYAN}curl -fsSL https://raw.githubusercontent.com/%s/main/scripts/install.sh | sh${RESET}\n" "$GITHUB_REPO" >&2
+    return 3
+  fi
+
+  # Persist only after the target launcher is validated, before a possible exec.
+  if ! printf '%s\n' "$INSTALL_MODE" > "$OSA_HOME/install_mode.new" ||
+     ! mv "$OSA_HOME/install_mode.new" "$OSA_HOME/install_mode"; then
+    rm -rf "$_ul_tmp"
+    printf 'Could not save OSA install mode.\n' >&2
     return 3
   fi
 
@@ -870,7 +917,7 @@ _update_report() {
     printf "    See ${CYAN}https://github.com/%s/releases/tag/%s${RESET}\n" "$GITHUB_REPO" "$2"
   fi
   printf '\n'
-  if [ -t 0 ]; then
+  if [ "$INSTALL_MODE" = "full" ] && [ -t 0 ]; then
     printf "  ${DIM}Press Enter to launch OSA…${RESET} "
     read -r _ || true
   fi
@@ -957,7 +1004,7 @@ do_update() {
     # are current while the TUI still runs old code — and every later
     # `osa update` would no-op forever. Verify against the real binary and
     # self-heal by re-installing instead of lying.
-    if _tui_is_version "$latest"; then
+    if [ "$INSTALL_MODE" = "headless" ] || _tui_is_version "$latest"; then
       # The binaries are current — but the LAUNCHER may not be, and nothing
       # else in this install would ever notice. Checking it here is what makes
       # "`osa update` leaves you with the launcher for the release you have" an
@@ -974,6 +1021,22 @@ do_update() {
     printf "  ${CYAN}→${RESET} New version available: ${BOLD}%s${RESET}\n" "$latest"
   fi
 
+  # A headless host must reject a legacy launcher before stopping its service
+  # or swapping the runtime. The final launcher swap validates it again.
+  if [ "$INSTALL_MODE" = "headless" ]; then
+    preflight="$(mktemp -d "${TMPDIR:-/tmp}/osa-launcher-check.XXXXXX")" || return 3
+    if ! _download "${_LAUNCHER_RAW_BASE}/${latest}/scripts/install.sh" "$preflight/install.sh"; then
+      rm -rf "$preflight"
+      printf 'Could not check headless launcher compatibility.\n' >&2
+      return 2
+    fi
+    if ! _launcher_extract "$preflight/install.sh" > "$preflight/osa" || ! _launcher_verify "$preflight/osa"; then
+      rm -rf "$preflight"
+      return 3
+    fi
+    rm -rf "$preflight"
+  fi
+
   base="https://github.com/${GITHUB_REPO}/releases/download/${latest}"
   tmp="$(mktemp -d "${TMPDIR:-/tmp}/osa-update.XXXXXX")"
 
@@ -981,11 +1044,13 @@ do_update() {
   if ! _download "${base}/${tarball}" "${tmp}/${tarball}"; then
     rm -rf "$tmp"; printf "  ${RED}✗${RESET} Download failed for %s.\n" "$tarball" >&2; return 2
   fi
-  printf "  ${CYAN}→${RESET} Downloading %s…\n" "$tui_asset"
-  if ! _download "${base}/${tui_asset}" "${tmp}/${tui_asset}"; then
-    rm -rf "$tmp"; printf "  ${RED}✗${RESET} Download failed for %s.\n" "$tui_asset" >&2; return 2
+  if [ "$INSTALL_MODE" = "full" ]; then
+    printf "  ${CYAN}→${RESET} Downloading %s…\n" "$tui_asset"
+    if ! _download "${base}/${tui_asset}" "${tmp}/${tui_asset}"; then
+      rm -rf "$tmp"; printf "  ${RED}✗${RESET} Download failed for %s.\n" "$tui_asset" >&2; return 2
+    fi
+    [ -s "${tmp}/${tui_asset}" ] || { rm -rf "$tmp"; printf "  ${RED}✗${RESET} Downloaded %s is empty — aborting update.\n" "$tui_asset" >&2; return 2; }
   fi
-  [ -s "${tmp}/${tui_asset}" ] || { rm -rf "$tmp"; printf "  ${RED}✗${RESET} Downloaded %s is empty — aborting update.\n" "$tui_asset" >&2; return 2; }
 
   # Verify the tarball checksum (mandatory when the sidecar exists).
   printf "  ${CYAN}→${RESET} Verifying checksum…\n"
@@ -997,6 +1062,11 @@ do_update() {
     elif command -v shasum >/dev/null 2>&1; then
       actual="$(shasum -a 256 "${tmp}/${tarball}" | awk '{print $1}')"
     fi
+    if [ "$INSTALL_MODE" = "headless" ] && [ -z "$actual" ]; then
+      rm -rf "$tmp"
+      printf 'Headless update requires sha256sum or shasum.\n' >&2
+      return 3
+    fi
     if [ -n "$actual" ] && [ "$actual" != "$expected" ]; then
       rm -rf "$tmp"
       printf "  ${RED}✗${RESET} Checksum mismatch — aborting update.\n" >&2
@@ -1004,26 +1074,33 @@ do_update() {
     fi
     [ -n "$actual" ] && printf "  ${GREEN}✓${RESET} Checksum verified\n"
   else
+    if [ "$INSTALL_MODE" = "headless" ]; then
+      rm -rf "$tmp"
+      printf 'Headless update requires the release checksum sidecar.\n' >&2
+      return 3
+    fi
     printf "  ${YELLOW}!${RESET} No .sha256 sidecar — skipping verification.\n" >&2
   fi
 
   # Verify the TUI binary checksum too (fetched separately — supply-chain, M2).
-  if _download "${base}/${tui_asset}.sha256" "${tmp}/${tui_asset}.sha256" 2>/dev/null; then
-    texpected="$(awk '{print $1}' "${tmp}/${tui_asset}.sha256")"
-    tactual=""
-    if command -v sha256sum >/dev/null 2>&1; then
-      tactual="$(sha256sum "${tmp}/${tui_asset}" | awk '{print $1}')"
-    elif command -v shasum >/dev/null 2>&1; then
-      tactual="$(shasum -a 256 "${tmp}/${tui_asset}" | awk '{print $1}')"
+  if [ "$INSTALL_MODE" = "full" ]; then
+    if _download "${base}/${tui_asset}.sha256" "${tmp}/${tui_asset}.sha256" 2>/dev/null; then
+      texpected="$(awk '{print $1}' "${tmp}/${tui_asset}.sha256")"
+      tactual=""
+      if command -v sha256sum >/dev/null 2>&1; then
+        tactual="$(sha256sum "${tmp}/${tui_asset}" | awk '{print $1}')"
+      elif command -v shasum >/dev/null 2>&1; then
+        tactual="$(shasum -a 256 "${tmp}/${tui_asset}" | awk '{print $1}')"
+      fi
+      if [ -n "$tactual" ] && [ "$tactual" != "$texpected" ]; then
+        rm -rf "$tmp"
+        printf "  ${RED}✗${RESET} Checksum mismatch for %s — aborting update.\n" "$tui_asset" >&2
+        return 3
+      fi
+      [ -n "$tactual" ] && printf "  ${GREEN}✓${RESET} Checksum verified (%s)\n" "$tui_asset"
+    else
+      printf "  ${YELLOW}!${RESET} No .sha256 sidecar for %s — skipping verification.\n" "$tui_asset" >&2
     fi
-    if [ -n "$tactual" ] && [ "$tactual" != "$texpected" ]; then
-      rm -rf "$tmp"
-      printf "  ${RED}✗${RESET} Checksum mismatch for %s — aborting update.\n" "$tui_asset" >&2
-      return 3
-    fi
-    [ -n "$tactual" ] && printf "  ${GREEN}✓${RESET} Checksum verified (%s)\n" "$tui_asset"
-  else
-    printf "  ${YELLOW}!${RESET} No .sha256 sidecar for %s — skipping verification.\n" "$tui_asset" >&2
   fi
 
   # Extract the new release beside the current one (same filesystem → atomic
@@ -1048,11 +1125,13 @@ do_update() {
     printf "  ${RED}✗${RESET} Could not create %s — aborting update.\n" "$(dirname "$TUI_BIN")" >&2
     return 3
   }
-  if ! cp "${tmp}/${tui_asset}" "${TUI_BIN}.new" || ! chmod +x "${TUI_BIN}.new"; then
-    rm -f "${TUI_BIN}.new"; rm -rf "$tmp" "$new_rel"
-    printf "  ${RED}✗${RESET} Could not stage the new TUI binary at %s.new — aborting update.\n" "$TUI_BIN" >&2
-    printf "  ${DIM}  Your existing install is untouched. Check disk space and permissions.${RESET}\n" >&2
-    return 3
+  if [ "$INSTALL_MODE" = "full" ]; then
+    if ! cp "${tmp}/${tui_asset}" "${TUI_BIN}.new" || ! chmod +x "${TUI_BIN}.new"; then
+      rm -f "${TUI_BIN}.new"; rm -rf "$tmp" "$new_rel"
+      printf "  ${RED}✗${RESET} Could not stage the new TUI binary at %s.new — aborting update.\n" "$TUI_BIN" >&2
+      printf "  ${DIM}  Your existing install is untouched. Check disk space and permissions.${RESET}\n" >&2
+      return 3
+    fi
   fi
 
   # Atomic swap of the release dir.
@@ -1071,13 +1150,15 @@ do_update() {
   # unchecked: when it failed the launcher kept exec'ing the OLD TUI while the
   # version stamp was rewritten to the new tag, so `osa update` printed success
   # and the TUI kept showing the old version forever.
-  if ! mv "${TUI_BIN}.new" "$TUI_BIN"; then
-    rm -f "${TUI_BIN}.new"; rm -rf "$tmp"
-    printf "  ${RED}✗${RESET} Could not replace the TUI binary at %s.\n" "$TUI_BIN" >&2
-    printf "  ${DIM}  The backend was updated but the TUI was NOT — the install is INCONSISTENT.${RESET}\n" >&2
-    printf "  ${DIM}  Repair with:${RESET} ${CYAN}%s${RESET}\n" \
-      "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh | sh" >&2
-    return 3
+  if [ "$INSTALL_MODE" = "full" ]; then
+    if ! mv "${TUI_BIN}.new" "$TUI_BIN"; then
+      rm -f "${TUI_BIN}.new"; rm -rf "$tmp"
+      printf "  ${RED}✗${RESET} Could not replace the TUI binary at %s.\n" "$TUI_BIN" >&2
+      printf "  ${DIM}  The backend was updated but the TUI was NOT — the install is INCONSISTENT.${RESET}\n" >&2
+      printf "  ${DIM}  Repair with:${RESET} ${CYAN}%s${RESET}\n" \
+        "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh | sh" >&2
+      return 3
+    fi
   fi
 
   # macOS: best-effort quarantine strip on the freshly swapped-in binaries.
@@ -1095,24 +1176,26 @@ do_update() {
       "$OSA_HOME/release/bin/osagent" >&2
     return 3
   fi
-  if [ ! -s "$TUI_BIN" ] || [ ! -x "$TUI_BIN" ]; then
-    rm -rf "$tmp"
-    printf "  ${RED}✗${RESET} TUI binary missing, empty, or not executable after update (%s).\n" "$TUI_BIN" >&2
-    printf "  ${DIM}  Repair with:${RESET} ${CYAN}%s${RESET}\n" \
-      "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh | sh" >&2
-    return 3
+  if [ "$INSTALL_MODE" = "full" ]; then
+    if [ ! -s "$TUI_BIN" ] || [ ! -x "$TUI_BIN" ]; then
+      rm -rf "$tmp"
+      printf "  ${RED}✗${RESET} TUI binary missing, empty, or not executable after update (%s).\n" "$TUI_BIN" >&2
+      printf "  ${DIM}  Repair with:${RESET} ${CYAN}%s${RESET}\n" \
+        "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh | sh" >&2
+      return 3
+    fi
+    if ! _tui_is_version "$latest"; then
+      tui_now="$(_installed_tui_version || true)"
+      rm -rf "$tmp"
+      printf "  ${RED}✗${RESET} TUI still reports %s after updating to %s — the update did not take.\n" \
+        "${tui_now:-<unreadable>}" "$latest" >&2
+      printf "  ${DIM}  Not stamping the new version, so ${RESET}${CYAN}osa update${RESET}${DIM} will retry.${RESET}\n" >&2
+      printf "  ${DIM}  Repair with:${RESET} ${CYAN}%s${RESET}\n" \
+        "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh | sh" >&2
+      return 3
+    fi
+    printf "  ${GREEN}✓${RESET} TUI binary verified ${DIM}(reports %s)${RESET}\n" "$(_installed_tui_version)"
   fi
-  if ! _tui_is_version "$latest"; then
-    tui_now="$(_installed_tui_version || true)"
-    rm -rf "$tmp"
-    printf "  ${RED}✗${RESET} TUI still reports %s after updating to %s — the update did not take.\n" \
-      "${tui_now:-<unreadable>}" "$latest" >&2
-    printf "  ${DIM}  Not stamping the new version, so ${RESET}${CYAN}osa update${RESET}${DIM} will retry.${RESET}\n" >&2
-    printf "  ${DIM}  Repair with:${RESET} ${CYAN}%s${RESET}\n" \
-      "curl -fsSL https://raw.githubusercontent.com/${GITHUB_REPO}/main/scripts/install.sh | sh" >&2
-    return 3
-  fi
-  printf "  ${GREEN}✓${RESET} TUI binary verified ${DIM}(reports %s)${RESET}\n" "$(_installed_tui_version)"
 
   printf "%s\n" "$OSA_HOME/release" > "$OSA_HOME/release_root"
   printf "%s\n" "$latest" > "$OSA_HOME/version"
@@ -1245,7 +1328,9 @@ case "$OSA_VERB" in
     # TUI binary; printing only the backend hides a half-applied update, which
     # is precisely how "I updated but the TUI shows the old version" happens.
     "$RELEASE_BIN" version || true
-    if [ -x "$TUI_BIN" ]; then
+    if [ "$INSTALL_MODE" = "headless" ]; then
+      printf 'osagent-tui disabled (headless mode)\n'
+    elif [ -x "$TUI_BIN" ]; then
       tui_v="$(_installed_tui_version || true)"
       printf "osagent-tui %s\n" "${tui_v:-<unreadable>}"
     else
@@ -1253,7 +1338,7 @@ case "$OSA_VERB" in
     fi
     stamp="$(cat "$OSA_HOME/version" 2>/dev/null || echo unknown)"
     printf "installed release stamp %s\n" "$stamp"
-    if [ "$stamp" != "unknown" ] && ! _tui_is_version "$stamp"; then
+    if [ "$INSTALL_MODE" = "full" ] && [ "$stamp" != "unknown" ] && ! _tui_is_version "$stamp"; then
       printf "  ${YELLOW}!${RESET} TUI does not match the installed release stamp — run ${CYAN}osa update${RESET} to repair.\n" >&2
     fi
     exit 0
@@ -1269,10 +1354,18 @@ case "$OSA_VERB" in
     # off to the new one (see _update_launcher), the user's exact invocation is
     # replayed across the process boundary instead of being silently dropped.
     do_update ${1+"$@"} || exit $?
+    [ "$INSTALL_MODE" != "headless" ] || exit 0
     # fall through to launch on success
     ;;
   help)                 print_help; exit 0 ;;
 esac
+
+# Headless hosts must not warm a daemon just because an interactive command was used.
+if [ "$INSTALL_MODE" = "headless" ]; then
+  printf 'OSA is installed in headless mode. Use osa serve for the service.\n' >&2
+  printf 'To add the TUI, rerun scripts/install.sh with OSA_INSTALL_MODE=full.\n' >&2
+  exit 1
+fi
 
 # ── Default: warm the daemon (attach instantly if healthy), then TUI ──
 #
@@ -1318,6 +1411,8 @@ export OSA_URL="http://localhost:${PORT}"
 exec "$TUI_BIN" "$@"
 LAUNCHER_EOF
 chmod +x "$LAUNCHER"
+printf '%s\n' "$INSTALL_MODE" > "$OSA_HOME/install_mode.new"
+mv "$OSA_HOME/install_mode.new" "$OSA_HOME/install_mode"
 ok "Launcher installed"
 
 # ---------------------------------------------------------------------------
@@ -1330,7 +1425,7 @@ for dir in $PATH; do
 done
 IFS="$_IFS"
 
-if [ "$on_path" = "false" ]; then
+if [ "$on_path" = "false" ] && [ "$INSTALL_MODE" = "full" ]; then
   SHELL_NAME="$(basename "${SHELL:-/bin/sh}" 2>/dev/null || echo sh)"
   EXPORT_LINE="export PATH=\"${BIN_DIR}:\$PATH\""
   case "$SHELL_NAME" in
@@ -1354,6 +1449,8 @@ printf "\n${GREEN}${BOLD}  OSA ${VERSION} installed.${RESET}\n\n"
 if [ -n "${RELOAD_HINT:-}" ]; then
   printf "  Reload your shell, then run ${BOLD}osa${RESET}:\n"
   printf "    ${DIM}. %s${RESET}\n\n" "$RELOAD_HINT"
+elif [ "$INSTALL_MODE" = "headless" ]; then
+  printf '  Headless install: run %s serve. No shell profiles were changed.\n\n' "$LAUNCHER"
 else
   printf "  Run ${BOLD}osa${RESET} to start.\n\n"
 fi

--- a/test/scripts/install_modes_test.exs
+++ b/test/scripts/install_modes_test.exs
@@ -1,0 +1,11 @@
+defmodule OptimalSystemAgent.Scripts.InstallModesTest do
+  use ExUnit.Case, async: true
+
+  @tag timeout: 120_000
+  test "prebuilt installer and updater preserve full and headless contracts" do
+    python = System.find_executable("python3") || flunk("python3 is required for installer tests")
+    script = Path.expand("../shell/install_modes_test.py", __DIR__)
+    {output, status} = System.cmd(python, [script], stderr_to_stdout: true)
+    assert status == 0, output
+  end
+end

--- a/test/shell/headless_runtime_smoke.py
+++ b/test/shell/headless_runtime_smoke.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Opt-in real release smoke, only inside a disposable network-isolated container.
+
+Requires a headless installation at /smoke-home/.osa and Python standard library.
+Never sends hello_ok or claims backend enrollment, PTY, or desktop support.
+"""
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+import socket
+import struct
+import subprocess
+import time
+import urllib.request
+
+
+def main():
+    assert Path("/.dockerenv").exists(), "Run only in a disposable Docker container"
+    routes = Path("/proc/net/route").read_text().splitlines()[1:]
+    assert not routes, "Disconnect Docker networking before this runtime smoke"
+    home = Path("/smoke-home/.osa")
+    evidence = Path("/evidence")
+    evidence.mkdir(exist_ok=True)
+    assert (home / "install_mode").read_text() == "headless\n"
+    assert not (home / "bin/osagent-tui").exists()
+    assert not Path("/usr/lib/x86_64-linux-gnu/libasound.so.2").exists()
+    for name in (".env", ".open_computers_enabled"):
+        assert not (home / name).exists(), name
+    env = {"PATH": "/usr/bin:/bin", "HOME": "/smoke-home", "OSA_HOME": str(home), "LANG": "C.UTF-8"}
+    osa = str(home / "bin/osa")
+    with (evidence / "runtime-cli.log").open("w") as log:
+        for args in (["version"], ["opencomputers", "login", "--key",
+                    "oc_host_disposable_smoke_only_0000000000000000", "--control-url",
+                    "ws://127.0.0.1:18765/api/v1/opencomputers/hosts/ws", "--force"]):
+            subprocess.run([osa, *args], env=env, stdout=log, stderr=log, check=True, timeout=40)
+        result = subprocess.run([osa], env=env, stdout=log, stderr=log, timeout=10)
+        assert result.returncode == 1, "Interactive invocation must fail without starting a daemon"
+        assert not (home / "run/backend.pid").exists()
+    assert (home / "open_computers.toml").stat().st_mode & 0o777 == 0o600
+    with socket.socket() as listener, (evidence / "runtime-serve.log").open("w") as log:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 18765))
+        listener.listen(1)
+        listener.settimeout(40)
+        process = subprocess.Popen([osa, "serve"], env=env | {"OSA_OPEN_COMPUTERS_ENABLED": "true"},
+                                   stdout=log, stderr=log, start_new_session=True)
+        try:
+            connection, _ = listener.accept()
+            with connection:
+                connection.settimeout(10)
+                request = b""
+                while b"\r\n\r\n" not in request:
+                    chunk = connection.recv(4096)
+                    assert chunk, "EOF during upgrade"
+                    request += chunk
+                assert request.startswith(b"GET /api/v1/opencomputers/hosts/ws HTTP/1.1\r\n")
+                headers = dict(line.lower().split(b": ", 1) for line in request.split(b"\r\n")[1:] if b": " in line)
+                assert headers[b"sec-websocket-protocol"] == b"miosa-opencomputers-v1"
+                # The key is case-sensitive; recover its original value.
+                key = next(line.split(b": ", 1)[1] for line in request.split(b"\r\n") if line.lower().startswith(b"sec-websocket-key:"))
+                accept = base64.b64encode(hashlib.sha1(key + b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11").digest())
+                connection.sendall(b"HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: " + accept + b"\r\nSec-WebSocket-Protocol: miosa-opencomputers-v1\r\n\r\n")
+
+                def read(n):
+                    data = b""
+                    while len(data) < n:
+                        chunk = connection.recv(n - len(data))
+                        assert chunk, "EOF during hello"
+                        data += chunk
+                    return data
+
+                header = read(2)
+                assert header[0] == 0x82 and header[1] & 0x80, "Expected masked binary frame"
+                size = header[1] & 127
+                if size == 126:
+                    size = struct.unpack("!H", read(2))[0]
+                elif size == 127:
+                    size = struct.unpack("!Q", read(8))[0]
+                assert size < 65536
+                mask = read(4)
+                payload = bytes(byte ^ mask[i % 4] for i, byte in enumerate(read(size)))
+                assert payload.startswith(b"\x83h\x02w\x05hello"), "Expected ETF hello"
+                version = (home / "version").read_text().strip().removeprefix("v")
+                assert version.encode() in payload
+                assert b"oc_host_disposable_smoke_only_0000000000000000" in payload
+                (evidence / "runtime-ws.log").write_text(request.decode() + "\nCLIENT_HELLO " + repr(payload) + "\nLOCAL MOCK ONLY; no backend acceptance asserted\n")
+            for attempt in range(30):
+                try:
+                    with urllib.request.urlopen("http://127.0.0.1:9089/health", timeout=1) as response:
+                        health = json.load(response)
+                    break
+                except OSError:
+                    time.sleep(1)
+            else:
+                raise AssertionError("HTTP health did not become ready")
+            assert health["status"] == "ok" and health["version"] == version
+            (evidence / "runtime-health.json").write_text(json.dumps(health) + "\n")
+            assert process.poll() is None
+            for name in (".env", ".open_computers_enabled"):
+                assert not (home / name).exists(), name
+            print("PASS: no TUI/ALSA; login 0600; environment-only local WS hello and HTTP health; marker absent")
+            print("NOT VERIFIED: backend enrollment, remote execution, desktop, or PTY (root PTY unsupported)")
+        finally:
+            os.killpg(process.pid, 15)
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, 9)
+                process.wait(timeout=5)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/shell/install_modes_test.py
+++ b/test/shell/install_modes_test.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Run the real installer/launcher offline with checksummed release fixtures.
+
+These tests cover shell control flow, not native runtime compatibility.
+See docs/headless-install.md for the separate real-artifact acceptance gate.
+"""
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+
+
+INSTALLER = Path(__file__).resolve().parents[2] / "scripts/install.sh"
+
+
+class InstallModesTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="osa-install-modes-")
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.osa = self.home / ".osa"
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.requests = self.root / "requests"
+        self.calls = self.root / "calls"
+        self.env = {
+            "PATH": f"{self.bin}:/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": str(self.home), "OSA_HOME": str(self.osa),
+            "SHELL": "/bin/bash", "LANG": "C.UTF-8",
+            "FIXTURE_ROOT": str(self.root), "INSTALLER": str(INSTALLER),
+        }
+        self.script(self.bin / "uname", 'case "$1" in -s) echo Linux;; -m) echo x86_64;; esac')
+        # Full installs finish by attaching to a healthy fixture, never a real daemon.
+        self.script(self.bin / "curl", r'''
+import json, os, pathlib, shutil, sys
+r = pathlib.Path(os.environ['FIXTURE_ROOT'])
+args = sys.argv[1:]
+url = next(a for a in args if a.startswith(('https://', 'http://')))
+with (r / 'requests').open('a') as f: f.write(url+'\n')
+dest = pathlib.Path(args[args.index('-o')+1]) if '-o' in args else None
+if '/health' in url:
+    print(json.dumps({'status':'ok', 'version': (r/'latest').read_text().strip()[1:]}))
+    sys.exit(0)
+if '/releases/latest' in url:
+    dest.write_text(json.dumps({'tag_name': (r/'latest').read_text().strip(), 'body': 'fixture notes'}))
+elif url.endswith('/scripts/install.sh'):
+    source = pathlib.Path(os.environ.get('FIXTURE_INSTALLER', os.environ['INSTALLER']))
+    shutil.copyfile(source, dest)
+else:
+    version, name = url.split('/')[-2:]
+    source = r/version/name
+    if not source.exists(): sys.exit(22)
+    shutil.copyfile(source, dest)
+''', python=True)
+        for version in ("1.0.194", "1.0.195"):
+            assets = self.root / f"v{version}"
+            assets.mkdir()
+            release = self.root / f"release-{version}"
+            (release / "bin").mkdir(parents=True)
+            self.script(release / "bin/osagent", f'''
+echo "backend $*" >> "$FIXTURE_ROOT/calls"
+case "$1" in version) echo "osagent v{version}";; esac
+''')
+            with tarfile.open(assets / "osa-linux-x64.tar.gz", "w:gz") as tar:
+                tar.add(release / "bin", arcname="bin")
+            self.script(assets / "osagent-tui-linux-x64", f'''
+echo "tui $*" >> "$FIXTURE_ROOT/calls"
+if [ "${{FAIL_TUI:-}}" = 1 ]; then echo 'libasound.so.2: not found' >&2; exit 127; fi
+if [ "${{1:-}}" = --version ]; then echo 'osagent-tui {version}'; fi
+''')
+            for name in ("osa-linux-x64.tar.gz", "osagent-tui-linux-x64"):
+                checksum = hashlib.sha256((assets / name).read_bytes()).hexdigest()
+                (assets / (name + ".sha256")).write_text(f"{checksum}  {name}\n")
+        (self.root / "latest").write_text("v1.0.195\n")
+
+    def script(self, path, body, python=False):
+        path.write_text((f"#!{sys.executable}\n" if python else "#!/bin/sh\n") + body + "\n")
+        path.chmod(0o755)
+
+    def call(self, args, expected=0, **env):
+        result = subprocess.run(args, env=self.env | env, text=True,
+                                stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=20)
+        self.assertEqual(result.returncode, expected, result.stdout)
+        return result.stdout
+
+    def install(self, **env):
+        return self.call(["sh", str(INSTALLER)], OSA_VERSION="v1.0.195", **env)
+
+    def cli(self, *args, expected=0, **env):
+        return self.call([str(self.osa / "bin/osa"), *args], expected, **env)
+
+    def assert_headless(self):
+        self.assertEqual((self.osa / "install_mode").read_text(), "headless\n")
+        self.assertFalse((self.osa / "bin/osagent-tui").exists())
+        self.assertNotIn("osagent-tui-", self.requests.read_text())
+        self.assertNotIn("tui ", self.calls.read_text() if self.calls.exists() else "")
+
+    def test_fresh_headless_without_tui_dependencies_and_no_implicit_daemon(self):
+        self.call(["bash", str(INSTALLER)], OSA_VERSION="v1.0.195", OSA_INSTALL_MODE="headless", FAIL_TUI="1")
+        self.assertFalse((self.home / ".bashrc").exists())
+        self.cli("opencomputers", "login", "--key", "oc_host_fixture")
+        self.cli("serve")
+        output = self.cli("version")
+        self.assertIn("headless", output)
+        self.assertNotIn("repair", output)
+        before = self.calls.read_text()
+        for args in ((), ("resume",), ("--overdrive",)):
+            self.assertIn("headless", self.cli(*args, expected=1))
+        self.assertEqual(self.calls.read_text(), before)
+        self.assertFalse((self.osa / "run/backend.pid").exists())
+        self.assert_headless()
+
+    def test_reinstall_and_same_version_update_preserve_headless(self):
+        self.install(OSA_INSTALL_MODE="headless")
+        self.install(FAIL_TUI="1")
+        self.cli("update", FAIL_TUI="1")
+        self.assert_headless()
+
+    def test_headless_upgrade_and_launcher_reexec(self):
+        self.call(["sh", str(INSTALLER)], OSA_INSTALL_MODE="headless", OSA_VERSION="v1.0.194")
+        launcher = self.osa / "bin/osa"
+        launcher.write_text(launcher.read_text() + "\n# previous launcher\n")
+        self.cli("update", FAIL_TUI="1")
+        self.assertEqual((self.osa / "version").read_text(), "v1.0.195\n")
+        self.assertIn("v1.0.195", self.cli("version"))
+        self.assert_headless()
+
+    def test_full_remains_default_and_missing_tui_is_repaired(self):
+        self.install()
+        self.assertEqual((self.osa / "install_mode").read_text(), "full\n")
+        (self.osa / "bin/osagent-tui").unlink()
+        self.cli("update")
+        self.assertTrue((self.osa / "bin/osagent-tui").exists())
+        self.assertIn("tui ", self.calls.read_text())
+
+    def test_full_upgrade_keeps_both_components(self):
+        self.call(["sh", str(INSTALLER)], OSA_VERSION="v1.0.194")
+        self.cli("update")
+        self.assertEqual((self.osa / "version").read_text(), "v1.0.195\n")
+        self.assertIn("osagent-tui 1.0.195", self.cli("version"))
+        self.assertEqual((self.osa / "install_mode").read_text(), "full\n")
+
+    def test_explicit_full_reinstall_adds_tui(self):
+        self.install(OSA_INSTALL_MODE="headless")
+        self.install(OSA_INSTALL_MODE="full")
+        self.assertEqual((self.osa / "install_mode").read_text(), "full\n")
+        self.assertTrue((self.osa / "bin/osagent-tui").exists())
+
+    def test_explicit_headless_preserves_existing_tui_and_profile(self):
+        self.install()
+        tui = (self.osa / "bin/osagent-tui").read_bytes()
+        profile = (self.home / ".bashrc").read_bytes()
+        self.requests.write_text("")
+        self.calls.write_text("")
+        self.install(OSA_INSTALL_MODE="headless", FAIL_TUI="1")
+        self.cli("update", FAIL_TUI="1")
+        self.assertEqual((self.osa / "bin/osagent-tui").read_bytes(), tui)
+        self.assertEqual((self.home / ".bashrc").read_bytes(), profile)
+        self.assertEqual((self.osa / "install_mode").read_text(), "headless\n")
+        self.assertNotIn("osagent-tui-", self.requests.read_text())
+        self.assertNotIn("tui ", self.calls.read_text())
+
+    def test_legacy_full_reinstall_and_update_remain_full(self):
+        self.install()
+        (self.osa / "install_mode").unlink()
+        self.install()
+        self.assertEqual((self.osa / "install_mode").read_text(), "full\n")
+        (self.osa / "install_mode").unlink()
+        self.cli("update")
+        self.assertEqual((self.osa / "install_mode").read_text(), "full\n")
+
+    def test_headless_refuses_launcher_without_mode_support(self):
+        self.install(OSA_INSTALL_MODE="headless")
+        old = self.root / "old-install.sh"
+        old.write_text(INSTALLER.read_text().replace("# OSA_HEADLESS_INSTALL_V1:", "# old launcher:"))
+        before = (self.osa / "bin/osa").read_bytes()
+        self.assertIn("does not support headless", self.cli("update", expected=3, FIXTURE_INSTALLER=str(old)))
+        self.assertEqual((self.osa / "bin/osa").read_bytes(), before)
+        self.assert_headless()
+        self.call(["sh", str(INSTALLER)], OSA_VERSION="v1.0.194")
+        self.cli("update", expected=3, FIXTURE_INSTALLER=str(old))
+        self.assertEqual((self.osa / "version").read_text(), "v1.0.194\n")
+        self.assertIn("v1.0.194", self.cli("version"))
+
+    def test_saved_invalid_mode_fails_closed(self):
+        self.install(OSA_INSTALL_MODE="headless")
+        (self.osa / "install_mode").write_text("typo\n")
+        self.requests.write_text("")
+        self.call(["sh", str(INSTALLER)], expected=1)
+        self.cli("update", expected=1)
+        self.assertEqual(self.requests.read_text(), "")
+
+    def test_headless_update_requires_valid_checksum_before_swap(self):
+        self.call(["sh", str(INSTALLER)], OSA_INSTALL_MODE="headless", OSA_VERSION="v1.0.194")
+        asset = self.root / "v1.0.195/osa-linux-x64.tar.gz.sha256"
+        for contents in ("0" * 64 + "  osa-linux-x64.tar.gz\n", None):
+            if contents is None:
+                asset.unlink()
+            else:
+                asset.write_text(contents)
+            self.cli("update", expected=3)
+            self.assertEqual((self.osa / "version").read_text(), "v1.0.194\n")
+            self.assertIn("v1.0.194", self.cli("version"))
+        self.assert_headless()
+
+    def test_full_still_fails_for_missing_native_tui_library(self):
+        self.call(["sh", str(INSTALLER)], expected=3, OSA_VERSION="v1.0.195", FAIL_TUI="1")
+        self.assertFalse((self.osa / "install_mode").exists())
+
+    def test_invalid_mode_fails_before_download_or_install(self):
+        self.call(["sh", str(INSTALLER)], expected=1, OSA_INSTALL_MODE="typo")
+        self.assertFalse(self.requests.exists())
+        self.assertFalse(self.osa.exists())
+
+    def test_headless_rejects_bad_or_missing_checksum(self):
+        asset = self.root / "v1.0.195/osa-linux-x64.tar.gz.sha256"
+        asset.write_text("0" * 64 + "  osa-linux-x64.tar.gz\n")
+        self.call(["sh", str(INSTALLER)], expected=3, OSA_INSTALL_MODE="headless", OSA_VERSION="v1.0.195")
+        self.assertFalse((self.osa / "install_mode").exists())
+        asset.unlink()
+        self.call(["sh", str(INSTALLER)], expected=3, OSA_INSTALL_MODE="headless", OSA_VERSION="v1.0.195")
+        self.assertFalse((self.osa / "install_mode").exists())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Fresh Linux OpenComputers hosts cannot finish the full OSA installer without ALSA: the installer unconditionally runs the Rust TUI and exits before writing the launcher when libasound.so.2 is missing.
Add `OSA_INSTALL_MODE=headless` to install and update the backend plus Bash launcher without downloading or executing the standalone TUI.

The successful install records `full` or `headless` in `$OSA_HOME/install_mode`.
Reinstall and update preserve that mode, absent mode files retain legacy full behavior, and an explicit setting can change it.
Headless conversion preserves existing TUI files and profiles; interactive launch fails before warming a daemon, version reports the intentionally disabled TUI, and update exits without prompting or launching it.
Headless install/update require runtime checksum verification and reject an incompatible historical launcher before an upgrade stops the service or swaps the runtime.

Validation:

- RED against the original installer; GREEN for 14 offline installer/update cases, including existing full installs, mode persistence, checksums, upgrades, and launcher re-exec.
- Standalone ExUnit: 25 tests passed (the installer-suite wrapper plus 24 existing launcher-argument tests).
- Existing launcher self-repair harness: 101 assertions passed on Linux, including full prebuilt updates and launcher replacement.
- Existing source-updater harness: 64 assertions passed as an unprivileged Linux user (its permission-denial tests require non-root).
- Shell syntax, ShellCheck error-level checks, Python syntax, ExUnit formatting, and git whitespace checks passed.
- Real published Linux x64 v1.0.195 installed fresh without ALSA or TUI; same-version update and real v1.0.194-to-v1.0.195 upgrade passed with the candidate launcher supplied via the existing local raw-base override.
- After disconnecting Docker networking, the real runtime saved login config with mode 0600, served HTTP health, and sent its binary hello to a local WebSocket mock using only `OSA_OPEN_COMPUTERS_ENABLED=true`, with `.env` and the enable marker absent.
- The unmodified published v1.0.195 launcher was correctly rejected with exit 3 because it lacks headless support.

The runtime tarball SHA256 was `60299959594885ae8b2fec3fa60e9df5c42e35632ee58f62eef462b800cfe23e`; runtime downloads were verified against their published checksum sidecars.
Native smoke ran on Debian 12 amd64 under Docker emulation on an arm64 host.
The normal Mix test command is blocked by absent dependencies in the clean worktree; the standalone focused ExUnit run above does not require those dependencies.

Release handoff: the paired MIOSA enrollment wrapper must check installer success and the exact saved mode before reporting installation readiness.
This PR must be reviewed/merged, and a release containing the launcher is needed for normal tag-based headless updates; this PR does not merge, release, or deploy anything.
Required rollout order: merge OSA #271, have the release owner publish a compatible latest release, verify public install/reinstall/update without the local raw-base override, merge the paired wrapper, then roll out compute and verify authenticated enrollment.
Fresh installation from merged main can use the existing v1.0.195 runtime, but the complete compute rollout should wait for the compatible published launcher so updates also work.
Local mock success is not authenticated MIOSA enrollment or proof of remote execution/desktop/PTY capability; root PTY remains explicitly unsupported.
See `docs/headless-install.md` and the opt-in real-runtime smoke harness for reproduction.
