### PR TITLE
fix(opencomputers): actionable session failures and safe reconnect timers

### DIFF
--- a/lib/optimal_system_agent/cli/opencomputers.ex
+++ b/lib/optimal_system_agent/cli/opencomputers.ex
@@ -37,6 +37,7 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
 
   defp cmd_status do
     cfg = read_toml()
+    session = session_status()
     config_enabled = Application.get_env(:optimal_system_agent, :open_computers_enabled, false)
     env_enabled = System.get_env(@env_var) == "true"
     marker_enabled = File.exists?(marker_path())
@@ -61,11 +62,12 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
     IO.puts("  Heartbeat ms: #{cfg[:heartbeat_ms] || 30_000}")
     IO.puts("")
     IO.puts("  Supervisor:   #{supervisor_status()}")
-    IO.puts("  Session:      #{session_status()}")
+    IO.puts("  Session:      #{session_label(session)}")
+    print_session_details(session)
     IO.puts("")
 
     has_key = present?(cfg[:host_key])
-    {verdict, hint} = connection_verdict(enabled, has_key, session_status())
+    {verdict, hint} = connection_verdict(enabled, has_key, session)
     IO.puts("  Status: #{verdict}")
     if hint, do: IO.puts("  Next:   #{hint}")
     IO.puts("")
@@ -76,7 +78,25 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
   # whether a host_key is present, and the human session-status string, return
   # {verdict, next_step_hint_or_nil}. Extracted so it can be tested without
   # touching live processes or the network.
-  @spec connection_verdict(boolean(), boolean(), String.t()) :: {String.t(), String.t() | nil}
+  @spec connection_verdict(boolean(), boolean(), String.t() | map()) ::
+          {String.t(), String.t() | nil}
+  def connection_verdict(_enabled, _key, %{phase: :rejected, failure: failure}) do
+    {"REJECTED - #{failure.reason}; automatic reconnect paused", failure.action}
+  end
+
+  def connection_verdict(_enabled, _key, %{phase: :active}) do
+    {"CONNECTED - this machine is online in MIOSA", nil}
+  end
+
+  def connection_verdict(_enabled, _key, %{retry_in_ms: delay, failure: failure})
+      when is_integer(delay) and not is_nil(failure) do
+    {"NOT connected - retrying in #{delay}ms", "transient failure; automatic reconnect scheduled"}
+  end
+
+  def connection_verdict(enabled, key, %{} = session) do
+    connection_verdict(enabled, key, session_label(session))
+  end
+
   def connection_verdict(_enabled, false, _session) do
     {"NOT connected — no host key configured",
      "run `osa opencomputers login` (generate a key at #{@dashboard_url})"}
@@ -127,8 +147,7 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
     case Process.whereis(OptimalSystemAgent.OpenComputers.Session) do
       pid when is_pid(pid) ->
         try do
-          %{phase: phase} = :sys.get_state(pid, 2_000)
-          if phase == :active, do: "connected (active)", else: "running (phase=#{phase})"
+          OptimalSystemAgent.OpenComputers.Session.status()
         rescue
           _ -> "running"
         catch
@@ -139,6 +158,24 @@ defmodule OptimalSystemAgent.CLI.OpenComputers do
         "not running"
     end
   end
+
+  defp session_label(%{phase: :active}), do: "connected (active)"
+  defp session_label(%{phase: phase}), do: "running (phase=#{phase})"
+  defp session_label(status), do: status
+
+  defp print_session_details(%{failure: failure, retry_in_ms: delay}) do
+    if failure do
+      IO.puts(
+        "  Failure:      #{OptimalSystemAgent.OpenComputers.Session.Failure.describe(failure)}"
+      )
+    end
+
+    IO.puts(
+      "  Retry:        #{if is_integer(delay), do: "in #{delay}ms", else: "none scheduled"}"
+    )
+  end
+
+  defp print_session_details(_), do: :ok
 
   # ── login ────────────────────────────────────────────────────────
 

--- a/lib/optimal_system_agent/open_computers/session.ex
+++ b/lib/optimal_system_agent/open_computers/session.ex
@@ -5,20 +5,21 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
   Lifecycle
   ---------
   1. On start, schedules an immediate `:connect` message to itself.
-  2. `:connect` — calls `Session.Connector.connect/1` (blocking Mint upgrade),
-     on success sends the `{:hello, ...}` frame and registers itself as the
-     active host_client in `OpenComputers.FrameRouter` so executor outbound
-     frames reach the wire.
+  2. `:connect` calls `Session.Connector.connect/1` and sends hello after a validated upgrade.
   3. After `{:hello_ok, _}` is received (via `Session.FrameRouter.handle/2`),
-     transitions to `:active` and schedules a self-heartbeat timer.
+     transitions to `:active`, registers the host_client and schedules heartbeat timers.
   4. Every `heartbeat_ms` (default 30 s), sends `{:heartbeat, %{ts, seq}}` to
      the control plane.  No response → connection considered dead after
      `@dead_ms` (90 s) of silence; reconnect is triggered.
-  5. On any transport error or explicit `{:close, _, _}` frame, resets to
-     `:disconnected` and schedules a reconnect with exponential backoff
-     (1 s → 2 s → … → 60 s, ±200 ms jitter, reset to 1 s on success).
+  5. Transient failures schedule exponential reconnect delays (2 s, 4 s, up to 60 s including jitter).
+     Only hello_ok resets the backoff baseline to 1 s.
+     Auth, upgrade, fingerprint and revoked-key rejections pause retries until correction and restart.
+     All timers are reference-tagged; cancelled or queued timers cannot affect a later attempt.
   6. After `@stuck_threshold` consecutive failures, emits
      `[:osa, :oc, :session, :stuck]` telemetry so an operator can alert.
+
+  `status/0` exposes only phase, safe failure details, failure count and remaining retry delay.
+  The CLI consumes this surface without reading the secret-bearing GenServer state.
 
   Outbound frame path
   -------------------
@@ -44,6 +45,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
   alias OptimalSystemAgent.OpenComputers.Session.{
     Backoff,
     Connector,
+    Failure,
     FrameCodec,
     FrameRouter,
     Hello
@@ -61,6 +63,9 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
     GenServer.start_link(__MODULE__, opts, name: __MODULE__)
   end
 
+  @doc "Safe connection status, including rejection reason/action and remaining retry delay."
+  def status, do: GenServer.call(__MODULE__, :status)
+
   # ── GenServer init ────────────────────────────────────────────────────────────
 
   @impl true
@@ -75,7 +80,10 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
       backoff_ms: Backoff.initial(),
       # consecutive connect failures (reset on successful hello_ok)
       failure_count: 0,
-      # reference to the active heartbeat timer (Process.send_after)
+      hello_timer: nil,
+      reconnect_timer: nil,
+      failure: nil,
+      # reference to the active heartbeat timer
       heartbeat_timer: nil,
       # reference to the inactivity watchdog timer
       dead_timer: nil,
@@ -93,7 +101,29 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
   # ── Connect ───────────────────────────────────────────────────────────────────
 
   @impl true
-  def handle_info(:connect, state) do
+  def handle_call(:status, _from, state) do
+    retry_in_ms = if state.reconnect_timer, do: Process.read_timer(state.reconnect_timer) || 0
+
+    {:reply,
+     %{
+       phase: state.phase,
+       failure: state.failure,
+       failure_count: state.failure_count,
+       retry_in_ms: retry_in_ms
+     }, state}
+  end
+
+  @impl true
+  def handle_info(
+        {:timeout, timer, :connect},
+        %{phase: :disconnected, reconnect_timer: timer} = state
+      ) do
+    handle_info(:connect, %{state | reconnect_timer: nil})
+  end
+
+  def handle_info({:timeout, _, :connect}, state), do: {:noreply, state}
+
+  def handle_info(:connect, %{phase: :disconnected, reconnect_timer: nil} = state) do
     cfg = Config.get()
 
     if is_nil(cfg.host_key) or cfg.host_key == "" do
@@ -103,73 +133,74 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
       )
 
       # Retry after a long delay; don't hammer logs.
-      schedule_reconnect(%{state | backoff_ms: 60_000})
-      {:noreply, state}
+      {:noreply, schedule_reconnect(%{state | backoff_ms: 60_000})}
     else
       connect_result =
         try do
           Connector.connect(cfg.control_url)
         rescue
-          e -> {:error, Exception.message(e)}
+          _ -> {:error, :connect_exception}
         catch
-          kind, reason -> {:error, {kind, reason}}
+          _, _ -> {:error, :connect_exception}
         end
 
       case connect_result do
         {:ok, {conn, ref, websocket}} ->
-          Logger.info(
-            "[OC.Session] WS upgrade complete — sending hello host_key=#{redact(cfg.host_key)}"
-          )
+          Logger.info("[OC.Session] WS upgrade complete - sending hello")
 
           state = %{
             state
             | conn: conn,
               ref: ref,
               websocket: websocket,
-              phase: :awaiting_hello_ok,
-              backoff_ms: Backoff.initial()
+              phase: :awaiting_hello_ok
           }
 
           case send_term(state, {:hello, Hello.build(cfg)}) do
             {:ok, state} ->
-              Process.send_after(self(), :hello_timeout, @hello_timeout_ms)
-              {:noreply, state}
+              timer = :erlang.start_timer(@hello_timeout_ms, self(), :hello_timeout)
+              {:noreply, %{state | hello_timer: timer}}
 
             {:error, reason, state} ->
-              Logger.error("[OC.Session] send hello failed: #{inspect(reason)}")
+              Logger.error(
+                "[OC.Session] send hello failed reason=#{safe_transport_reason(reason)}"
+              )
+
               new_state = on_failure(close(state))
-              schedule_reconnect(new_state)
-              {:noreply, new_state}
+              {:noreply, schedule_reconnect(new_state)}
           end
 
+        {:error, {:handshake, reason}} ->
+          {:noreply, handle_failure(state, Failure.handshake(reason))}
+
         {:error, reason} ->
-          new_state = on_failure(state)
-
-          Logger.warning(
-            "[OC.Session] connect failed (attempt=#{new_state.failure_count}): " <>
-              "#{inspect(reason)} — retrying in ~#{new_state.backoff_ms}ms"
-          )
-
-          schedule_reconnect(new_state)
-          {:noreply, new_state}
+          {:noreply, handle_failure(state, Failure.transport(reason))}
       end
     end
   end
 
+  def handle_info(:connect, state), do: {:noreply, state}
+
   # ── Hello timeout ─────────────────────────────────────────────────────────────
 
-  def handle_info(:hello_timeout, %{phase: :awaiting_hello_ok} = state) do
+  def handle_info(
+        {:timeout, timer, :hello_timeout},
+        %{phase: :awaiting_hello_ok, hello_timer: timer} = state
+      ) do
     Logger.warning("[OC.Session] hello_ok timeout — reconnecting")
     new_state = on_failure(close(state))
-    schedule_reconnect(new_state)
-    {:noreply, new_state}
+    {:noreply, schedule_reconnect(new_state)}
   end
 
   def handle_info(:hello_timeout, state), do: {:noreply, state}
+  def handle_info({:timeout, _, :hello_timeout}, state), do: {:noreply, state}
 
   # ── Self-heartbeat ────────────────────────────────────────────────────────────
 
-  def handle_info(:heartbeat, %{phase: :active} = state) do
+  def handle_info(
+        {:timeout, timer, :heartbeat},
+        %{phase: :active, heartbeat_timer: timer} = state
+      ) do
     seq = state.heartbeat_seq + 1
 
     frame = {:heartbeat, %{ts: DateTime.utc_now() |> DateTime.to_unix(:millisecond), seq: seq}}
@@ -178,29 +209,32 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
 
     case send_term(state, frame) do
       {:ok, state} ->
-        timer = Process.send_after(self(), :heartbeat, state.heartbeat_ms)
+        timer = :erlang.start_timer(state.heartbeat_ms, self(), :heartbeat)
         {:noreply, %{state | heartbeat_seq: seq, heartbeat_timer: timer}}
 
       {:error, reason, state} ->
-        Logger.warning("[OC.Session] heartbeat send failed: #{inspect(reason)} — reconnecting")
+        Logger.warning(
+          "[OC.Session] heartbeat send failed reason=#{safe_transport_reason(reason)} - reconnecting"
+        )
+
         new_state = on_failure(close(state))
-        schedule_reconnect(new_state)
-        {:noreply, new_state}
+        {:noreply, schedule_reconnect(new_state)}
     end
   end
 
   def handle_info(:heartbeat, state), do: {:noreply, state}
+  def handle_info({:timeout, _, :heartbeat}, state), do: {:noreply, state}
 
   # ── Inactivity watchdog ───────────────────────────────────────────────────────
 
-  def handle_info(:dead_check, %{phase: :active} = state) do
+  def handle_info({:timeout, timer, :dead_check}, %{phase: :active, dead_timer: timer} = state) do
     Logger.warning("[OC.Session] no inbound traffic for #{@dead_ms}ms — reconnecting")
     new_state = on_failure(close(state))
-    schedule_reconnect(new_state)
-    {:noreply, new_state}
+    {:noreply, schedule_reconnect(new_state)}
   end
 
   def handle_info(:dead_check, state), do: {:noreply, state}
+  def handle_info({:timeout, _, :dead_check}, state), do: {:noreply, state}
 
   # ── Outbound frames from executors (via FrameRouter.send_frame/1) ─────────────
   # FrameRouter does: send(host_client_pid, {:send_frame, frame})
@@ -211,10 +245,12 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
         {:noreply, state}
 
       {:error, reason, state} ->
-        Logger.warning("[OC.Session] send_frame failed: #{inspect(reason)} — reconnecting")
+        Logger.warning(
+          "[OC.Session] send_frame failed reason=#{safe_transport_reason(reason)} - reconnecting"
+        )
+
         new_state = on_failure(close(state))
-        schedule_reconnect(new_state)
-        {:noreply, new_state}
+        {:noreply, schedule_reconnect(new_state)}
     end
   end
 
@@ -226,12 +262,14 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
 
   # ── Legacy executor_frame path (kept for compatibility) ───────────────────────
 
-  def handle_info({:executor_frame, frame}, state) do
+  def handle_info({:executor_frame, frame}, %{phase: :active} = state) do
     case send_term(state, frame) do
       {:ok, state} -> {:noreply, state}
       {:error, _reason, state} -> {:noreply, state}
     end
   end
+
+  def handle_info({:executor_frame, _frame}, state), do: {:noreply, state}
 
   # ── TCP/WS transport messages ─────────────────────────────────────────────────
 
@@ -242,8 +280,10 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
 
       {:reconnect, state} ->
         new_state = on_failure(close(state))
-        schedule_reconnect(new_state)
-        {:noreply, new_state}
+        {:noreply, schedule_reconnect(new_state)}
+
+      {:server_close, code, reason, state} ->
+        {:noreply, server_close(state, code, reason)}
 
       :unknown ->
         {:noreply, state}
@@ -305,6 +345,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
             case handle_frames(frames, %{state | websocket: websocket}) do
               {:ok, new_state} -> {:cont, {:ok, new_state}}
               {:reconnect, new_state} -> {:halt, {:reconnect, new_state}}
+              {:server_close, _, _, _} = result -> {:halt, result}
             end
 
           {:error, websocket, _reason} ->
@@ -326,6 +367,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
             case apply_actions(actions, state) do
               {:ok, new_state} -> {:cont, {:ok, new_state}}
               {:reconnect, new_state} -> {:halt, {:reconnect, new_state}}
+              {:server_close, _, _, _} = result -> {:halt, result}
             end
 
           :error ->
@@ -339,8 +381,8 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
           {:error, _reason, state} -> {:halt, {:reconnect, state}}
         end
 
-      {:close, _code, _reason}, {:ok, state} ->
-        {:halt, {:reconnect, state}}
+      {:close, code, reason}, {:ok, state} ->
+        {:halt, {:server_close, code, reason, state}}
 
       _other, acc ->
         {:cont, acc}
@@ -356,6 +398,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
         end
 
       {:start_heartbeat, interval_ms}, {:ok, s} ->
+        cancel_timer(s.hello_timer)
         # Register this pid as host_client for executor outbound frames.
         # Guard with whereis — FrameRouter may not be running in test environments.
         case Process.whereis(GlobalFrameRouter) do
@@ -367,18 +410,21 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
         end
 
         cancel_timer(s.heartbeat_timer)
-        timer = Process.send_after(self(), :heartbeat, interval_ms)
+        timer = :erlang.start_timer(interval_ms, self(), :heartbeat)
 
-        dead = Process.send_after(self(), :dead_check, @dead_ms)
+        dead = :erlang.start_timer(@dead_ms, self(), :dead_check)
         cancel_timer(s.dead_timer)
 
         Logger.info("[OC.Session] phase=active heartbeat_interval=#{interval_ms}ms")
 
         new_s = %{
           s
-          | heartbeat_timer: timer,
+          | hello_timer: nil,
+            heartbeat_timer: timer,
             dead_timer: dead,
             heartbeat_ms: interval_ms,
+            backoff_ms: Backoff.initial(),
+            failure: nil,
             failure_count: 0
         }
 
@@ -386,6 +432,9 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
 
       :reconnect, {:ok, s} ->
         {:halt, {:reconnect, s}}
+
+      {:close, code, reason}, {:ok, s} ->
+        {:halt, {:server_close, code, reason, s}}
 
       :noop, acc ->
         {:cont, acc}
@@ -400,6 +449,8 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
   # ── State helpers ─────────────────────────────────────────────────────────────
 
   defp close(state) do
+    cancel_timer(state.reconnect_timer)
+    cancel_timer(state.hello_timer)
     cancel_timer(state.heartbeat_timer)
     cancel_timer(state.dead_timer)
 
@@ -411,6 +462,8 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
         ref: nil,
         websocket: nil,
         phase: :disconnected,
+        reconnect_timer: nil,
+        hello_timer: nil,
         heartbeat_timer: nil,
         dead_timer: nil
     }
@@ -436,20 +489,44 @@ defmodule OptimalSystemAgent.OpenComputers.Session do
   end
 
   defp schedule_reconnect(state) do
+    cancel_timer(state.reconnect_timer)
     delay = Backoff.with_jitter(state.backoff_ms)
-    Process.send_after(self(), :connect, delay)
+    timer = :erlang.start_timer(delay, self(), :connect)
+    %{state | reconnect_timer: timer}
   end
 
-  defp reset_dead_timer(state) do
+  defp reset_dead_timer(%{phase: :active} = state) do
     cancel_timer(state.dead_timer)
-    timer = Process.send_after(self(), :dead_check, @dead_ms)
+    timer = :erlang.start_timer(@dead_ms, self(), :dead_check)
     %{state | dead_timer: timer}
   end
+
+  defp reset_dead_timer(state), do: state
 
   defp cancel_timer(nil), do: :ok
   defp cancel_timer(ref) when is_reference(ref), do: Process.cancel_timer(ref)
 
-  defp redact(nil), do: "(nil)"
-  defp redact(key) when byte_size(key) > 8, do: binary_part(key, 0, 7) <> "..."
-  defp redact(key), do: key
+  defp server_close(state, code, _reason), do: handle_failure(state, Failure.close(code))
+
+  defp handle_failure(state, failure) do
+    state = %{close(state) | failure: failure}
+
+    if failure.action do
+      Logger.error(
+        "[OC.Session] #{Failure.describe(failure)}; reconnect paused. #{failure.action}"
+      )
+
+      %{state | phase: :rejected}
+    else
+      state = on_failure(state)
+
+      Logger.warning(
+        "[OC.Session] #{Failure.describe(failure)} - retrying in ~#{state.backoff_ms}ms"
+      )
+
+      schedule_reconnect(state)
+    end
+  end
+
+  defp safe_transport_reason(reason), do: Failure.transport_reason(reason)
 end

--- a/lib/optimal_system_agent/open_computers/session/backoff.ex
+++ b/lib/optimal_system_agent/open_computers/session/backoff.ex
@@ -4,7 +4,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session.Backoff do
 
     * Initial delay 1 s
     * Doubles each attempt, capped at 60 s
-    * ±200 ms uniform jitter to decorrelate reconnect thundering-herds
+    * Up to 200 ms positive jitter, bounded by the 60 s maximum
   """
 
   @initial_ms 1_000
@@ -23,5 +23,5 @@ defmodule OptimalSystemAgent.OpenComputers.Session.Backoff do
   end
 
   @spec with_jitter(pos_integer()) :: pos_integer()
-  def with_jitter(base_ms), do: base_ms + :rand.uniform(@jitter_ms)
+  def with_jitter(base_ms), do: min(base_ms + :rand.uniform(@jitter_ms), @max_ms)
 end

--- a/lib/optimal_system_agent/open_computers/session/connector.ex
+++ b/lib/optimal_system_agent/open_computers/session/connector.ex
@@ -19,7 +19,10 @@ defmodule OptimalSystemAgent.OpenComputers.Session.Connector do
 
   The host side uses the default `#{@subprotocol}` subprotocol. The remote
   CLIENT side passes `subprotocol: "miosa-opencomputers-client-v1"` so it
-  negotiates the #484 client endpoint. All other callers are unchanged.
+  negotiates the #484 client endpoint.
+  The response must select exactly that subprotocol and return HTTP 101.
+  Deploy the backend's selected-subprotocol response-header fix before releasing this validation.
+  Upgrade failures close the owned connection and return safe handshake categories.
   """
   @spec connect(String.t(), keyword()) :: {:ok, t()} | {:error, term()}
   def connect(control_url, opts \\ []) when is_binary(control_url) and is_list(opts) do
@@ -41,50 +44,85 @@ defmodule OptimalSystemAgent.OpenComputers.Session.Connector do
            Mint.WebSocket.upgrade(ws_scheme, conn, path, [
              {"sec-websocket-protocol", subprotocol}
            ]),
-         {:ok, conn, websocket} <- await_upgrade(conn, ref) do
+         {:ok, conn, websocket} <-
+           await_upgrade(conn, ref, subprotocol, nil, now() + @upgrade_timeout_ms) do
       {:ok, {conn, ref, websocket}}
     else
       {:error, reason} -> {:error, reason}
-      {:error, _conn, reason} -> {:error, reason}
+      {:error, conn, reason} -> fail(conn, reason)
     end
   end
 
   # ── Private ──
 
-  defp await_upgrade(conn, ref) do
+  defp await_upgrade(conn, ref, subprotocol, status, deadline) do
+    socket = Mint.HTTP.get_socket(conn)
+    remaining = max(deadline - now(), 0)
+
     receive do
-      message ->
+      message
+      when is_tuple(message) and tuple_size(message) in [2, 3] and
+             elem(message, 1) == socket and
+             elem(message, 0) in [:tcp, :ssl, :tcp_closed, :ssl_closed, :tcp_error, :ssl_error] ->
         case Mint.WebSocket.stream(conn, message) do
-          {:ok, conn, responses} -> upgrade_response(conn, ref, responses)
-          {:error, _conn, reason, _responses} -> {:error, reason}
-          :unknown -> await_upgrade(conn, ref)
+          {:ok, conn, responses} ->
+            case upgrade_response(conn, ref, responses, subprotocol, status) do
+              {:waiting, conn, status} -> await_upgrade(conn, ref, subprotocol, status, deadline)
+              result -> result
+            end
+
+          # Mint may mark the returned connection closed before closing its socket.
+          # Close the owned, pre-stream connection so the transport is released.
+          {:error, _closed_conn, _reason, _responses} ->
+            fail(conn, :upgrade_transport_error)
+
+          :unknown ->
+            await_upgrade(conn, ref, subprotocol, status, deadline)
         end
     after
-      @upgrade_timeout_ms -> {:error, :upgrade_timeout}
+      remaining -> fail(conn, :upgrade_timeout)
     end
   end
 
-  defp upgrade_response(conn, ref, responses) do
-    Enum.reduce_while(responses, {:waiting, conn}, fn
-      {:status, ^ref, _status}, {:waiting, conn} ->
-        {:cont, {:waiting, conn}}
+  defp upgrade_response(conn, ref, responses, subprotocol, status) do
+    Enum.reduce_while(responses, {:waiting, conn, status}, fn
+      {:status, ^ref, status}, {:waiting, conn, _} when status != 101 ->
+        {:halt, fail(conn, {:handshake, {:http_status, status}})}
 
-      {:headers, ^ref, headers}, {:waiting, conn} ->
-        case Mint.WebSocket.new(conn, ref, 101, headers) do
-          {:ok, conn, websocket} -> {:halt, {:ok, conn, websocket}}
-          {:error, _conn, reason} -> {:halt, {:error, reason}}
+      {:status, ^ref, 101}, {:waiting, conn, _} ->
+        {:cont, {:waiting, conn, 101}}
+
+      {:headers, ^ref, headers}, {:waiting, conn, status} ->
+        result =
+          if for({"sec-websocket-protocol", value} <- headers, do: value) == [subprotocol] do
+            case Mint.WebSocket.new(conn, ref, status, headers) do
+              {:error, conn, _reason} -> {:error, conn, {:handshake, :invalid_upgrade}}
+              result -> result
+            end
+          else
+            {:error, conn, {:handshake, :subprotocol_mismatch}}
+          end
+
+        case result do
+          {:ok, conn, websocket} ->
+            {:halt, {:ok, conn, websocket}}
+
+          {:error, conn, reason} ->
+            {:halt, fail(conn, reason)}
         end
 
-      {:done, ^ref}, acc ->
-        {:halt, acc}
+      {:done, ^ref}, {:waiting, conn, _} ->
+        {:halt, fail(conn, {:handshake, :invalid_upgrade})}
 
       _other, acc ->
         {:cont, acc}
     end)
-    |> case do
-      {:ok, conn, websocket} -> {:ok, conn, websocket}
-      {:error, reason} -> {:error, reason}
-      _ -> {:error, :no_upgrade}
-    end
   end
+
+  defp fail(conn, reason) do
+    Mint.HTTP.close(conn)
+    {:error, reason}
+  end
+
+  defp now, do: System.monotonic_time(:millisecond)
 end

--- a/lib/optimal_system_agent/open_computers/session/failure.ex
+++ b/lib/optimal_system_agent/open_computers/session/failure.ex
@@ -1,0 +1,83 @@
+defmodule OptimalSystemAgent.OpenComputers.Session.Failure do
+  @moduledoc """
+  Safe session failure policy shared by reconnect handling and status reporting.
+  Remote text, HTTP headers, credentials and exception messages never enter diagnostics.
+  A non-nil action pauses automatic reconnect until operator correction and restart.
+  """
+
+  def close(code) do
+    {reason, action} =
+      case code do
+        4001 ->
+          {:auth, auth_action()}
+
+        4003 ->
+          {:upgrade_required, protocol_action()}
+
+        4004 ->
+          {:fingerprint_pinned,
+           "Verify this host's registered fingerprint with the administrator, then restart OSA."}
+
+        4007 ->
+          {:key_revoked,
+           "Obtain a new host key and run `osa opencomputers login --key <key>`, then restart OSA."}
+
+        4008 ->
+          {:timeout, nil}
+
+        _ ->
+          {:transient, nil}
+      end
+
+    code = if is_integer(code) and code in 1000..4999, do: code, else: :unknown
+    %{source: :server_close, code: code, reason: reason, action: action}
+  end
+
+  def handshake({:http_status, status}) do
+    {reason, action} =
+      if status in [401, 403], do: {:auth, auth_action()}, else: {:http_error, nil}
+
+    %{source: :handshake, status: status, reason: reason, action: action}
+  end
+
+  def handshake(reason) when reason in [:subprotocol_mismatch, :invalid_upgrade] do
+    %{source: :handshake, reason: reason, action: protocol_action()}
+  end
+
+  def transport(reason), do: %{source: :transport, reason: transport_reason(reason), action: nil}
+
+  def transport_reason(%Mint.TransportError{reason: reason}), do: transport_reason(reason)
+
+  def transport_reason(reason)
+      when reason in [
+             :closed,
+             :timeout,
+             :econnrefused,
+             :nxdomain,
+             :enetunreach,
+             :ehostunreach,
+             :upgrade_timeout,
+             :upgrade_transport_error,
+             :connect_exception
+           ],
+      do: reason
+
+  def transport_reason(_), do: :transport_error
+
+  def describe(failure) do
+    detail =
+      cond do
+        Map.has_key?(failure, :code) -> "code=#{failure.code} "
+        Map.has_key?(failure, :status) -> "status=#{failure.status} "
+        true -> ""
+      end
+
+    "#{failure.source} #{detail}reason=#{failure.reason}"
+  end
+
+  defp auth_action,
+    do: "Run `osa opencomputers login --key <key>` with a valid host key, then restart OSA."
+
+  defp protocol_action,
+    do: "Update OSA and verify the control-plane WebSocket subprotocol, then restart OSA."
+end

--- a/lib/optimal_system_agent/open_computers/session/frame_router.ex
+++ b/lib/optimal_system_agent/open_computers/session/frame_router.ex
@@ -15,6 +15,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session.FrameRouter do
           | {:send, term()}
           | {:start_heartbeat, pos_integer()}
           | :reconnect
+          | {:close, term(), term()}
 
   @spec handle(term(), map()) :: {[action()], map()}
   def handle({:hello_ok, info}, state) do
@@ -26,8 +27,7 @@ defmodule OptimalSystemAgent.OpenComputers.Session.FrameRouter do
   def handle({:ping, seq}, state), do: {[{:send, {:pong, seq}}], state}
 
   def handle({:close, code, reason}, state) do
-    Logger.info("[OpenComputers.Session] server close code=#{code} reason=#{reason}")
-    {[:reconnect], state}
+    {[{:close, code, reason}], state}
   end
 
   def handle({:job, job}, state) do

--- a/test/optimal_system_agent/cli/opencomputers_test.exs
+++ b/test/optimal_system_agent/cli/opencomputers_test.exs
@@ -75,6 +75,18 @@ defmodule OptimalSystemAgent.CLI.OpenComputersTest do
   end
 
   describe "connection_verdict/3 — status summariser" do
+    test "missing-key retry polling still gives the login instruction" do
+      {verdict, hint} =
+        OpenComputers.connection_verdict(true, false, %{
+          phase: :disconnected,
+          failure: nil,
+          retry_in_ms: 60_000
+        })
+
+      assert verdict =~ "no host key"
+      assert hint =~ "login"
+    end
+
     test "no host key -> not connected, points at login" do
       {verdict, hint} = OpenComputers.connection_verdict(true, false, "not running")
       assert verdict =~ "NOT connected"

--- a/test/optimal_system_agent/open_computers/session/backoff_test.exs
+++ b/test/optimal_system_agent/open_computers/session/backoff_test.exs
@@ -50,6 +50,10 @@ defmodule OptimalSystemAgent.OpenComputers.Session.BackoffTest do
   end
 
   describe "with_jitter/1" do
+    test "never exceeds the maximum reconnect delay" do
+      assert Backoff.with_jitter(Backoff.max()) <= Backoff.max()
+    end
+
     test "returns a value >= base" do
       base = 5_000
       result = Backoff.with_jitter(base)

--- a/test/optimal_system_agent/open_computers/session/frame_router_test.exs
+++ b/test/optimal_system_agent/open_computers/session/frame_router_test.exs
@@ -35,9 +35,9 @@ defmodule OptimalSystemAgent.OpenComputers.Session.FrameRouterTest do
   end
 
   describe "handle/2 — close" do
-    test "returns :reconnect action" do
+    test "preserves close details for Session's retry policy" do
       {actions, _state} = FrameRouter.handle({:close, 1000, "normal"}, @initial_state)
-      assert :reconnect in actions
+      assert {:close, 1000, "normal"} in actions
     end
   end
 

--- a/test/optimal_system_agent/open_computers/session/lifecycle_test.exs
+++ b/test/optimal_system_agent/open_computers/session/lifecycle_test.exs
@@ -1,0 +1,369 @@
+defmodule OptimalSystemAgent.OpenComputers.Session.LifecycleTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+  import Bitwise
+
+  alias OptimalSystemAgent.OpenComputers.{Config, Session}
+
+  setup %{tmp_dir: dir} do
+    previous_home = System.get_env("OSA_HOME")
+    System.put_env("OSA_HOME", dir)
+
+    on_exit(fn ->
+      if previous_home,
+        do: System.put_env("OSA_HOME", previous_home),
+        else: System.delete_env("OSA_HOME")
+    end)
+
+    {:ok, listener} = :gen_tcp.listen(0, [:binary, active: false, ip: {127, 0, 0, 1}])
+    {:ok, port} = :inet.port(listener)
+    path = Path.join(dir, "open_computers.toml")
+
+    File.write!(path, """
+    control_url = "ws://127.0.0.1:#{port}/ws"
+    host_key = "s3cr3t"
+    fingerprint_path = "#{dir}/fingerprint"
+    modes = ["direct"]
+    """)
+
+    start_supervised!({Config, path: path})
+    on_exit(fn -> :gen_tcp.close(listener) end)
+    %{listener: listener}
+  end
+
+  @tag :tmp_dir
+  test "auth rejection reports an actionable close without leaking secrets or retrying", ctx do
+    log =
+      capture_log(fn ->
+        start_supervised!(Session)
+        socket = accept_hello(ctx.listener)
+        close_frame(socket, 4001, "auth s3cr3t bearer-token")
+        assert {:error, :timeout} = :gen_tcp.accept(ctx.listener, 2_700)
+      end)
+
+    assert log =~ "code=4001"
+    assert log =~ "auth"
+    assert log =~ "osa opencomputers login"
+    refute log =~ "s3cr3t"
+    refute log =~ "bearer-token"
+  end
+
+  @tag :tmp_dir
+  test "an earlier hello deadline cannot disconnect the next attempt", ctx do
+    start_supervised!(Session)
+    first = accept_hello(ctx.listener)
+    close_frame(first, 4008, "timeout")
+    second = accept_hello(ctx.listener)
+    # The first hello deadline expires at 5s. The second still has time to reply.
+    Process.sleep(3_200)
+    send_term(second, {:hello_ok, %{heartbeat_ms: 60_000}})
+    send_term(second, {:ping, 123})
+    assert {:pong, 123} = receive_term(second)
+  end
+
+  @tag :tmp_dir
+  test "transient rejections increase delay until hello_ok resets it", ctx do
+    start_supervised!(Session)
+    first = accept_hello(ctx.listener)
+    close_frame(first, 4008, "timeout")
+    second = accept_hello(ctx.listener)
+    close_frame(second, 4008, "timeout")
+    # Second consecutive failure must wait ~4s, even though HTTP upgraded.
+    assert {:error, :timeout} = :gen_tcp.accept(ctx.listener, 3_000)
+    third = accept_hello(ctx.listener)
+    send_term(third, {:hello_ok, %{heartbeat_ms: 60_000}})
+    send_term(third, {:ping, 99})
+    assert {:pong, 99} = receive_term(third)
+    close_frame(third, 4008, "timeout")
+    fourth = accept_hello(ctx.listener, 3_000)
+    send_term(fourth, {:hello_ok, %{heartbeat_ms: 60_000}})
+    send_term(fourth, {:ping, 100})
+    assert {:pong, 100} = receive_term(fourth)
+  end
+
+  @tag :tmp_dir
+  test "application close uses the same safe permanent rejection policy", ctx do
+    log =
+      capture_log(fn ->
+        start_supervised!(Session)
+        socket = accept_hello(ctx.listener)
+        send_term(socket, {:close, 4003, "s3cr3t bearer-token"})
+        assert {:error, :timeout} = :gen_tcp.accept(ctx.listener, 2_700)
+      end)
+
+    assert log =~ "code=4003"
+    assert log =~ "upgrade_required"
+    assert log =~ "Update OSA"
+    refute log =~ "s3cr3t"
+    refute log =~ "bearer-token"
+  end
+
+  defp accept_hello(listener, timeout \\ 8_000) do
+    {:ok, socket} = :gen_tcp.accept(listener, timeout)
+    upgrade(socket)
+    assert {:hello, %{host_key: "s3cr3t"}} = receive_term(socket)
+    socket
+  end
+
+  @tag :tmp_dir
+  test "missing selected subprotocol reports a handshake error before sending credentials", ctx do
+    log =
+      capture_log(fn ->
+        start_supervised!(Session)
+        {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+        upgrade(socket, "")
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+        assert {:error, :timeout} = :gen_tcp.accept(ctx.listener, 2_700)
+      end)
+
+    assert log =~ "handshake"
+    assert log =~ "subprotocol"
+    assert log =~ "Update OSA"
+    refute log =~ "s3cr3t"
+  end
+
+  @tag :tmp_dir
+  test "HTTP auth rejection reports actual status without response headers", ctx do
+    log =
+      capture_log(fn ->
+        start_supervised!(Session)
+        {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+        headers(socket, "")
+
+        :ok =
+          :gen_tcp.send(
+            socket,
+            "HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nSet-Cookie: s3cr3t\r\n\r\n"
+          )
+
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+        assert {:error, :timeout} = :gen_tcp.accept(ctx.listener, 2_700)
+      end)
+
+    assert log =~ "status=401"
+    assert log =~ "osa opencomputers login"
+    refute log =~ "s3cr3t"
+  end
+
+  @tag :tmp_dir
+  test "HTTP service failure reports status and reconnects successfully", ctx do
+    log =
+      capture_log(fn ->
+        start_supervised!(Session)
+        {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+        headers(socket, "")
+
+        :ok =
+          :gen_tcp.send(
+            socket,
+            "HTTP/1.1 503 Unavailable\r\nContent-Length: 0\r\nSet-Cookie: s3cr3t\r\n\r\n"
+          )
+
+        assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+        second = accept_hello(ctx.listener, 3_000)
+        send_term(second, {:hello_ok, %{heartbeat_ms: 60_000}})
+        send_term(second, {:ping, 503})
+        assert {:pong, 503} = receive_term(second)
+      end)
+
+    assert log =~ "status=503"
+    assert log =~ "retrying"
+    refute log =~ "s3cr3t"
+  end
+
+  @tag :tmp_dir
+  test "a fragmented HTTP upgrade still establishes a usable session", ctx do
+    start_supervised!(Session)
+    {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+    upgrade(socket, "Sec-WebSocket-Protocol: miosa-opencomputers-v1\r\n", true)
+    assert {:hello, _} = receive_term(socket)
+    send_term(socket, {:hello_ok, %{heartbeat_ms: 60_000}})
+    send_term(socket, {:ping, 42})
+    assert {:pong, 42} = receive_term(socket)
+  end
+
+  @tag :tmp_dir
+  test "status exposes safe rejection details and stale timer messages cannot resume retries",
+       ctx do
+    pid = start_supervised!(Session)
+    socket = accept_hello(ctx.listener)
+    close_frame(socket, 4007, "s3cr3t bearer-token")
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+
+    assert %{
+             phase: :rejected,
+             failure: %{code: 4007, reason: :key_revoked, action: action},
+             retry_in_ms: nil
+           } = Session.status()
+
+    assert action =~ "new host key"
+    # Fault injection at the timer boundary: already queued legacy/current events.
+    for message <- [
+          :hello_timeout,
+          :connect,
+          :heartbeat,
+          :dead_check,
+          {:executor_frame, {:job_done, "old-job", %{}}},
+          {:timeout, make_ref(), :connect},
+          {:timeout, make_ref(), :hello_timeout}
+        ] do
+      send(pid, message)
+    end
+
+    assert %{phase: :rejected} = Session.status()
+    assert {:error, :timeout} = :gen_tcp.accept(ctx.listener, 2_700)
+    refute inspect(Session.status()) =~ "s3cr3t"
+  end
+
+  @tag :tmp_dir
+  test "an incomplete upgrade times out, closes its socket, and allows reconnect", ctx do
+    start_supervised!(Session)
+    {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+    headers(socket, "")
+    :ok = :gen_tcp.send(socket, "HTTP/1.1 101 Switching Protocols\r\n")
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 6_000)
+    assert %{phase: :disconnected, failure: %{reason: :upgrade_timeout}} = Session.status()
+    second = accept_hello(ctx.listener, 3_000)
+    send_term(second, {:hello_ok, %{heartbeat_ms: 60_000}})
+    send_term(second, {:ping, 7})
+    assert {:pong, 7} = receive_term(second)
+  end
+
+  @tag :tmp_dir
+  test "invalid HTTP stream closes the owned connection before retrying", ctx do
+    start_supervised!(Session)
+    {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+    headers(socket, "")
+    :ok = :gen_tcp.send(socket, "not HTTP\r\n\r\n")
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+
+    assert %{phase: :disconnected, failure: %{reason: :upgrade_transport_error}} =
+             Session.status()
+
+    accept_hello(ctx.listener, 3_000)
+  end
+
+  @tag :tmp_dir
+  test "CLI status displays rejected reason and action instead of connecting", ctx do
+    start_supervised!(Session)
+    socket = accept_hello(ctx.listener)
+    close_frame(socket, 4004, "s3cr3t")
+    assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+
+    output =
+      ExUnit.CaptureIO.capture_io(fn ->
+        OptimalSystemAgent.CLI.OpenComputers.dispatch(["status"])
+      end)
+
+    assert output =~ "REJECTED"
+    assert output =~ "fingerprint_pinned"
+    assert output =~ "code=4004"
+    assert output =~ "administrator"
+    assert output =~ "paused"
+    refute output =~ "connecting - session"
+    refute output =~ "s3cr3t"
+  end
+
+  @tag :tmp_dir
+  test "CLI displays transient retry timing and heartbeats still work after reconnect", ctx do
+    start_supervised!(Session)
+    first = accept_hello(ctx.listener)
+    close_frame(first, 4008, "timeout")
+    assert {:error, :closed} = :gen_tcp.recv(first, 0, 2_000)
+
+    output =
+      ExUnit.CaptureIO.capture_io(fn ->
+        OptimalSystemAgent.CLI.OpenComputers.dispatch(["status"])
+      end)
+
+    assert output =~ "reason=timeout"
+    assert output =~ "code=4008"
+    assert output =~ "retrying in"
+    second = accept_hello(ctx.listener, 3_000)
+    send_term(second, {:hello_ok, %{heartbeat_ms: 100}})
+    assert {:heartbeat, %{seq: 1}} = receive_term(second)
+    assert %{phase: :active, failure: nil, retry_in_ms: nil} = Session.status()
+  end
+
+  for protocol <- [
+        "Sec-WebSocket-Protocol: wrong\r\n",
+        "Sec-WebSocket-Protocol: miosa-opencomputers-v1\r\nSec-WebSocket-Protocol: miosa-opencomputers-v1\r\n"
+      ] do
+    @tag :tmp_dir
+    test "rejects an unnegotiated or duplicate protocol: #{inspect(protocol)}", ctx do
+      start_supervised!(Session)
+      {:ok, socket} = :gen_tcp.accept(ctx.listener, 2_000)
+      upgrade(socket, unquote(protocol))
+      assert {:error, :closed} = :gen_tcp.recv(socket, 0, 2_000)
+
+      assert %{phase: :rejected, failure: %{reason: :subprotocol_mismatch}, retry_in_ms: nil} =
+               Session.status()
+    end
+  end
+
+  defp upgrade(
+         socket,
+         protocol \\ "Sec-WebSocket-Protocol: miosa-opencomputers-v1\r\n",
+         fragmented? \\ false
+       ) do
+    request = headers(socket, "")
+    [_, key] = Regex.run(~r/sec-websocket-key: ([^\r]+)/i, request)
+    accept = Base.encode64(:crypto.hash(:sha, key <> "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+
+    status = "HTTP/1.1 101 Switching Protocols\r\n"
+
+    rest =
+      "Upgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: #{accept}\r\n#{protocol}\r\n"
+
+    if fragmented? do
+      :ok = :gen_tcp.send(socket, status)
+      Process.sleep(100)
+      :ok = :gen_tcp.send(socket, rest)
+    else
+      :ok = :gen_tcp.send(socket, status <> rest)
+    end
+  end
+
+  defp headers(socket, acc) do
+    if String.contains?(acc, "\r\n\r\n") do
+      acc
+    else
+      {:ok, data} = :gen_tcp.recv(socket, 0, 5_000)
+      headers(socket, acc <> data)
+    end
+  end
+
+  defp receive_term(socket, timeout \\ 5_000) do
+    {:ok, <<0x82, size>>} = :gen_tcp.recv(socket, 2, timeout)
+
+    length =
+      case band(size, 127) do
+        126 ->
+          {:ok, <<length::16>>} = :gen_tcp.recv(socket, 2, timeout)
+          length
+
+        length ->
+          length
+      end
+
+    {:ok, mask} = :gen_tcp.recv(socket, 4, timeout)
+    {:ok, payload} = :gen_tcp.recv(socket, length, timeout)
+
+    payload
+    |> :binary.bin_to_list()
+    |> Enum.with_index()
+    |> Enum.map(fn {byte, index} -> bxor(byte, :binary.at(mask, rem(index, 4))) end)
+    |> :binary.list_to_bin()
+    |> :erlang.binary_to_term([:safe])
+  end
+
+  defp close_frame(socket, code, reason) do
+    payload = <<code::16, reason::binary>>
+    :ok = :gen_tcp.send(socket, <<0x88, byte_size(payload), payload::binary>>)
+  end
+
+  defp send_term(socket, term) do
+    payload = :erlang.term_to_binary(term)
+    :ok = :gen_tcp.send(socket, <<0x82, byte_size(payload), payload::binary>>)
+  end
+end


### PR DESCRIPTION
OSA 1.0.197 discarded WebSocket close diagnostics, reset retry backoff on HTTP upgrade, and allowed an old hello timeout to disconnect a later attempt.
This change reports actionable failures, pauses permanent rejection retries, preserves transient reconnect with a strict 60-second delay cap, and exposes safe failure/retry details through both `Session.status/0` and `osa opencomputers status`.

Release dependency: [backend PR #1557](https://github.com/Miosa-osa/miosa-compute/pull/1557)'s selected `Sec-WebSocket-Protocol` response header fix MUST be deployed before publishing a client release containing strict validation.
The current headerless backend response is intentionally rejected before credentials are sent.
Creating this PR does not authorize merge, deployment or release publication.
Full-host resource placement requires a separate adapter and is outside this PR.

Implementation:

- Shared `Session.Failure` policy covers server codes 4001 (auth), 4003 (upgrade), 4004 (fingerprint), 4007 (revoked), and retryable 4008 (timeout), plus HTTP auth and protocol-handshake failures.
- Failure logs/status use local categories and recovery actions, never raw close text, response headers, credential prefixes or exception messages.
- Reconnect, hello, heartbeat and watchdog timers are referenced and cancelled; stale messages and late executor replies cannot restart a rejected session.
- Connector preserves split status/header receives, validates actual HTTP status and exactly one selected protocol, uses a bounded upgrade deadline, and closes owned sockets on failure.
- The CLI reads the public safe status surface, displays rejected reason/action or transient retry timing, and preserves missing-key login guidance.

RED/GREEN evidence from public Session processes against real loopback WebSocket servers:

| Regression | Observed RED | GREEN |
| --- | --- | --- |
| Auth close | 4001 opened another connection after about 2 seconds | Rejected, actionable, no secret output or retry |
| Stale hello timer | First deadline closed the second socket before its deadline | Delayed second hello succeeds and answers ping |
| Transient backoff | Repeated 4008 stayed at about 2 seconds | Second delay grows to about 4 seconds; hello_ok resets it |
| Application close | Retried and logged raw reason | Uses the same safe permanent-failure policy |
| Missing selected protocol | Headerless 101 caused hello credentials to be sent | Closed before hello; safe subprotocol rejection |
| HTTP diagnostics | 401 lost its status; 503 lacked clear status reporting | Auth action for 401; successful automatic reconnect for 503 |
| Fragmented upgrade | Status-only receive returned no_upgrade | Split response establishes a usable session |
| Stream cleanup | Closing Mint's returned closed-state connection left the socket open | Closing the owned pre-stream connection releases it |
| Rejected status/late reply | Status API absent; late executor reply crashed Session | Safe public/CLI status; stale messages leave rejection intact |
| Backoff cap | Jitter produced 60067 ms | Delay never exceeds 60000 ms |
| CLI guidance | Rejection was ambiguous; missing-key polling looked transient | Specific rejection recovery and missing-key login guidance |

Validation command:

```sh
mix test --no-start test/optimal_system_agent/open_computers/session test/optimal_system_agent/cli/opencomputers_test.exs test/optimal_system_agent/open_computers/remote_test.exs
```

Result: **103 tests, 0 failures** (44.5 seconds), including 15 public Session lifecycle tests.
Toolchain: Elixir 1.19.5, Erlang/OTP 28.4.2, ERTS 16.3.1, macOS.
The full application is not started; this avoids starting a daemon or live external integrations.
Changed-file formatting and `git diff --check` pass.
Existing unrelated compiler warnings remain; this macOS run is not production enrollment/placement proof.
The backend owner separately reported five passing cold-suite tests including job results; those are not counted as OSA validation.

Packaged Linux runtime validation completed for the same commit `60afcd16`:

- **18 current-source modules compiled**, including all six changed production modules, using sequential `Code.compile_file/1` on the actual cached OSA **1.0.197 Linux amd64 runtime**.
- **88 tests passed, 0 failed/skipped/excluded**, including all **15 public Session loopback lifecycle tests**, plus Connector, Backoff, FrameCodec, Hello, Fingerprint and CLI tests (44.9 seconds).
- Runtime: **Elixir 1.17.3, Erlang/OTP 26, ERTS 14.2.5.15**; bundled Mint 1.7.1, mint_web_socket 1.0.5 and telemetry 1.3.0.
- The packaged release omits ExUnit; the cached image supplied matching Elixir 1.17.3 ExUnit without downloads.
- The read-only shared release copy's `beam.smp` SHA-256 exactly matches `/smoke-home/.osa` in Zeno's existing `miosa-oc-unix-contract-20260911-stdin` container: `2539310a419806c60097c89ea4788288046122d3c81a30938387be2638726976`.
- Validation used a separate disposable container with networking disabled, `--pull=never`, and read-only source/release mounts.
  Zeno's runtime remained untouched.
- Saved runner, compiled modules, receipt and passing transcript: `/tmp/osa-session-linux-validation.eEIGUQ/` (`RESULT.md`, `validate.exs`, `release-sequential.log`, `ebin/`).

The successful run used the actual packaged runtime after an older-cache attempt exited with signal 139 and the parallel compiler hit an internal checker error.
This is shipped-runtime compatibility evidence for the changed modules and selected tests, not a rebuilt release artifact, live enrollment or full-host placement test.
No new PR, merge, deployment or release publication was performed.
